### PR TITLE
Document Gradle support across remaining docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     id: project
     attributes:
       label: Target project
-      description: What kind of Maven project were you driving (Spring Boot? BootUI? plain Java)?
+      description: What kind of project were you driving (Maven or Gradle? Spring Boot? BootUI? plain Java)?
       placeholder: Spring Boot 3.3 multi-module, no BootUI
     validations:
       required: false
@@ -38,11 +38,11 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: OS, Java version, Maven/mvnd, Copilot app/CLI version.
+      description: OS, Java version, build tool (Maven/mvnd or Gradle), Copilot app/CLI version.
       placeholder: |
         - OS: macOS 14
         - Java: 21
-        - Maven: ./mvnw 3.9.x (mvnd: no)
+        - Build tool: ./mvnw 3.9.x (mvnd: no) — or ./gradlew 8.x
         - Copilot: …
     validations:
       required: false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
 # Coffilot — Copilot instructions
 
 Coffilot is a **GitHub Copilot canvas extension** (not a Java app). It turns a
-Maven-based Java / Spring Boot project into an interactive console in the Copilot
-app's side panel: Build / Test / Package / Run lanes, live JVM metrics, and a
+Maven- or Gradle-based Java / Spring Boot project into an interactive console in the
+Copilot app's side panel: Build / Test / Package / Run lanes, live JVM metrics, and a
 "Fix with Copilot" bridge. Read `README.md`, `PLAN.md`, and `CONTRIBUTING.md`
 before changing visible behavior.
 
@@ -43,28 +43,33 @@ before changing visible behavior.
 
 The project identity is **Coffilot**. Keep references to **BootUI**, **Actuator**,
 and **`mvnd`** only where they name a real integration/tier — BootUI is the richest
-optional metrics + advisor-scan tier, not the project's identity.
+optional metrics + advisor-scan tier, not the project's identity. Maven and Gradle
+are both first-class build tools, auto-detected per project.
 
 ## How it works (orientation)
 
 - `extension.mjs`: `joinSession({ canvases: [makeCanvas()] })`, the canvas
   declaration + agent actions (`build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`), the Maven runner
