### PR TITLE
Add Spring Boot "Startup" graphical view to the Run tab

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,6 +25,10 @@ Shipped in the extension today:
 
 - Build / Test / Package / Run lanes with live SSE-streamed console output, a
   graphical Surefire test view with a live progress bar, and a console toggle.
+- Run lane "Startup" graphical view: a Spring Boot startup summary parsed from
+  stdout (status, Boot version, Java, PID, active profiles, web server + clickable
+  port, notable WARN/ERROR events, and the failure reason on a failed start) with
+  a Startup / Console sub-toggle. Works from plain stdout, no Actuator/BootUI needed.
 - Maven lane (Build/Test/Package) running independently of the long-lived Run lane.
 - Reactor scan for runnable modules, Spring Boot detection, and Spring + Maven
   profile discovery.

--- a/extension.mjs
+++ b/extension.mjs
@@ -497,7 +497,30 @@ const app = {
   appReachedUp: false, // app served a metrics endpoint at least once this run
   module: null, // module selected for the current run (for live reload)
   mavenProfiles: null, // Maven profiles used for the current run (for live reload)
+  // Structured Spring Boot startup summary, parsed from the run console so it
+  // works from plain stdout (no Actuator/BootUI needed). null until first Run.
+  startup: null,
 };
+
+// Reset the Spring Boot startup summary at the start of a Run. status walks
+// starting -> started (banner "Started … in N s") -> stopped | failed (on exit).
+function resetStartup() {
+  app.startup = {
+    status: "starting", // starting | started | stopped | failed
+    appName: null,
+    bootVersion: null,
+    javaVersion: null,
+    pid: null,
+    profiles: [],
+    server: null, // Tomcat | Netty | Undertow | Jetty
+    port: null,
+    contextPath: null,
+    startupSeconds: null,
+    events: [], // { level: "WARN" | "ERROR", message } captured during startup
+    failureReason: null, // human-readable reason from Spring's failure analyzer
+  };
+  awaitingFailureDesc = false;
+}
 
 // Latest unit-test results (from a foreground Test run).
 let lastTest = null; // summary { tests, failures, errors, skipped }
@@ -890,6 +913,10 @@ function spawnMaven(op, args, phase, { onLine, bin, label } = {}) {
         // A run that exits non-zero before the app ever served metrics is a
         // startup crash (surface a Fix button); otherwise it was a clean stop.
         lane.phase = code === 0 || app.appReachedUp ? "stopped" : "failed";
+        if (app.startup) {
+          app.startup.status = lane.phase === "failed" ? "failed" : "stopped";
+          broadcast("run-startup", app.startup);
+        }
       } else {
         lane.phase = code === 0 ? "idle" : "failed";
       }
@@ -1099,6 +1126,8 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   app.appPort = null;
   app.appUp = false;
   app.appReachedUp = false;
+  resetStartup();
+  broadcast("run-startup", app.startup);
   csrfToken = null;
   lastMetrics = { appUp: false };
 
@@ -1132,7 +1161,7 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
       args.push(`-Dspring-boot.run.arguments=--server.port=${port}`);
       pushConsole(`[coffilot] using HTTP port ${port || "(random)"} via server.port.`, "stdout", "run");
     }
-    spawnMaven("run", args, "running", { onLine: detectPort }); // fire-and-forget
+    spawnMaven("run", args, "running", { onLine: onRunLine }); // fire-and-forget
     // DevTools restarts in place when target/classes changes, so watch sources
     // and recompile on save to drive that loop automatically.
     if (settings.devtools && mod && mod.devtools) {
@@ -1167,7 +1196,7 @@ async function runPureJava({ module, mavenProfiles }) {
     broadcast("status", statusSnapshot());
     return;
   }
-  spawnMaven("run", [NATIVE_ACCESS_FLAG, "-jar", jar], "running", { bin: "java", label: "java", onLine: detectPort });
+  spawnMaven("run", [NATIVE_ACCESS_FLAG, "-jar", jar], "running", { bin: "java", label: "java", onLine: onRunLine });
 }
 
 /** Best-effort pick of a module's main artifact jar (skip sources/javadoc). */
