### PR TITLE
Serve favicon.svg and link it from the canvas iframe

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -1919,6 +1919,7 @@ async function loadIndex() {
 const STATIC_ASSETS = {
   "/styles.css": { file: "styles.css", type: "text/css; charset=utf-8" },
   "/app.js": { file: "app.js", type: "text/javascript; charset=utf-8" },
+  "/favicon.svg": { file: "favicon.svg", type: "image/svg+xml; charset=utf-8" },
 };
 const staticCache = new Map();
 async function loadStatic(name) {

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Coffilot</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary

`public/favicon.svg` shipped in the repo but was completely orphaned: it was never referenced from `index.html` and never registered in the loopback server's `STATIC_ASSETS` map, so the Coffilot canvas iframe never used it.

This wires it up:
- Adds `/favicon.svg` to the unauthenticated `STATIC_ASSETS` map (`image/svg+xml`) so the loopback server actually serves it.
- Adds `<link rel="icon" type="image/svg+xml" href="favicon.svg" />` to `index.html` so the iframe document references it.

Note on scope: this sets the iframe document's own favicon. It does not change the icon the Copilot app renders on the canvas tab/header, because the canvas SDK contract (`createCanvas` / `CanvasProviderOpenResult`) has no icon field; the host derives that chrome from `displayName`. So this makes the bundled asset live rather than dead, without claiming to restyle host chrome.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

`favicon.svg` is served unauthenticated alongside `styles.css` / `app.js`, which is consistent with those assets (it carries no secrets). The `/api/*` and `/events` endpoints remain token-gated.