-  (`spawn` of `./mvnw`/`mvnd` with `--enable-native-access=ALL-UNNAMED` via
-  `MAVEN_OPTS`), the Surefire report parser, the metrics/MCP proxy (tiered
-  BootUI → Actuator → process), and the fix-prompt builder.
+  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`), the build-tool
+  runner (`spawn` of `./mvnw`/`mvnd` for Maven or `./gradlew`/`gradle` for Gradle,
+  with `--enable-native-access=ALL-UNNAMED` via `MAVEN_OPTS` / `GRADLE_OPTS`), the
+  JUnit report parser (Maven Surefire / Gradle `build/test-results`), the metrics/MCP
+  proxy (tiered BootUI → Actuator → process), and the fix-prompt builder.
 - `public/index.html`: the iframe UI markup (Build/Test/Package/Run + Live JVM +
   Settings tabs, live console, graphical test view, MCP panel). Styles live in
   `public/styles.css` (canvas theme tokens, e.g. `var(--background-color-default, …)`)
   and client logic in `public/app.js`; both are served unauthenticated since they
   hold no secrets, while `/api/*` and `/events` stay token-gated.
-- The Maven project root is resolved from the session's primary working directory
-  (the project the user opened, via the SDK permission-paths API), falling back to
-  walking up from the extension folder / launch cwd to the directory that owns
-  `mvnw`, so Coffilot works regardless of where it is installed (project-embedded or
-  a user/global symlink).
+- The build tool is auto-detected per project: Maven (`pom.xml` / `mvnw`) wins when
+  present, otherwise Gradle (`build.gradle[.kts]` / `gradlew`). The project root is
+  resolved from the session's primary working directory (the project the user opened,
+  via the SDK permission-paths API), falling back to walking up from the extension
+  folder / launch cwd to the directory that owns the build wrapper (`mvnw` or
+  `gradlew`), so Coffilot works regardless of where it is installed (project-embedded
+  or a user/global symlink).
 
 ## Scope
 
-Maven only (Gradle is out of scope), loopback only (no remote access), and no
-mutation of the target project's source without an explicit agent action.
+Maven and Gradle build tools (auto-detected per project), loopback only (no remote
+access), and no mutation of the target project's source without an explicit agent
+action.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 - [ ] `npm run check` passes (syntax check of `extension.mjs`).
 - [ ] `npm run format:check` passes (Prettier).
-- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
+- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
 - [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
 - [ ] No secrets committed.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,27 +20,29 @@ You will receive an acknowledgement within five working days.
 ## Threat model and intended use
 
 Coffilot is a **local developer tool**: a GitHub Copilot canvas extension that runs
-as a Node process on the developer's machine and drives Maven builds of the project
-being worked on. By design it:
+as a Node process on the developer's machine and drives Maven or Gradle builds of
+the project being worked on. By design it:
 
 - binds its iframe / control HTTP server to the **loopback interface only**
   (`127.0.0.1`); the Copilot app only embeds loopback URLs;
-- executes the project's own committed Maven wrapper (`./mvnw`) and, when running a
-  plain-Java module, the JAR produced by that build — it does not download or run
-  arbitrary third-party binaries beyond what Maven itself resolves;
+- executes the project's own committed build wrapper (`./mvnw` or `./gradlew`) and,
+  when running a plain-Java module, the JAR produced by that build — it does not
+  download or run arbitrary third-party binaries beyond what Maven or Gradle itself
+  resolves;
 - exposes mutating actions (Build / Test / Package / Run / Stop, the BootUI MCP
   toggle, and "Fix with Copilot") explicitly from the UI or agent actions, never
   implicitly on load.
 
 ### Known limitations
 
-- **Build and run output is not secret-masked.** Maven and application stdout are
-  streamed verbatim to the iframe and can be included in "Fix with Copilot"
+- **Build and run output is not secret-masked.** Build-tool and application stdout
+  are streamed verbatim to the iframe and can be included in "Fix with Copilot"
   context. If your build prints secrets, they will be visible in the console and in
   any fix request sent to the agent. Masking this output is on the
   [roadmap](PLAN.md).
-- Coffilot trusts the Maven project it is pointed at. Only use it on projects you
-  trust, exactly as you would before running `./mvnw` yourself.
+- Coffilot trusts the Maven or Gradle project it is pointed at. Only use it on
+  projects you trust, exactly as you would before running `./mvnw` or `./gradlew`
+  yourself.
 
 ### Operator responsibilities
 


### PR DESCRIPTION
## Summary

Gradle support shipped a while back (PR #14), but only the user-facing docs (README, PLAN, CONTRIBUTING, integration-tests README) were updated at the time. The internal/governance docs were left describing Coffilot as Maven-only, which is now inaccurate and misleading for both contributors and the agent.

This change brings the remaining docs in line so every doc reflects that Coffilot drives **Maven and Gradle**, auto-detected per project:

- **`.github/copilot-instructions.md`** was the most out of date. It described only the Maven runner (`MAVEN_OPTS`, Surefire), Maven-only root resolution, and a Scope line that literally read "Maven only (Gradle is out of scope)". Rewrote the orientation to cover the build-tool runner (`./mvnw`/`mvnd` and `./gradlew`/`gradle`, `MAVEN_OPTS`/`GRADLE_OPTS`), the JUnit/Gradle report parser, build-wrapper-based root resolution, and a Scope of "Maven and Gradle".
- **`SECURITY.md`** threat model now refers to Maven or Gradle builds and the `./mvnw` or `./gradlew` wrapper.
- **`.github/pull_request_template.md`** and **`.github/ISSUE_TEMPLATE/bug_report.yml`** now ask about Maven or Gradle.

PLAN.md's "Maven profile discovery (Maven only)" was intentionally left as-is: Spring/Maven profiles are genuinely a Maven-only concept with no Gradle equivalent.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project. (N/A: docs-only change, no runtime behaviour touched.)
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A: those already documented Gradle; this fills the gaps in the other docs.)
- [x] No secrets committed.

## Notes for reviewers

Docs-only change, no code touched. Worth a quick read of the rewritten "How it works" / Scope sections in `.github/copilot-instructions.md` to confirm the Gradle wording matches how the runner actually behaves.