### PR TITLE
Add "Register with Copilot" button for the BootUI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ agent with **Fix with Copilot**.
 - **Advisor scans (with BootUI)** &mdash; when the running app exposes
   [BootUI](https://github.com/jdubois/boot-ui), a toggle enables its MCP server and
   the advisor scans (architecture, Spring, security, Hibernate, …); findings can be
-  sent to the agent with one click.
+  sent to the agent with one click. A **Register with Copilot** button can also wire
+  the running MCP server into the Copilot CLI config so the agent can call the scans
+  directly as native MCP tools.
 
 ## Graceful degradation by capability
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -1730,6 +1730,24 @@ function buildFixPrompt(kind, extra = {}) {
         .filter(Boolean)
         .join("\n\n");
     }
+    case "register-mcp": {
+      const base = appBase();
+      const mcpUrl = base ? `${base}/bootui/api/mcp` : "http://127.0.0.1:<app-port>/bootui/api/mcp";
+      const cfg = JSON.stringify({ mcpServers: { bootui: { type: "http", url: mcpUrl } } }, null, 2);
+      return [
+        "Register this app's running BootUI MCP server with the GitHub Copilot CLI so its advisor scans (architecture, security, Spring, Hibernate, …) become callable as native MCP tools in this chat.",
+        `The BootUI MCP server is exposed by the running app over Streamable HTTP (JSON-RPC) at \`${mcpUrl}\`.`,
+        "Add it to the Copilot CLI MCP config (`~/.copilot/mcp-config.json`; create the file if it doesn't exist) under the `mcpServers` map, keyed as `bootui`:",
+        codeBlock(cfg, "json"),
+        [
+          "- Merge into any existing `mcpServers` block rather than overwriting it; if a `bootui` entry already exists, update its `url` instead of duplicating it.",
+          "- The URL points at the current run, so the app must stay up with its MCP server enabled for the tools to respond. If the app's port changes on a later run, update the `url`.",
+          "- After saving, the Copilot CLI must pick up the new server: reload the MCP config (e.g. the `/mcp` command) or restart the CLI, then confirm the `bootui` tools are listed.",
+        ].join("\n"),
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
     default:
       return null;
   }

--- a/public/index.html
+++ b/public/index.html
@@ -946,6 +946,7 @@
                 data-tip="Run BootUI's MCP server inside the running app so its advisor scans (architecture, security, Hibernate, …) can analyze the project from this console."
                 >&#9432;</span
               >
+              <button id="mcp-register" class="fix tiny" style="margin-left: auto" hidden>Register with Copilot</button>
             </div>
             <div id="mcp-scans" class="scans">
               <span class="muted" style="font-size: 12px"
@@ -1044,6 +1045,7 @@
       const mcpState = document.getElementById("mcp-state");
       const mcpScansEl = document.getElementById("mcp-scans");
       const mcpResultEl = document.getElementById("mcp-result");
+      const mcpRegisterBtn = document.getElementById("mcp-register");
       let caps = {};
 
       if (warmCmd) {
@@ -1317,6 +1319,22 @@
       // ---- BootUI MCP server panel ------------------------------------------
       let mcpScansLoaded = false;
 
+      // Offer "Register with Copilot" only while the MCP server is enabled (and
+      // therefore reachable). Reset the button's label/enabled state only on the
+      // hidden→visible transition so a recent "Asked Copilot ✓" survives the
+      // frequent metrics re-renders.
+      function showMcpRegister(show) {
+        if (!show) {
+          mcpRegisterBtn.hidden = true;
+          return;
+        }
+        if (mcpRegisterBtn.hidden) {
+          mcpRegisterBtn.hidden = false;
+          mcpRegisterBtn.disabled = false;
+          mcpRegisterBtn.textContent = "Register with Copilot";
+        }
+      }
+
       // The MCP server lives inside the running app, so the toggle is only
       // actionable while a BootUI app (dev profile) exposes its endpoint. The
       // row stays visible in Settings either way; when unavailable we grey out
@@ -1327,6 +1345,7 @@
         mcpToggle.disabled = true;
         mcpToggleLabel.classList.add("disabled");
         mcpState.textContent = "";
+        showMcpRegister(false);
         mcpScansEl.innerHTML =
           '<span class="muted" style="font-size:12px">Start a BootUI app (dev profile) with <strong>Run</strong> to manage its MCP server and advisor scans.</span>';
         mcpResultEl.innerHTML = "";
@@ -1342,6 +1361,7 @@
         const enabled = mcp.enabled === true;
         mcpToggle.checked = enabled;
         mcpState.textContent = "";
+        showMcpRegister(enabled);
         if (!enabled) {
           mcpScansLoaded = false;
           mcpScansEl.innerHTML =
@@ -1371,6 +1391,7 @@
         const enabled = st.enabled === true;
         mcpToggle.checked = enabled;
         mcpState.textContent = "";
+        showMcpRegister(enabled);
         const scans = (st && st.scans) || [];
         if (!enabled) {
           mcpScansLoaded = false;
@@ -1855,6 +1876,12 @@
         await post("/api/mcp/toggle", { enabled });
         // Reflect the server's actual state and (re)load advisor scans.
         loadMcpScans();
+      };
+
+      mcpRegisterBtn.onclick = async () => {
+        mcpRegisterBtn.disabled = true;
+        mcpRegisterBtn.textContent = "Asked Copilot \u2713";
+        await post("/api/fix", { kind: "register-mcp" });
       };
 
       let lastRunnerLabel = null;


### PR DESCRIPTION
## Summary

A running BootUI app exposes its own MCP server (advisor scans) at `/bootui/api/mcp`, but that server is **not** automatically usable by the GitHub Copilot CLI: Copilot only talks to MCP servers listed in its config (`~/.copilot/mcp-config.json`, etc.) or added via `/mcp`. Today Coffilot bridges the endpoint itself (proxies scans, pastes findings into chat), so the agent never sees the BootUI tools natively.

This adds a **Register with Copilot** button in the MCP panel that wires the running server into Copilot so its scans become callable as real MCP tools.

It follows the same prompt-based pattern as the existing **Add BootUI** / **Add DevTools** buttons rather than mutating config files directly:

- `extension.mjs` gains a `register-mcp` fix kind. It computes the live URL (`http://127.0.0.1:<appPort>/bootui/api/mcp`) and asks the agent to add a `bootui` entry (`type: "http"`) to `~/.copilot/mcp-config.json`, with guidance to merge rather than overwrite, keep the URL current, and reload via `/mcp` afterward.
- `public/index.html` adds the button to the MCP panel. It is shown only while the server is enabled (and therefore reachable), and only resets its label on the hidden->visible transition so a recent "Asked Copilot" confirmation survives the frequent metrics re-renders.
- `README.md` mentions the new button.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

Note: I could not live-test in the canvas because the installed `coffilot` extension symlinks to the main checkout, which this worktree session must not modify. Validated instead with `node --check`, an inline-script syntax check, and Prettier.

## Notes for reviewers

Two things worth a careful look:

1. **Reload semantics.** Copilot loads MCP servers at startup, so a freshly written config entry does not take effect until the CLI reloads (`/mcp`) or restarts. The generated prompt calls this out, but the button cannot make the server "just work" instantly.
2. **Transport compatibility.** Coffilot speaks raw JSON-RPC to `/bootui/api/mcp` and skips the MCP `initialize` handshake. Copilot's stricter `http` MCP client may require BootUI to fully implement the Streamable-HTTP transport. Worth verifying once against a real BootUI app.