### PR TITLE
Silence JLine dumb-terminal warning on Maven builds

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -82,9 +82,18 @@ const wrapperPath = path.join(workspacePath, wrapperName);
 // Maven, the launched app JVM.
 const NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED";
 
+// Maven 3.9+ embeds JLine for its console. When spawned without a TTY (as this
+// canvas always does), JLine can't open a system terminal and logs a noisy
+// "Unable to create a system terminal, creating a dumb terminal" warning at the
+// top of every build. Telling JLine to use a dumb terminal up front makes it do
+// so silently, without changing any build behaviour. Maven-only (Gradle uses
+// --console=plain instead).
+const JLINE_DUMB_FLAG = "-Dorg.jline.terminal.dumb=true";
+
 // Merge the native-access flag into the build tool's JVM options (MAVEN_OPTS for
 // Maven, GRADLE_OPTS for Gradle) so the build JVM doesn't print restricted-method
-// warnings, while preserving whatever the user already set. `extra` adds/overrides
+// warnings, while preserving whatever the user already set. For Maven we also add
+// the JLine dumb-terminal flag to suppress its no-TTY warning. `extra` adds/overrides
 // environment variables for a specific spawn (e.g. SPRING_PROFILES_ACTIVE).
 function toolEnv(extra) {
   const env = { ...process.env, ...(extra || {}) };
@@ -93,7 +102,7 @@ function toolEnv(extra) {
     env.GRADLE_OPTS = existing + NATIVE_ACCESS_FLAG;
   } else {
     const existing = process.env.MAVEN_OPTS ? process.env.MAVEN_OPTS.trim() + " " : "";
-    env.MAVEN_OPTS = existing + NATIVE_ACCESS_FLAG;
+    env.MAVEN_OPTS = existing + NATIVE_ACCESS_FLAG + " " + JLINE_DUMB_FLAG;
   }
   return env;
 }


### PR DESCRIPTION
## Summary

Every Maven Build (and Test/Package/Run) lane started with a red warning at the top of the console:

```
WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
[main] WARNING org.jline - Unable to create a system terminal, creating a dumb terminal ...
```

Maven 3.9+ embeds JLine for its console. Coffilot always spawns the build tool without a TTY (output is streamed into the canvas), so JLine can't open a system terminal and logs this noisy warning on startup.

The fix sets `-Dorg.jline.terminal.dumb=true` in `MAVEN_OPTS` (next to the existing `--enable-native-access` flag in `toolEnv()`). This tells JLine to create the dumb terminal *silently* instead of warning about it. It applies to all Maven lanes since they all default to `toolEnv()`. No build behaviour changes. Gradle is unaffected, it already runs with `--console=plain`.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A - no behaviour change)
- [x] No secrets committed.

## Notes for reviewers

This is a single, self-contained change in `toolEnv()`. The new `JLINE_DUMB_FLAG` is only appended in the Maven branch of `MAVEN_OPTS`, so Gradle output formatting is untouched. Worth confirming the warning is gone in a live canvas after reloading extensions (the iframe port/token rotate on reload).