@@ -1254,12 +1283,142 @@ function detectPort(line) {
     const m = line.match(re);
     if (m) {
       app.appPort = Number(m[1]);
+      if (app.startup && app.startup.port == null) app.startup.port = app.appPort;
       pushConsole(`[coffilot] detected app port ${app.appPort}; polling /bootui/api`, "stdout", "run");
       broadcast("status", statusSnapshot());
       startMetricsPolling();
       return;
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Spring Boot startup parsing (drives the Run tab's graphical "Startup" view)
+// ---------------------------------------------------------------------------
+//
+// Spring Boot prints a structured startup sequence to stdout regardless of
+// whether Actuator / BootUI are present, so parsing it gives a useful summary
+// for plain `java -jar` fat jars and `spring-boot:run` alike. Each matcher is
+// defensive about version-to-version wording differences.
+
+// ":: Spring Boot ::                (v3.4.1)"
+const SB_VERSION_RE = /:: Spring Boot ::\s*\(v?([^)\s]+)\)/i;
+// "Starting DemoApplication using Java 21.0.1 with PID 12345 (… started by …)"
+// Older: "Starting DemoApplication v0.0.1 using Java 17 on HOST with PID 12345"
+const SB_STARTING_RE =
+  /\bStarting\s+(\S+?)(?:\s+v\S+)?\s+(?:using\s+Java\s+(\S+)\s+)?(?:on\s+\S+\s+)?with\s+PID\s+(\d+)/i;
+// "The following 1 profile is active: "dev"" / "… 2 profiles are active: "dev", "local""
+const SB_PROFILES_RE = /following\s+\d+\s+profiles?\s+(?:is|are)\s+active:\s*(.+)$/i;
+const SB_NO_PROFILE_RE = /No active profile set/i;
+// "Tomcat started on port 8080 (http) with context path '/'" and the earlier
+// "Tomcat initialized with port 8080 (http)"; also Netty/Undertow/Jetty. The
+// server name must be followed by started/initialized so it matches the message
+// wording rather than the logger's package (e.g. "…embedded.tomcat.Tomcat…").
+const SB_SERVER_RE =
+  /\b(Tomcat|Netty|Undertow|Jetty)\s+(?:started|initialized)\b[^\n]*?\bport[s]?(?:\(s\))?:?\s*(\d+)/i;
+const SB_CONTEXT_RE = /context path '([^']*)'/i;
+// "Started DemoApplication in 3.456 seconds (process running for 3.789)"
+const SB_STARTED_RE = /\bStarted\s+\S+\s+in\s+([\d.]+)\s+seconds/i;
+const SB_FAILED_RE = /APPLICATION FAILED TO START/i;
+// Default logback pattern: "<ISO ts>  WARN 12345 --- [thread] logger : message".
+// Anchored on a leading timestamp + level so a stray "WARN" inside a message
+// (or one of our own [coffilot] lines) is never mistaken for a log event. The
+// bracket group repeats because tracing setups (e.g. BootUI) insert an extra
+// "[traceId,spanId]" correlation field between the thread name and the logger.
+const SB_EVENT_RE =
+  /^\d{4}-\d\d-\d\d[ T][\d:.,]+(?:[+-]\d\d:?\d\d|Z)?\s+(WARN|ERROR)\s+\d+\s+---\s+(?:\[[^\]]*\]\s+)+(\S+)\s+:\s+(.*)$/;
+
+const STARTUP_EVENT_CAP = 50;
+
+// Tracks whether we are inside Spring Boot's "APPLICATION FAILED TO START" block,
+// waiting for the "Description:" reason line so it can be captured.
+let awaitingFailureDesc = false;
+
+function splitProfiles(raw) {
+  return raw
+    .split(",")
+    .map((p) => p.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean);
+}
+
+function parseStartupLine(line) {
+  const su = app.startup;
+  if (!su) return;
+  let changed = false;
+
+  let m = line.match(SB_VERSION_RE);
+  if (m && su.bootVersion !== m[1]) {
+    su.bootVersion = m[1];
+    changed = true;
+  }
+
+  m = line.match(SB_STARTING_RE);
+  if (m) {
+    su.appName = m[1];
+    if (m[2]) su.javaVersion = m[2];
+    su.pid = Number(m[3]);
+    changed = true;
+  }
+
+  m = line.match(SB_PROFILES_RE);
+  if (m) {
+    su.profiles = splitProfiles(m[1]);
+    changed = true;
+  } else if (SB_NO_PROFILE_RE.test(line) && !su.profiles.length) {
+    su.profiles = ["default"];
+    changed = true;
+  }
+
+  m = line.match(SB_SERVER_RE);
+  if (m) {
+    su.server = m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
+    if (su.port == null) su.port = Number(m[2]);
+    const ctx = line.match(SB_CONTEXT_RE);
+    if (ctx) su.contextPath = ctx[1] || "/";
+    changed = true;
+  }
+
+  m = line.match(SB_STARTED_RE);
+  if (m) {
+    su.startupSeconds = Number(m[1]);
+    su.status = "started";
+    changed = true;
+  }
+
+  if (SB_FAILED_RE.test(line)) {
+    su.status = "failed";
+    awaitingFailureDesc = false;
+    changed = true;
+  }
+
+  // After the "APPLICATION FAILED TO START" banner, Spring's failure analyzer
+  // prints a human-readable reason under "Description:" with no log prefix.
+  // Capture the first non-blank line that follows so the failed view can explain
+  // *why* (e.g. "Web server failed to start. Port 8080 was already in use.").
+  if (su.status === "failed" && !su.failureReason) {
+    if (/^Description:\s*$/.test(line)) {
+      awaitingFailureDesc = true;
+    } else if (awaitingFailureDesc && line.trim()) {
+      su.failureReason = line.trim();
+      awaitingFailureDesc = false;
+      changed = true;
+    }
+  }
+
+  m = line.match(SB_EVENT_RE);
+  if (m && m[3].trim()) {
+    su.events.push({ level: m[1], message: m[3].trim() });
+    if (su.events.length > STARTUP_EVENT_CAP) su.events.shift();
+    changed = true;
+  }
+
+  if (changed) broadcast("run-startup", su);
+}
+
+// Per-line hook for the Run lane: app-port detection + Spring Boot startup parse.
+function onRunLine(line) {
+  detectPort(line);
+  parseStartupLine(line);
 }
 
 // ---------------------------------------------------------------------------
