### PR TITLE
Silence JLine dumb-terminal warning on mvnd builds

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -114,11 +114,14 @@ async function recheckBuildTool() {
 // Maven, the launched app JVM.
 const NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED";
 
-// Maven 3.9+ embeds JLine for its console. When spawned without a TTY (as this
-// canvas always does), JLine can't open a system terminal and logs a noisy
-// "Unable to create a system terminal, creating a dumb terminal" warning at the
-// top of every build. Telling JLine to use a dumb terminal up front makes it do
-// so silently, without changing any build behaviour. Maven-only (Gradle uses
+// Maven 3.9+ (and the mvnd native client) embed JLine for their console. When
+// spawned without a TTY (as this canvas always does), JLine can't open a system
+// terminal and logs a noisy "Unable to create a system terminal, creating a dumb
+// terminal" warning at the top of every build. Telling JLine to use a dumb
+// terminal up front makes it do so silently, without changing any build
+// behaviour. The JVM-based runners (./mvnw, mvn) pick it up from MAVEN_OPTS, but
+// the mvnd *native* client ignores MAVEN_OPTS entirely, so it must also be passed
+// as a CLI argument (see withJLineDumbFlag). Maven-only (Gradle uses
 // --console=plain instead).
 const JLINE_DUMB_FLAG = "-Dorg.jline.terminal.dumb=true";
 
@@ -137,6 +140,17 @@ function toolEnv(extra) {
     env.MAVEN_OPTS = existing + NATIVE_ACCESS_FLAG + " " + JLINE_DUMB_FLAG;
   }
   return env;
+}
+
+// Prepend the JLine dumb-terminal flag as a real CLI argument for Maven spawns.
+// The mvnd native client ignores MAVEN_OPTS, so this is the only way to silence
+// its no-TTY warning; ./mvnw and mvn also honour it here (in addition to
+// MAVEN_OPTS). Skipped for Gradle and for direct `java` launches, neither of
+// which emit the warning.
+function withJLineDumbFlag(args, bin) {
+  if (buildTool !== "maven") return args;
+  if (/(^|[\\/])java(\.exe)?$/i.test(bin || "")) return args;
+  return [JLINE_DUMB_FLAG, ...args];
 }
 
 /** Decide the build tool for a project root: Maven preferred, else Gradle, else null. */
@@ -1257,7 +1271,7 @@ function triggerRecompile() {
   let out = "";
   let child;
   try {
-    child = spawn(ctx.bin, args, { cwd: workspacePath, env: toolEnv(), shell: isWindows });
+    child = spawn(ctx.bin, withJLineDumbFlag(args, ctx.bin), { cwd: workspacePath, env: toolEnv(), shell: isWindows });
   } catch (e) {
     pushConsole(`[live-reload] recompile failed to start: ${e.message}`, "stderr", "run");
     return finishRecompile();
@@ -1467,7 +1481,7 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
     broadcast("status", statusSnapshot());
     session.log(`[coffilot] ${lane.command}`, { level: "info", ephemeral: true });
 
-    const child = spawn(toolBin, args, {
+    const child = spawn(toolBin, withJLineDumbFlag(args, toolBin), {
       cwd: workspacePath,
       env: env || toolEnv(),
       // mvnw.cmd / mvnd.cmd / gradlew.bat are batch scripts; modern Node refuses


### PR DESCRIPTION
## Summary

Warm builds were still printing the JLine "Unable to create a system terminal, creating a dumb terminal" warning at the top of every build/test/recompile, even though we thought we'd already fixed it.

The earlier fix put `-Dorg.jline.terminal.dumb=true` in `MAVEN_OPTS`, which the JVM-based `./mvnw` and `mvn` honour. But when the "Keep JVM warm" tier is active the build runs through the **mvnd native client**, which ignores `MAVEN_OPTS` entirely, so the warning came right back.

This passes the flag as a real CLI argument for Maven spawns via a new `withJLineDumbFlag()` helper, which reaches both the JVM runners and the mvnd native client. It's skipped for Gradle (already uses `--console=plain`) and for direct `java -jar` launches, neither of which emit the warning. Wired into both Maven spawn sites: `spawnTool` and the live-reload recompile.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project. <!-- Reproduced + fixed against integration-tests/hello-world: a real `mvnd -ntp -DskipTests install` went from 2 warning lines to 0 with the flag injected. -->
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. <!-- N/A: internal noise-suppression only, no visible behaviour change. -->
- [x] No secrets committed.

## Notes for reviewers

The flag is injected at spawn time only, so it does not appear in the displayed lane command (kept clean, consistent with how the existing native-access flag is hidden in `MAVEN_OPTS`). The `MAVEN_OPTS` jline entry is intentionally kept as well: it sets the property at JVM startup for the JVM-based runners, which is the earliest possible point, while the CLI arg is the only thing that reaches the mvnd native client.