### PR TITLE
Resolve Maven project root from session working directory

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,8 +58,11 @@ optional metrics + advisor-scan tier, not the project's identity.
   `public/styles.css` (canvas theme tokens, e.g. `var(--background-color-default, …)`)
   and client logic in `public/app.js`; both are served unauthenticated since they
   hold no secrets, while `/api/*` and `/events` stay token-gated.
-- The Maven project root is resolved by walking up from the extension folder to the
-  directory that owns `mvnw`, so Coffilot works regardless of where it is installed.
+- The Maven project root is resolved from the session's primary working directory
+  (the project the user opened, via the SDK permission-paths API), falling back to
+  walking up from the extension folder / launch cwd to the directory that owns
+  `mvnw`, so Coffilot works regardless of where it is installed (project-embedded or
+  a user/global symlink).
 
 ## Scope
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -35,13 +35,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const session = await joinSession({ canvases: [makeCanvas()] });
 
-// Resolve the Maven project root. session.workspacePath is the session-artifacts
-// folder (checkpoints/, plan.md, files/), never the repo, so it must not be used
-// as the project root. We look in two places: the extension's own location (for a
-// project-embedded install at <repo>/.github/extensions/coffilot) and the CLI's
-// working directory (for a user/global install, where the CLI launches us with
-// cwd set to the project the user opened).
-const workspacePath = findProjectRoot();
+// Resolve the Maven project root. The authoritative source is the session's
+// primary working directory (the project the user actually opened), read from the
+// permission-paths API. The older heuristics are unreliable on their own:
+// session.workspacePath is the session-artifacts folder (checkpoints/, plan.md,
+// files/), never the repo; __dirname points into the coffilot repo for a
+// user/global install; and the extension host launches us with cwd=<COPILOT_HOME>,
+// not the project. We still fall back to __dirname (project-embedded install at
+// <repo>/.github/extensions/coffilot) and cwd for hosts that don't expose the
+// primary directory.
+const sessionPrimaryDir = await getSessionPrimaryDir();
+const workspacePath = findProjectRoot(sessionPrimaryDir);
 const mvnw = path.join(workspacePath, process.platform === "win32" ? "mvnw.cmd" : "mvnw");
 
 // Silence the JDK native-access warnings (JEP 472) that Jansi (Maven's native
@@ -252,12 +256,28 @@ function freePort() {
   });
 }
 
-function findProjectRoot() {
+// Read the session's primary working directory (the project the user opened) via
+// the permission-paths API. This is the only reliable signal for a user/global
+// install, where the host runs the extension with cwd=<COPILOT_HOME> and __dirname
+// resolves into the coffilot repo. Older hosts may not implement it, so failures
+// are tolerated and we fall back to path heuristics.
+async function getSessionPrimaryDir() {
+  try {
+    const res = await session.rpc?.permissions?.paths?.list?.();
+    if (res && typeof res.primary === "string" && res.primary) return res.primary;
+  } catch (e) {
+    session.log(`[coffilot] could not read session working directory: ${e.message}`, { level: "warn" });
+  }
+  return null;
+}
+
+function findProjectRoot(primary) {
   const wrapper = process.platform === "win32" ? "mvnw.cmd" : "mvnw";
   const owns = (dir) => existsSync(path.join(dir, wrapper)) || existsSync(path.join(dir, "pom.xml"));
   // Walk up from `start` (max 8 hops) to the first directory that owns the Maven
-  // wrapper or a pom.xml; null if none is found.
+  // wrapper or a pom.xml; null if `start` is falsy or none is found.
   const walkUp = (start) => {
+    if (!start) return null;
     let dir = start;
     for (let i = 0; i < 8; i++) {
       if (owns(dir)) return dir;
@@ -267,12 +287,14 @@ function findProjectRoot() {
     }
     return null;
   };
-  // 1) Project-embedded install (.github/extensions/coffilot): walk up from here.
-  // 2) User/global install (e.g. symlinked into ~/.copilot/extensions): the CLI
-  //    launches the extension with cwd set to the project, so walk up from there.
-  //    session.workspacePath is the session-artifacts folder, never the Maven
-  //    project, so it is deliberately not consulted.
-  return walkUp(__dirname) || walkUp(process.cwd()) || process.cwd();
+  // 1) The session's primary working directory is the project the user opened —
+  //    the most reliable signal, and the only one that works for a user/global
+  //    install (where the host runs the extension with cwd=<COPILOT_HOME> and
+  //    __dirname is the coffilot repo).
+  // 2) Project-embedded install (.github/extensions/coffilot): walk up from here.
+  // 3) Launch cwd, as a last resort for older hosts that don't expose (1).
+  // If nothing owns a pom.xml, still prefer the opened project dir over the cwd.
+  return walkUp(primary) || walkUp(__dirname) || walkUp(process.cwd()) || primary || process.cwd();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Coffilot was failing to find a project's `pom.xml` when installed as a user/global (symlinked) extension. It resolved the Maven project root by walking up from `__dirname` and `process.cwd()`, on the assumption that "the CLI launches the extension with cwd set to the project."

That assumption is false in the desktop app. I confirmed empirically (via `lsof` on the live extension forks) that the extension host runs every fork with `cwd=<COPILOT_HOME>` (`~/.copilot`), not the project. For a user/global symlink install `__dirname` also resolves into the coffilot repo, which has no `pom.xml`. So both walk-ups returned null and resolution fell back to `~/.copilot`, making Coffilot look for `~/.copilot/pom.xml` and report no Maven project.

The fix uses the session's **primary working directory** (the project the user actually opened), read from the SDK permission-paths API (`session.rpc.permissions.paths.list().primary`), as the authoritative source. The previous `__dirname` / `process.cwd()` walk-up is kept as a fallback for older hosts that don't expose it, and `getSessionPrimaryDir()` tolerates the call being unavailable.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (Updated `.github/copilot-instructions.md`; no README/PLAN behaviour change needed.)
- [x] No secrets committed.

## Notes for reviewers

- The ordering in `findProjectRoot` is `walkUp(primary) || walkUp(__dirname) || walkUp(process.cwd()) || primary || process.cwd()`, so the project-embedded install path is unchanged and the opened-project dir is preferred over the launch cwd as the final fallback.
- `getSessionPrimaryDir()` is intentionally defensive (optional chaining + try/catch) because `permissions.paths` is marked `@experimental` in the SDK.
- To exercise the user-install path that was broken, point `~/.copilot/extensions/coffilot` at a worktree containing this change and reload.