### PR TITLE
Add immediate feedback to canvas Stop buttons

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -246,6 +246,54 @@ function appendLine(line, stream, op) {
 // Last status snapshot ({ build, test, package, run, reload }).
 // (declared above, near activeTab, so showTab can read it)
 
+// Optimistic "stopping" state for the two grouped Stop buttons. A stop request
+// is fire-and-forget, and the lane only reports !busy once the child process
+// actually dies (which can take a few seconds for a server). Without local
+// feedback the button looks dead, so we flip it to a disabled "Stopping…"
+// spinner the moment it's clicked and clear it when the lane goes idle (or a
+// safety timeout fires, in case the process ignores the stop and the user
+// needs to retry).
+const stopping = { maven: false, run: false };
+const stopTimers = { maven: null, run: null };
+
+function markStopping(which, op) {
+  if (stopping[which]) return;
+  stopping[which] = true;
+  appendLine(`[canvas] stopping ${which === "run" ? "the app" : "the build"}\u2026`, "stdout", op);
+  if (statusSnap) renderStatus(statusSnap);
+  clearTimeout(stopTimers[which]);
+  stopTimers[which] = setTimeout(() => {
+    if (!stopping[which]) return;
+    stopping[which] = false;
+    if (statusSnap) renderStatus(statusSnap);
+  }, 8000);
+}
+
+function clearStopping(which) {
+  stopping[which] = false;
+  clearTimeout(stopTimers[which]);
+  stopTimers[which] = null;
+}
+
+function applyStopButton(btn, which, busy) {
+  // The process has actually stopped: drop the optimistic state.
+  if (stopping[which] && !busy) clearStopping(which);
+  const isStopping = stopping[which];
+  btn.disabled = !busy || isStopping;
+  btn.classList.toggle("is-stopping", isStopping);
+  const spin = btn.querySelector(".btn-spin");
+  if (spin) spin.hidden = !isStopping;
+  const label = btn.querySelector(".btn-label");
+  if (label) label.textContent = isStopping ? "Stopping\u2026" : "Stop";
+  if (isStopping) {
+    btn.title = which === "run" ? "Stopping the app\u2026" : "Stopping the build\u2026";
+  } else if (busy) {
+    btn.title = which === "run" ? "Stop the running app" : "Stop the running build, test or package";
+  } else {
+    btn.title = which === "run" ? "The app isn't running" : "No build is running";
+  }
+}
+
 function renderStatus(s) {
   if (!s) return;
   statusSnap = s;
@@ -267,10 +315,8 @@ function renderStatus(s) {
   // The two grouped Stop buttons are global, not tied to the active tab:
   // the Maven Stop covers build/test/package; the Run Stop covers run.
   const mvnBusy = (s.build && s.build.busy) || (s.test && s.test.busy) || (s.package && s.package.busy);
-  btnStopMaven.disabled = !mvnBusy;
-  btnStopMaven.title = mvnBusy ? "Stop the running build, test or package" : "No build is running";
-  btnStopRun.disabled = !(run && run.busy);
-  btnStopRun.title = run && run.busy ? "Stop the running app" : "The app isn't running";
+  applyStopButton(btnStopMaven, "maven", mvnBusy);
+  applyStopButton(btnStopRun, "run", !!(run && run.busy));
   // Per-lane running spinners on the trigger buttons and tabs (global, so
   // they reflect activity regardless of which tab is showing).
   for (const op of ["build", "test", "package", "run"]) {
@@ -1000,8 +1046,18 @@ document.getElementById("btn-run").onclick = () => {
 // Two grouped Stop buttons: the Maven Stop kills the shared build/test/
 // package lane; the Run Stop kills the independent app. They are global,
 // so you can stop a build without killing the running app, or vice versa.
-btnStopMaven.onclick = () => post("/api/stop", { op: "maven" });
-btnStopRun.onclick = () => post("/api/stop", { op: "run" });
+btnStopMaven.onclick = () => {
+  if (btnStopMaven.disabled) return;
+  const s = statusSnap || {};
+  const op = ["build", "test", "package"].find((o) => s[o] && s[o].busy) || activeTab;
+  markStopping("maven", op);
+  post("/api/stop", { op: "maven" });
+};
+btnStopRun.onclick = () => {
+  if (btnStopRun.disabled) return;
+  markStopping("run", "run");
+  post("/api/stop", { op: "run" });
+};
 
 // Run tab: force-open the running app in a browser.
 btnOpenBrowser.onclick = () => post("/api/open-app", {});

--- a/public/index.html
+++ b/public/index.html
@@ -20,11 +20,15 @@
         <button id="btn-build"><span class="btn-spin" hidden></span>Build</button>
         <button id="btn-test"><span class="btn-spin" hidden></span>Test</button>
         <button id="btn-package"><span class="btn-spin" hidden></span>Package</button>
-        <button id="btn-stop-maven" class="danger">Stop</button>
+        <button id="btn-stop-maven" class="danger">
+          <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
+        </button>
       </div>
       <div class="btn-group" id="run-group">
         <button id="btn-run" class="primary"><span class="btn-spin" hidden></span>Run</button>
-        <button id="btn-stop-run" class="danger">Stop</button>
+        <button id="btn-stop-run" class="danger">
+          <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
+        </button>
       </div>
       <div class="inputs">
         <label>module</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -81,6 +81,19 @@ button.danger:hover {
   background: color-mix(in srgb, #000 14%, var(--true-color-red, #cf222e));
   border-color: color-mix(in srgb, #000 14%, var(--true-color-red, #cf222e));
 }
+/* A Stop button that's been clicked but whose process hasn't exited yet: keep
+   it visibly "busy" (spinner + label) rather than letting :disabled grey it
+   out, so the click clearly registered. */
+button.is-stopping,
+button.is-stopping:hover {
+  opacity: 0.9;
+  cursor: progress;
+}
+button.danger.is-stopping,
+button.danger.is-stopping:hover {
+  background: var(--true-color-red, #cf222e);
+  border-color: var(--true-color-red, #cf222e);
+}
 button.fix {
   border-color: var(--true-color-orange, #bc4c00);
   color: var(--color-white, #fff);


### PR DESCRIPTION
## Summary

Clicking a Stop button in the canvas appeared to do nothing. The buttons fire a fire-and-forget `POST /api/stop`, but their UI only updated once the server broadcast a fresh status, which happens only after the child process has actually exited. For a running server that graceful shutdown can take several seconds (or up to the SIGTERM -> SIGKILL escalation), so the button looked inert and the stop seemed broken.

This adds optimistic, client-side feedback the moment Stop is clicked:

- The button immediately flips to a disabled "Stopping..." state with a spinner, staying red (`is-stopping` class, `cursor: progress`) so the click is obviously registered.
- A `[canvas] stopping ...` line is logged into the relevant lane console (the Maven Stop targets whichever of build/test/package is actually busy; the Run Stop targets the run lane).
- The state clears automatically when the lane reports it is no longer busy (process really stopped).
- An 8s safety timeout re-enables the button if the process ignores the stop, so the user can retry instead of being stuck on a dead "Stopping..." button.

This is a UI-feedback fix only; the underlying `/api/stop` kill behavior is unchanged.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A, no documented behavior change.)
- [x] No secrets committed.

## Notes for reviewers

Separate, deeper issue spotted while here (not addressed): for Gradle `bootRun` the app runs as a forked JVM off the Gradle daemon, so SIGTERM to `gradlew` may not actually kill it. The new safety timeout will surface that case (the button re-enables while the app is still up) rather than masking it. Fixing the kill propagation itself is a larger change left for a follow-up.