### PR TITLE
Add loading overlay to Coffilot canvas content

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1084,6 +1084,19 @@ es.addEventListener("reset", (e) => {
   if (el) el.innerHTML = "";
 });
 
+// Full-cover loading overlay: dismissed once the first /api/state lands (or a
+// safety timeout fires) so the canvas never shows empty panels on open.
+const loadingOverlay = document.getElementById("loading-overlay");
+let loadingHidden = false;
+function hideLoading() {
+  if (loadingHidden || !loadingOverlay) return;
+  loadingHidden = true;
+  loadingOverlay.classList.add("hide");
+  loadingOverlay.setAttribute("aria-hidden", "true");
+  setTimeout(() => loadingOverlay.setAttribute("hidden", ""), 220);
+}
+setTimeout(hideLoading, 4000);
+
 fetch(`/api/state?${qs}`)
   .then((r) => r.json())
   .then((s) => {
@@ -1096,7 +1109,8 @@ fetch(`/api/state?${qs}`)
     // Open the tab matching whatever the backend was last doing.
     followLaneActivity(s.status);
   })
-  .catch(() => {});
+  .catch(() => {})
+  .finally(hideLoading);
 
 // Env (mvnd availability, modules, profiles, capabilities) is only sampled
 // at page load, so installing mvnd while the canvas is open would otherwise

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,12 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div id="loading-overlay">
+      <div class="loading-card">
+        <span class="loading-spinner"></span>
+        <span class="loading-text">Starting Coffilot…</span>
+      </div>
+    </div>
     <header>
       <h1>Coffilot</h1>
       <div class="btn-group" id="maven-group">

--- a/public/styles.css
+++ b/public/styles.css
@@ -778,6 +778,39 @@ aside h2 {
 .tab-spin {
   margin-left: 0.1rem;
 }
+/* Full-cover overlay shown until the canvas has fetched its first state,
+         so opening Coffilot never flashes empty/placeholder panels. Fades out
+         (and is removed from the a11y tree) once the UI is populated. */
+#loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--background-color-default, #ffffff);
+  transition: opacity 0.2s ease;
+}
+#loading-overlay.hide {
+  opacity: 0;
+  pointer-events: none;
+}
+.loading-card {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--text-color-muted, #656d76);
+}
+.loading-spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color-default, #d0d7de);
+  border-top-color: var(--true-color-blue, #0969da);
+  animation: cof-spin 0.7s linear infinite;
+  flex: none;
+  display: inline-block;
+}
 .tprogress {
   height: 6px;
   border-radius: 3px;


### PR DESCRIPTION
## Summary

Opening the Coffilot canvas briefly showed empty/placeholder panels (`idle`, "No command run yet", "Scanning modules...") before the first `/api/state` response populated the UI. This adds a full-cover "Starting Coffilot..." overlay that hides that flash so the canvas feels ready the moment it opens.

The overlay is dismissed on the first `/api/state` response via `.finally()`, so it also clears on fetch error, with a 4s safety timeout so it can never get stuck. Styling reuses the existing `cof-spin` keyframe and canvas theme tokens, fading out via a `.hide` class.

Context on the original request: the user noticed the canvas chip is often absent at the start of a chat and then appears. That delay is **not** fixable from extension code. The chip is declared in the extension's first `joinSession` -> `session.resume` RPC (boot to that point measured at ~150-200ms), and the gap comes from the host re-forking the extension whenever the foreground session is replaced (a new chat). This PR addresses the part we control: the content load experience once the canvas opens.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project. (Installed extension symlinks to the main checkout, not this worktree, so a live reload here would not pick up these changes until merged.)
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed. (No behaviour/docs change; purely additive UI.)
- [x] No secrets committed.

## Notes for reviewers

- Pure front-end change scoped to `public/` (no `extension.mjs` changes), so loopback binding and the `/api/*` token gate are untouched.
- The overlay is additive markup right after `<body>` and is removed from the a11y tree (`aria-hidden` + `hidden`) after it fades.
- Worth a sanity check on the dark theme, since the overlay background uses `var(--background-color-default, ...)`.