@@ -1882,6 +2041,7 @@ const server = createServer(async (req, res) => {
       // UI replays it into the right console.
       console: [...lanes.build.console, ...lanes.test.console, ...lanes.package.console, ...lanes.run.console],
       tests: lastTestReport,
+      startup: app.startup,
       env: envSnapshot(),
     });
     return;

--- a/public/index.html
+++ b/public/index.html
@@ -253,8 +253,8 @@
         border-color: var(--true-color-blue, #0969da);
       }
       .subpane-wrap { flex: 1 1 auto; min-height: 0; position: relative; }
-      .tsub { display: none; height: 100%; overflow: auto; min-height: 0; }
-      .tsub.active { display: block; }
+      .tsub, .rsub { display: none; height: 100%; overflow: auto; min-height: 0; }
+      .tsub.active, .rsub.active { display: block; }
       @media (max-width: 760px) {
         .subpane-wrap { min-height: 50vh; }
       }
@@ -268,6 +268,42 @@
         padding: 0.5rem 0.75rem;
         border-bottom: 1px solid var(--border-color-default, #d0d7de);
         flex: 0 0 auto;
+      }
+
+      /* Run tab: Spring Boot startup summary (the "Startup" graphical view) */
+      #run-startup { padding: 0.85rem 1rem; }
+      .su-status { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.85rem; }
+      .su-time { font-size: 12px; color: var(--text-color-muted, #656d76); }
+      .su-facts { margin-bottom: 0.85rem; }
+      .su-profiles { display: inline-flex; flex-wrap: wrap; gap: 0.3rem; justify-content: flex-end; }
+      .su-waiting { display: flex; align-items: center; gap: 0.4rem; }
+      .su-events-h {
+        display: flex; align-items: center; gap: 0.4rem;
+        margin: 0 0 0.4rem;
+        font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+        color: var(--text-color-muted, #656d76);
+      }
+      .su-ecount { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 0.02rem 0.4rem; color: var(--color-white, #fff); }
+      .su-ecount.bad { background: var(--true-color-red, #cf222e); }
+      .su-ecount.warn { background: var(--true-color-orange, #bc4c00); }
+      .su-event-row {
+        display: flex; align-items: flex-start; gap: 0.5rem;
+        padding: 0.3rem 0;
+        border-top: 1px dashed var(--border-color-muted, #d8dee4);
+        font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace); font-size: 11.5px;
+      }
+      .su-lvl { font-size: 10px; font-weight: 700; line-height: 1.55; border-radius: 4px; padding: 0.02rem 0.32rem; flex: none; color: var(--color-white, #fff); }
+      .su-lvl.WARN { background: var(--true-color-orange, #bc4c00); }
+      .su-lvl.ERROR { background: var(--true-color-red, #cf222e); }
+      .su-emsg { flex: 1; word-break: break-word; color: var(--text-color-default, #1f2328); }
+      .su-fail {
+        margin: -0.35rem 0 0.85rem;
+        padding: 0.5rem 0.7rem;
+        border: 1px solid var(--true-color-red, #cf222e);
+        border-radius: 6px;
+        background: var(--background-color-danger-muted, rgba(207, 34, 46, 0.08));
+        color: var(--text-color-default, #1f2328);
+        font-size: 12.5px; word-break: break-word;
       }
         border-left: 1px solid var(--border-color-default, #d0d7de);
         padding: 0.75rem 1rem;
@@ -805,6 +841,10 @@
         </section>
 
         <section id="run-pane" class="lpane col">
+          <div class="subtabs" role="tablist" aria-label="Run view">
+            <button class="subtab active" data-rview="graphical">Startup</button>
+            <button class="subtab" data-rview="console">Console</button>
+          </div>
           <div class="run-bar">
             <label class="switch" id="openbrowser-toggle">
               <input type="checkbox" id="in-openbrowser" />
@@ -815,7 +855,12 @@
               Open in browser
             </button>
           </div>
-          <pre id="run-console" class="term" aria-label="Run output"></pre>
+          <div class="subpane-wrap">
+            <div id="run-startup" class="rsub active">
+              <p class="empty">App not started yet. Click <strong>Run</strong> to launch it.</p>
+            </div>
+            <pre id="run-console" class="rsub term" aria-label="Run output"></pre>
+          </div>
         </section>
       </div>
       <aside>
@@ -969,6 +1014,7 @@
       const packageConsoleEl = document.getElementById("package-console");
       const testConsoleEl = document.getElementById("test-console");
       const runConsoleEl = document.getElementById("run-console");
+      const runStartupEl = document.getElementById("run-startup");
       const consoles = { build: buildConsoleEl, package: packageConsoleEl, test: testConsoleEl, run: runConsoleEl };
       // Which main tab is active, used as the fallback target for op-less lines.
       let activeTab = "build";
@@ -1105,11 +1151,23 @@
 
       // Test tab: Graphical / Console sub-toggle (graphical is the default).
       function showTestView(view) {
-        document.querySelectorAll(".subtab").forEach((t) => t.classList.toggle("active", t.dataset.tview === view));
+        document
+          .querySelectorAll("#test-pane .subtab")
+          .forEach((t) => t.classList.toggle("active", t.dataset.tview === view));
         document.getElementById("tests").classList.toggle("active", view === "graphical");
         document.getElementById("test-console").classList.toggle("active", view === "console");
       }
-      document.querySelectorAll(".subtab").forEach((t) => (t.onclick = () => showTestView(t.dataset.tview)));
+      document.querySelectorAll("#test-pane .subtab").forEach((t) => (t.onclick = () => showTestView(t.dataset.tview)));
+
+      // Run tab: Startup / Console sub-toggle (the Startup graphical view is the default).
+      function showRunView(view) {
+        document
+          .querySelectorAll("#run-pane .subtab")
+          .forEach((t) => t.classList.toggle("active", t.dataset.rview === view));
+        document.getElementById("run-startup").classList.toggle("active", view === "graphical");
+        document.getElementById("run-console").classList.toggle("active", view === "console");
+      }
+      document.querySelectorAll("#run-pane .subtab").forEach((t) => (t.onclick = () => showRunView(t.dataset.rview)));
 
       // Aside sub-tabs (Live JVM Metrics / Settings)
       function showAsideTab(name) {
@@ -1474,6 +1532,81 @@
           html += "</div>";
         }
         testsEl.innerHTML = html;
+      }
+
+      // Run tab graphical view: a Spring Boot startup summary parsed from the
+      // run console (so it works from plain stdout, no Actuator/BootUI needed).
+      const STARTUP_STATUS_LABEL = {
+        starting: "Starting\u2026",
+        started: "Started",
+        stopped: "Stopped",
+        failed: "Failed to start",
+      };
+      const STARTUP_PILL_CLASS = { starting: "building", started: "running", stopped: "stopped", failed: "failed" };
+
+      function renderStartup(su) {
+        const el = runStartupEl;
+        if (!el) return;
+        if (!su || !su.status) {
+          el.innerHTML = '<p class="empty">App not started yet. Click <strong>Run</strong> to launch it.</p>';
+          return;
+        }
+        const status = su.status;
+        let html = '<div class="su-status">';
+        if (status === "starting") html += '<span class="spinner"></span>';
+        html += `<span class="pill ${STARTUP_PILL_CLASS[status] || "idle"}">${
+          STARTUP_STATUS_LABEL[status] || esc(status)
+        }</span>`;
+        if (su.startupSeconds != null && status === "started")
+          html += `<span class="su-time">in ${su.startupSeconds.toFixed(2)} s</span>`;
+        html += "</div>";
+
+        if (status === "failed" && su.failureReason) html += `<p class="su-fail">${esc(su.failureReason)}</p>`;
+
+        const facts = [];
+        if (su.bootVersion) facts.push(["Spring Boot", esc("v" + String(su.bootVersion).replace(/^v/, ""))]);
+        if (su.appName) facts.push(["Application", esc(su.appName)]);
+        if (su.javaVersion) facts.push(["Java", esc(su.javaVersion)]);
+        if (su.pid != null) facts.push(["PID", esc(String(su.pid))]);
+        if (su.server || su.port != null) {
+          let v = su.server ? esc(su.server) : "";
+          if (su.port != null) {
+            const url = `http://127.0.0.1:${su.port}`;
+            v += (v ? " " : "") + `<a href="${url}">:${su.port}</a>`;
+          }
+          if (su.contextPath && su.contextPath !== "/") v += ` <span class="muted">${esc(su.contextPath)}</span>`;
+          facts.push(["Web server", v]);
+        }
+        if (su.profiles && su.profiles.length) {
+          const chips = su.profiles.map((p) => `<span class="chip">${esc(p)}</span>`).join("");
+          facts.push(["Active profiles", `<span class="su-profiles">${chips}</span>`]);
+        }
+
+        if (facts.length) {
+          html += '<div class="su-facts">';
+          for (const [k, v] of facts)
+            html += `<div class="metric"><span class="k">${k}</span><span class="v">${v}</span></div>`;
+          html += "</div>";
+        } else if (status === "starting") {
+          html += '<p class="muted su-waiting"><span class="spinner"></span> Reading startup log\u2026</p>';
+        } else {
+          html +=
+            '<p class="muted">No Spring Boot startup banner detected in the output. See the Console view for raw logs.</p>';
+        }
+
+        const events = su.events || [];
+        if (events.length) {
+          const errs = events.filter((e) => e.level === "ERROR").length;
+          html += `<div class="su-events"><div class="su-events-h">Notable log events <span class="su-ecount ${
+            errs > 0 ? "bad" : "warn"
+          }">${events.length}</span></div>`;
+          for (const ev of events) {
+            html += `<div class="su-event-row"><span class="su-lvl ${ev.level}">${ev.level}</span>`;
+            html += `<span class="su-emsg">${esc(ev.message || "")}</span></div>`;
+          }
+          html += "</div>";
+        }
+        el.innerHTML = html;
       }
 
       function renderTests(report, opts) {
@@ -1890,6 +2023,7 @@
         followLaneActivity(s);
       });
       es.addEventListener("metrics", (e) => renderMetrics(JSON.parse(e.data)));
+      es.addEventListener("run-startup", (e) => renderStartup(JSON.parse(e.data)));
       es.addEventListener("test-progress", (e) => {
         renderTestProgress(JSON.parse(e.data));
       });
@@ -1913,6 +2047,7 @@
         .then((s) => {
           renderStatus(s.status);
           renderMetrics(s.metrics);
+          renderStartup(s.startup);
           applyEnv(s.env);
           if (s.status && s.status.test) lastRunnerLabel = s.status.test.runnerLabel;
           renderTests(s.tests, { runnerLabel: lastRunnerLabel });


### PR DESCRIPTION
## What

Adds a second view to the **Run** tab, mirroring the Test tab's `Graphical | Console` sub-toggle. The new **Startup** view parses the Spring Boot startup sequence straight from the run console — so it works from plain stdout, with **no Actuator/BootUI required** — and renders a structured summary instead of raw logs.

It shows:
- **Status pill** (Starting… / Started / Stopped / Failed) with spinner + startup time
- **Spring Boot version**, **application name**, **Java version**, **PID**
- **Web server** (Tomcat/Netty/Undertow/Jetty) with a **clickable port** and context path
- **Active profiles** as chips
- **Notable WARN/ERROR events** with a count badge
- **Failure reason** banner on a failed start (e.g. _"Web server failed to start. Port 8080 was already in use."_)

The `Console` sub-view keeps the existing raw run output.

## How it works

**Backend (`extension.mjs`)**
- `app.startup` state + `resetStartup()`; `parseStartupLine()` with defensive, version-tolerant matchers; `onRunLine()` wired into both run spawns (`spring-boot:run` and `java -jar`).
- Status lifecycle `starting → started → stopped|failed`, broadcast over SSE (`run-startup`) and exposed via `/api/state`.
- Captures Spring's failure-analyzer `Description:` reason; skips blank-message log events; tolerates the extra tracing `[traceId,spanId]` correlation bracket so WARN/ERROR events are still detected under BootUI/tracing.

**Frontend (`public/index.html`)**
- `Startup | Console` sub-toggle, `renderStartup()`, SSE + state-load wiring, and the failure-reason banner.

## Testing

Validated against **real Spring Boot 4.1.0 / Java 26** output captured from the `integration-tests` projects, by running each app exactly as the extension does and feeding real stdout through the actual parser:

| Scenario | Result |
|---|---|
| `spring-mvc` (basic) | ✅ v4.1.0, Java 26.0.1, PID, profile `default`, Tomcat :8080, ctx `/`, 0.70s |
| `spring-mvc-actuator-devtools` | ✅ parsed cleanly despite `[restartedMain]` |
| `spring-mvc-bootui` (`-Pdev`) | ✅ profile `dev` shown; tracing bracket + BootUI logs handled |
| port-conflict failure | ✅ status **failed** + reason surfaced, no empty event row |

The render layer (`renderStartup()` HTML for starting/started/failed) was validated separately. Live testing against real output is what surfaced the three robustness fixes above (empty failure ERROR row, missing failure reason, BootUI correlation bracket).

`npm run check` and `npm run format:check` pass.

## Notes

- The `integration-tests/` projects used for validation live on a separate branch and were **not** committed here.
- A pre-existing malformed CSS block (an orphan `aside { … }` rule missing its selector) was left untouched — fixing it re-enables Prettier's embedded-CSS formatting and triggers a ~450-line reflow, so it's better handled in its own PR.