### PR TITLE
Recover from failed build-tool detection without a reload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ verification in a live canvas is still expected for UI changes.
 ## Safety notes when testing
 
 The loopback control endpoints are mostly safe to `curl` for inspection
-(`/api/state`, `/api/settings`, `/api/build`, `/api/test`, `/api/run`, `/api/stop`,
+(`/api/state`, `/api/settings`, `/api/recheck`, `/api/build`, `/api/test`, `/api/run`, `/api/stop`,
 `/events`, …), but **`/api/fix` and `/api/mcp/scan` fire prompts / scans into the
 conversation** — don't call them casually. The HTTP server binds to `127.0.0.1`
 only; keep it that way.

--- a/extension.mjs
+++ b/extension.mjs
@@ -61,19 +61,51 @@ const GRADLE_MARKERS = [
 // __dirname points into the coffilot repo for a user/global install; and the host
 // launches us with cwd=<COPILOT_HOME>, not the project. We fall back to __dirname
 // (project-embedded install at <repo>/.github/extensions/coffilot) and cwd.
-const sessionPrimaryDir = await getSessionPrimaryDir();
-const workspacePath = findProjectRoot(sessionPrimaryDir);
+// These five are `let`, not `const`, because the "Check again" control
+// (recheckBuildTool / POST /api/recheck) re-resolves them at runtime: detection
+// runs once at startup, and if the session's primary working directory isn't
+// available yet the project root / build tool would otherwise stay wrong until an
+// extension reload.
+let workspacePath = findProjectRoot(await getSessionPrimaryDir());
 
 // Auto-detect the build tool from the project. Maven wins when both are present,
 // per Coffilot's "prefer Maven" rule; null means neither was found (degraded UI).
-const buildTool = detectBuildTool(workspacePath); // "maven" | "gradle" | null
-const TOOL_LABEL = buildTool === "gradle" ? "Gradle" : buildTool === "maven" ? "Maven" : null;
+let buildTool = detectBuildTool(workspacePath); // "maven" | "gradle" | null
+let TOOL_LABEL = buildTool === "gradle" ? "Gradle" : buildTool === "maven" ? "Maven" : null;
 
 // The committed wrapper for the active tool, preferred over a system binary
 // because it pins the tool version. Gradle ships gradlew / gradlew.bat; Maven
 // ships mvnw / mvnw.cmd.
-const wrapperName = buildTool === "gradle" ? (isWindows ? "gradlew.bat" : "gradlew") : isWindows ? "mvnw.cmd" : "mvnw";
-const wrapperPath = path.join(workspacePath, wrapperName);
+let wrapperName = wrapperFileNameFor(buildTool);
+let wrapperPath = path.join(workspacePath, wrapperName);
+
+/** The wrapper file name for a build tool, accounting for the platform. */
+function wrapperFileNameFor(tool) {
+  return tool === "gradle" ? (isWindows ? "gradlew.bat" : "gradlew") : isWindows ? "mvnw.cmd" : "mvnw";
+}
+
+// Re-resolve the project root and build tool at runtime (driven by the canvas's
+// "Check again" control). Startup detection is a single shot, so a project that
+// wasn't visible then — or a user/global install whose primary working directory
+// the host reported late — would otherwise be stuck in the degraded "no Maven or
+// Gradle" state until an extension reload. This re-queries the session's primary
+// directory, re-walks for a build marker, and refreshes every workspace-derived
+// cache so the UI can recover without a reload. Returns the new env snapshot.
+async function recheckBuildTool() {
+  workspacePath = findProjectRoot(await getSessionPrimaryDir());
+  buildTool = detectBuildTool(workspacePath);
+  TOOL_LABEL = buildTool === "gradle" ? "Gradle" : buildTool === "maven" ? "Maven" : null;
+  wrapperName = wrapperFileNameFor(buildTool);
+  wrapperPath = path.join(workspacePath, wrapperName);
+  // Drop caches that were computed against the old root / tool so they recompute.
+  baseRunnerInfo = null;
+  projectModules = null;
+  javaVersion = undefined;
+  mavenProfiles = null;
+  springProfiles = null;
+  session.log(`[coffilot] re-checked build tool: ${TOOL_LABEL || "none"} at ${workspacePath}`, { level: "info" });
+  return envSnapshot();
+}
 
 // Silence the JDK native-access warnings (JEP 472) that Jansi (Maven's native
 // console) and FFM-using app dependencies emit at startup. The flag exists
@@ -2810,6 +2842,11 @@ const server = createServer(async (req, res) => {
   if (req.method === "POST" && url.pathname === "/api/settings") {
     const body = await readBody(req);
     sendJson(res, 200, applySettings(body));
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/api/recheck") {
+    sendJson(res, 200, await recheckBuildTool());
     return;
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -36,6 +36,7 @@ const mvnProfilesInput = document.getElementById("in-mvn-profiles");
 const mvnProfilesLabel = document.getElementById("lbl-mvn-profiles");
 const mvnProfilesCombo = document.getElementById("mvn-profiles-combo");
 const noToolBanner = document.getElementById("no-tool-banner");
+const btnRecheck = document.getElementById("btn-recheck");
 const warmBanner = document.getElementById("warm-banner");
 const warmMsg = document.getElementById("warm-msg");
 const warmCmd = document.getElementById("warm-cmd");
@@ -1167,6 +1168,25 @@ document.addEventListener("visibilitychange", () => {
   if (!document.hidden) refreshEnv();
 });
 window.addEventListener("focus", refreshEnv);
+
+// "Check again": re-run project-root + build-tool detection on the backend, then
+// re-apply the env. Lets a project that wasn't visible at startup recover without
+// reloading the extension (applyEnv hides this banner once a tool is found).
+if (btnRecheck) {
+  btnRecheck.addEventListener("click", async () => {
+    btnRecheck.disabled = true;
+    btnRecheck.textContent = "Checking…";
+    const env = await postJson("/api/recheck");
+    applyEnv(env);
+    btnRecheck.disabled = false;
+    btnRecheck.textContent = "Check again";
+    if (env && env.buildTool) {
+      appendLine(`[canvas] detected ${env.toolLabel || env.buildTool} project.`, "stdout");
+    } else {
+      appendLine("[canvas] still no Maven or Gradle project detected.", "stderr");
+    }
+  });
+}
 
 // The iframe can't open a browser via target="_blank"; route external
 // http(s) links through the backend opener instead.

--- a/public/index.html
+++ b/public/index.html
@@ -46,9 +46,12 @@
     </header>
 
     <div id="no-tool-banner" hidden>
-      ⚠️ No Maven or Gradle project detected. Coffilot needs a <code>pom.xml</code>/<code>mvnw</code> or a
-      <code>build.gradle</code>/<code>gradlew</code> in the project to build, test, package or run. The actions are
-      disabled until one is present.
+      <span id="no-tool-msg"
+        >⚠️ No Maven or Gradle project detected. Coffilot needs a <code>pom.xml</code>/<code>mvnw</code> or a
+        <code>build.gradle</code>/<code>gradlew</code> in the project to build, test, package or run. The actions are
+        disabled until one is present.</span
+      >
+      <button id="btn-recheck" class="fix tiny">Check again</button>
     </div>
 
     <div id="status">

--- a/public/styles.css
+++ b/public/styles.css
@@ -507,12 +507,22 @@ aside h2 {
 
 /* Degraded-mode banner shown when neither Maven nor Gradle is detected. */
 #no-tool-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   padding: 0.55rem 1rem;
   font-size: 12.5px;
   line-height: 1.5;
   color: var(--text-color-default, #1f2328);
   background: color-mix(in srgb, var(--true-color-orange, #bc4c00) 12%, var(--background-color-default, #fff));
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
+}
+#no-tool-banner #no-tool-msg {
+  flex: 1;
+}
+#no-tool-banner #btn-recheck {
+  flex: none;
+  white-space: nowrap;
 }
 #no-tool-banner code {
   font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);


### PR DESCRIPTION
## Summary

Coffilot detects the build tool once at startup. The project root and `buildTool` were stored in `const` bindings, so if the session's primary working directory wasn't reported yet (the permission-paths RPC returning late, or a user/global install where the host launches with `cwd=COPILOT_HOME` and `__dirname` points at the coffilot repo, neither of which owns a `pom.xml`), detection fell through to a non-project folder and `buildTool` stayed `null` permanently. Even the existing focus/visibility `/api/env` refresh couldn't recover, because it just re-read the frozen `const`. The only fix was an extension reload, which is why the canvas showed "no Maven or Gradle" despite a real `pom.xml` being present.

This makes detection re-runnable at runtime and gives the user a way to trigger it:

- The five detection bindings (`workspacePath`, `buildTool`, `TOOL_LABEL`, `wrapperName`, `wrapperPath`) are now `let`, and `recheckBuildTool()` re-queries the session primary dir, re-walks for a build marker, recomputes the wrapper, and drops the workspace-derived caches (`baseRunnerInfo`, `projectModules`, `javaVersion`, `mavenProfiles`, `springProfiles`) so they recompute against the new root.
- Exposed via `POST /api/recheck` (token-gated, no prompts or side effects), returning a fresh env snapshot.
- Added a "Check again" button to the no-tool banner. It posts to `/api/recheck`, re-applies the env (which hides the banner and re-enables the lanes once a tool is found), and reports the outcome in the console, all without an extension reload.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (Updated `CONTRIBUTING.md` to list `/api/recheck` among the safe-to-inspect endpoints; no README/PLAN behaviour change needed.)
- [x] No secrets committed.

## Notes for reviewers

`recheckBuildTool` references the cache `let`s and `envSnapshot()` declared later in the file; this is safe because it only runs at HTTP request time, well after module init (no TDZ). The installed extension here symlinks to the main checkout, so live canvas verification still needs a follow-up once this is merged/installed. Settings/`lastTestTotal` are intentionally left keyed to the original workspace path to avoid clobbering any in-session edits if the resolved root changes.