### PR TITLE
Kill spawned Maven/Java processes on extension shutdown

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -1523,6 +1523,50 @@ function stopApp(op) {
   return stopped ? { ok: true, stopped: true } : { ok: true, stopped: false, note: "Nothing was running." };
 }
 
+// ---------------------------------------------------------------------------
+// Process shutdown — never let a spawned Maven/Java process outlive us.
+//
+// The host stops the extension by terminating this Node process (SIGTERM, or
+// SIGINT during a Ctrl-C). Our children are spawned *attached*, but on POSIX an
+// attached child is NOT killed when its parent dies — it is reparented to
+// init/launchd and keeps running, holding its HTTP port. Closing the canvas
+// panel does not stop the app either (that is intentional; a panel can be
+// reopened). So the only safe place to guarantee no orphans is here, on the way
+// out: SIGTERM the whole lane group (which lets Spring Boot run its shutdown
+// hook / the plugin kill its forked JVM) and tear down the polling timers.
+let shuttingDown = false;
+function gracefulShutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    session.log(`[coffilot] received ${signal}; stopping child processes`, { level: "info", ephemeral: true });
+  } catch {
+    /* host channel may already be gone */
+  }
+  stopApp(); // SIGTERM every lane + stop metrics polling / live reload timers
+  // Don't block on killChild's 5s SIGKILL escalation; exit promptly. The "exit"
+  // handler below force-kills anything still alive as a last resort.
+  setTimeout(() => process.exit(0), 1500).unref();
+}
+
+process.once("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.once("SIGINT", () => gracefulShutdown("SIGINT"));
+
+// Last-ditch synchronous sweep for any other exit path (process.exit elsewhere,
+// a handled fatal error). Only synchronous work runs during "exit".
+process.on("exit", () => {
+  for (const o of ["build", "test", "package", "run"]) {
+    const child = lanes[o].child;
+    if (child && !child.killed) {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+});
+
 const PORT_PATTERNS = [
   /Tomcat (?:started|initialized).*?port[s]?(?:\(s\))?:?\s*(\d+)/i,
   /Netty started on port[s]?(?:\(s\))?:?\s*(\d+)/i,


### PR DESCRIPTION
<!-- Thanks for contributing to Coffilot! -->

## Summary

Closing the canvas already left running apps alone (intentional, a panel can be reopened), but nothing stopped a spawned `mvn`/`java` process when the extension itself shut down. On POSIX an attached child is reparented to init/launchd when its parent dies, so when the Copilot CLI tore down the extension (session end, `extensions reload`) the app process kept running and held its HTTP port. That is the "Java processes running forever / blocked ports" leak.

This adds process-level shutdown handlers in `extension.mjs`:

- `SIGTERM` / `SIGINT` -> a graceful shutdown that calls `stopApp()`, which SIGTERMs every lane (letting Spring Boot run its shutdown hook / the spring-boot plugin kill its forked JVM) and tears down the metrics-polling and live-reload timers, then exits after a short unref'd grace period so it never hangs the host.
- `exit` -> a last-ditch synchronous `SIGKILL` sweep for any other exit path.

Panel-close behavior is unchanged and the manual Stop button / `stop_app` action still work as before. The only unrecoverable case is a hard `SIGKILL` of the Node process itself, where no handler can run.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (No user-facing behavior change; internal lifecycle only.)
- [x] No secrets committed.

## Notes for reviewers

Handlers reuse the existing `stopApp` / `killChild` logic so the SIGTERM-first ordering (important for spring-boot:run's forked JVM) is preserved. Registration is placed after `stopApp` so the closures resolve `lanes` lazily at signal time. The 1.5s grace timer is `unref()`'d so it cannot keep the host process alive on its own.