### PR TITLE
Fix Run module dropdown stuck on "Scanning modules…" for user/global installs

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -35,10 +35,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const session = await joinSession({ canvases: [makeCanvas()] });
 
-// Resolve the Maven project root. session.workspacePath points at the session
-// artifacts folder, not the repo, so we walk up from this extension's own
-// location (it lives at <repo>/.github/extensions/coffilot) until we find
-// the directory that owns the Maven wrapper, then fall back gracefully.
+// Resolve the Maven project root. session.workspacePath is the session-artifacts
+// folder (checkpoints/, plan.md, files/), never the repo, so it must not be used
+// as the project root. We look in two places: the extension's own location (for a
+// project-embedded install at <repo>/.github/extensions/coffilot) and the CLI's
+// working directory (for a user/global install, where the CLI launches us with
+// cwd set to the project the user opened).
 const workspacePath = findProjectRoot();
 const mvnw = path.join(workspacePath, process.platform === "win32" ? "mvnw.cmd" : "mvnw");
 
@@ -184,19 +186,25 @@ function freePort() {
 
 function findProjectRoot() {
   const wrapper = process.platform === "win32" ? "mvnw.cmd" : "mvnw";
-  let dir = __dirname;
-  for (let i = 0; i < 8; i++) {
-    if (existsSync(path.join(dir, wrapper)) || existsSync(path.join(dir, "pom.xml"))) {
-      return dir;
+  const owns = (dir) => existsSync(path.join(dir, wrapper)) || existsSync(path.join(dir, "pom.xml"));
+  // Walk up from `start` (max 8 hops) to the first directory that owns the Maven
+  // wrapper or a pom.xml; null if none is found.
+  const walkUp = (start) => {
+    let dir = start;
+    for (let i = 0; i < 8; i++) {
+      if (owns(dir)) return dir;
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
     }
-    const parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  if (session.workspacePath && existsSync(path.join(session.workspacePath, wrapper))) {
-    return session.workspacePath;
-  }
-  return session.workspacePath || process.cwd();
+    return null;
+  };
+  // 1) Project-embedded install (.github/extensions/coffilot): walk up from here.
+  // 2) User/global install (e.g. symlinked into ~/.copilot/extensions): the CLI
+  //    launches the extension with cwd set to the project, so walk up from there.
+  //    session.workspacePath is the session-artifacts folder, never the Maven
+  //    project, so it is deliberately not consulted.
+  return walkUp(__dirname) || walkUp(process.cwd()) || process.cwd();
 }
 
 // ---------------------------------------------------------------------------

--- a/public/index.html
+++ b/public/index.html
@@ -1535,7 +1535,15 @@
       }
 
       function populateModules(modules) {
-        if (!Array.isArray(modules) || !modules.length) return;
+        // A non-array means the env probe is unavailable (e.g. a failed fetch);
+        // leave whatever is currently shown rather than wiping it.
+        if (!Array.isArray(modules)) return;
+        // An empty array means the probe ran but found no Maven project: surface
+        // that instead of leaving the dropdown stuck on "Scanning modules…".
+        if (!modules.length) {
+          moduleSelect.innerHTML = '<option value="" disabled selected>No Maven modules found</option>';
+          return;
+        }
         const prev = moduleSelect.value;
         const runnable = modules.filter((m) => m.runnable);
         const libs = modules.filter((m) => !m.runnable);


### PR DESCRIPTION
## Summary

Opening Coffilot on a Maven project left the Run module dropdown stuck forever on "Scanning modules…" when the extension is installed as a user/global extension (symlinked into `~/.copilot/extensions/coffilot`) rather than embedded in the project.

Root cause was in `findProjectRoot()`. It walked up from the extension's own location for a `pom.xml`/`mvnw`, then fell back to `session.workspacePath`. But the Copilot SDK documents `session.workspacePath` as the session-artifacts folder (`checkpoints/`, `plan.md`, `files/`), never the repo. For a symlinked install the walk-up finds no pom, and with infinite sessions enabled the old `session.workspacePath || process.cwd()` returned the artifacts folder before ever trying `process.cwd()`. `listModules()` then scanned an empty directory, `populateModules([])` returned early, and the placeholder never got replaced. (Status/metrics still arrived over SSE, so only the module picker looked frozen.)

The fix resolves the Maven root by walking up from the extension location first (project-embedded install), then from `process.cwd()` (the project the CLI launched us in), and never consults `session.workspacePath`. This keeps the existing behavior for embedded installs while fixing user/global installs.

Also a small defense-in-depth touch: when no Maven project is detected, the dropdown now shows "No Maven modules found" instead of hanging on the scanning placeholder.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (No behaviour docs affected; internal resolution change.)
- [x] No secrets committed.

Verified `findProjectRoot()` against three scenarios (user/global install with cwd at the project, project-embedded install, and no project anywhere): the first two resolve to the project root, the last falls back to cwd.

## Notes for reviewers

The reported live instance loads from the main checkout via the `~/.copilot/extensions/coffilot` symlink, so it won't pick up the fix until this is merged and that checkout is updated. The key assumption is that the CLI launches the extension subprocess with `cwd` set to the project the user opened; the previous code already relied on `process.cwd()` as a last-resort fallback, so this just promotes it ahead of the (incorrect) `session.workspacePath` fallback.