### PR TITLE
Rename CI workflow to Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coffilot
 
-[![CI](https://github.com/jdubois/coffilot/actions/workflows/ci.yml/badge.svg)](https://github.com/jdubois/coffilot/actions/workflows/ci.yml)
+[![Build](https://github.com/jdubois/coffilot/actions/workflows/ci.yml/badge.svg)](https://github.com/jdubois/coffilot/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **Coffilot** is a [GitHub Copilot **canvas extension**](https://docs.github.com/en/copilot/how-tos/github-copilot-app/working-with-canvas-extensions)


### PR DESCRIPTION
Renames the GitHub Actions workflow from "CI" to "Build" so the Actions tab and status checks use a clearer, more descriptive label for what the workflow does (lint, syntax check, manifest validation).

## Changes
- `.github/workflows/ci.yml`: `name: CI` -> `name: Build`.
- `README.md`: updated the status badge label to match the new workflow name.

The workflow filename stays `ci.yml`, so the badge URL and the reference in `.github/copilot-instructions.md` remain valid. No behavior changes to the workflow itself.