### PR TITLE
Add system mvn fallback when no Maven wrapper is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ small badge (`BootUI` / `Actuator` / `process`) indicating which source is live.
 
 - The [GitHub Copilot app](https://docs.github.com/en/copilot) or Copilot CLI with
   canvas-extension support.
-- A target project built with **Maven** (the committed `./mvnw` wrapper is used; no
-  system Maven required) on **Java 17+**.
+- A target project built with **Maven** (the committed `./mvnw` wrapper is used when
+  present, otherwise a system `mvn` on `PATH`) on **Java 17+**.
 - Optional: [`mvnd`](https://github.com/apache/maven-mvnd) for warm builds, and
   [BootUI](https://github.com/jdubois/boot-ui) on the target app for the richest
   metrics and advisor scans.
@@ -121,8 +121,9 @@ and `run_scan` actions.
 
 Coffilot is a Node process (the extension) that:
 
-- shells out to `./mvnw` (or `mvnd`) for Build / Test / Package / Run and streams
-  the output into the canvas over Server-Sent Events;
+- shells out to `./mvnw` (the Maven wrapper, or a system `mvn` when no wrapper is
+  present — or `mvnd`) for Build / Test / Package / Run and streams the output into
+  the canvas over Server-Sent Events;
 - parses the Surefire XML reports into a graphical test view;
 - once an app is up, polls it for live metrics from the richest source available,
   proxying [BootUI](https://github.com/jdubois/boot-ui)'s sanitized `/bootui/api/**`

--- a/extension.mjs
+++ b/extension.mjs
@@ -106,6 +106,73 @@ function detectMvnd() {
   return mvndInfo;
 }
 
+// When a project ships a pom.xml but no Maven wrapper, fall back to a system
+// `mvn` discovered on PATH (and common install locations) so Coffilot still
+// works. The wrapper is always preferred when present because it pins the Maven
+// version; `mvn` is the graceful fallback.
+let mvnInfo = null;
+function detectMvn() {
+  if (mvnInfo) return mvnInfo;
+  // Windows resolves `mvn` to a batch script (mvn.cmd / mvn.bat) or a shim exe.
+  const exeNames = isWindows ? ["mvn.cmd", "mvn.bat", "mvn.exe", "mvn"] : ["mvn"];
+  const candidates = [];
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue;
+    for (const exe of exeNames) candidates.push(path.join(dir, exe));
+  }
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  if (isWindows) {
+    if (home) {
+      candidates.push(
+        path.join(home, "scoop", "shims", "mvn.cmd"),
+        path.join(home, "scoop", "shims", "mvn.exe"),
+        path.join(home, ".sdkman", "candidates", "maven", "current", "bin", "mvn.cmd"),
+      );
+    }
+    if (process.env.ProgramData) {
+      candidates.push(path.join(process.env.ProgramData, "chocolatey", "bin", "mvn.exe"));
+    }
+  } else {
+    candidates.push(
+      "/opt/homebrew/bin/mvn",
+      "/usr/local/bin/mvn",
+      "/usr/bin/mvn",
+      "/home/linuxbrew/.linuxbrew/bin/mvn",
+    );
+    if (home) candidates.push(path.join(home, ".sdkman/candidates/maven/current/bin/mvn"));
+  }
+  for (const c of candidates) {
+    try {
+      if (existsSync(c)) {
+        mvnInfo = { available: true, path: c };
+        return mvnInfo;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  mvnInfo = { available: false, path: null };
+  return mvnInfo;
+}
+
+// The base (non-daemon) Maven command for a run: the project's wrapper when it
+// exists, else a system `mvn` from PATH. mvnd layers on top of this for warm
+// builds. Cached because neither the wrapper's presence nor PATH change at
+// runtime.
+let baseRunnerInfo = null;
+function baseRunner() {
+  if (baseRunnerInfo) return baseRunnerInfo;
+  if (existsSync(mvnw)) {
+    baseRunnerInfo = { bin: mvnw, label: "./mvnw" };
+  } else {
+    const m = detectMvn();
+    // Fall back to system `mvn`; if that's missing too, keep pointing at the
+    // wrapper path so the spawn fails with a clear ENOENT in the lane console.
+    baseRunnerInfo = m.available ? { bin: m.path, label: "mvn" } : { bin: mvnw, label: "./mvnw" };
+  }
+  return baseRunnerInfo;
+}
+
 /** Platform-appropriate guidance for installing mvnd, shown when it's missing. */
 function mvndInstallHint() {
   const url = "https://github.com/apache/maven-mvnd#how-to-install-mvnd";
@@ -166,7 +233,8 @@ function resolveRunner(warm) {
     const m = detectMvnd();
     if (m.available) return { bin: m.path, label: "mvnd", warm: true };
   }
-  return { bin: mvnw, label: "./mvnw", warm: false };
+  const b = baseRunner();
+  return { bin: b.bin, label: b.label, warm: false };
 }
 
 /** Reserve a free loopback TCP port (for "Use a random HTTP port"). */
@@ -390,7 +458,7 @@ function detectJavaVersion() {
 function capabilitiesSnapshot() {
   const mods = listModules();
   return {
-    maven: true,
+    maven: existsSync(mvnw) || detectMvn().available,
     java: detectJavaVersion(),
     springBoot: mods.some((m) => m.springBoot),
     runnable: mods.some((m) => m.runnable),
@@ -474,7 +542,7 @@ function newLane(op) {
     op,
     phase: "idle", // idle | building | testing | running | stopped | failed
     command: "",
-    runnerLabel: "./mvnw",
+    runnerLabel: baseRunner().label,
     warm: false,
     exitCode: null,
     child: null, // the process this op currently owns (null when not running)
@@ -827,8 +895,9 @@ function pushConsole(line, stream, op = "build") {
  */
 function spawnMaven(op, args, phase, { onLine, bin, label } = {}) {
   const lane = lanes[op];
-  const mavenBin = bin || mvnw;
-  const mavenLabel = label || "./mvnw";
+  const base = baseRunner();
+  const mavenBin = bin || base.bin;
+  const mavenLabel = label || base.label;
   return new Promise((resolve) => {
     lane.phase = phase;
     lane.runnerLabel = mavenLabel;
@@ -1111,7 +1180,7 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   app.mavenProfiles = mavenProfiles || null;
 
   if (resolved === "spring") {
-    // The app is long-lived, so it always runs via ./mvnw (mvnd is for builds).
+    // The app is long-lived, so it always runs via the wrapper/mvn (mvnd is for builds).
     const args = ["-ntp"];
     if (module) args.push("-pl", module);
     if (mavenProfiles && mavenProfiles.trim()) args.push("-P", mavenProfiles.trim());
@@ -1139,7 +1208,7 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
       const r = resolveRunner(true);
       startLiveReload({ module: module || "", mavenProfiles, bin: r.bin, label: r.label });
     }
-    return { ok: true, started: true, mode: "spring", command: `./mvnw ${args.join(" ")}` };
+    return { ok: true, started: true, mode: "spring", command: `${baseRunner().label} ${args.join(" ")}` };
   }
 
   // Pure-Java: package the module, then launch its jar with `java -jar`.


### PR DESCRIPTION
## Problem

Coffilot always spawned the project's Maven wrapper (`./mvnw` / `mvnw.cmd`). For projects that ship a `pom.xml` **without** a committed wrapper, every Build / Test / Package / Run failed with `ENOENT` — there was no fallback to a system `mvn` on `PATH`.

## Change

Add a graceful fallback to a system `mvn` while keeping the wrapper as the preferred runner (it pins the Maven version).

- **`detectMvn()`** — new, mirrors the existing `mvnd` detection. Scans `PATH` plus common install locations, cross-platform:
  - macOS/Linux: `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, linuxbrew, SDKMAN.
  - Windows: `mvn.cmd` / `mvn.bat` / `mvn.exe` names, plus scoop, chocolatey, and SDKMAN paths.
- **`baseRunner()`** — new single source of truth for the non-daemon Maven command: **wrapper if `./mvnw` exists → else system `mvn` → else fall back to the wrapper path** (so a truly-missing Maven still surfaces a clear `ENOENT` in the lane console).
- Wired `baseRunner()` into `resolveRunner`, `spawnMaven`'s default bin/label, the lane's default `runnerLabel`, and the Spring run command string.
- `capabilitiesSnapshot().maven` now reflects reality (`existsSync(mvnw) || detectMvn().available`) instead of being hardcoded `true`, so the UI "Maven" pill greys out when no Maven is found at all.

The `runnerLabel` chip in the UI automatically shows `mvn` instead of `./mvnw` when the fallback is active — no UI code change needed. Existing Windows `shell: true` spawning already handles `.cmd`/`.bat`.

## Docs

`README.md` prerequisites and "How it works" now mention the `mvn`-on-`PATH` fallback.

## Verification

- `npm run check` (node `--check`) passes.
- `prettier --check .` clean (both run in CI).
- Validated the new logic against a real environment: with no wrapper present, it resolves to `/opt/homebrew/bin/mvn` and labels the runner `mvn`.

Cross-platform (macOS / Linux / Windows) detection paths and exe-name handling are all covered.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>