### PR TITLE
Add Quarkus support alongside Spring Boot

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3,18 +3,18 @@
 ## Vision
 
 Coffilot is the Java inner-loop console for the GitHub Copilot app: a canvas that
-lets you build, test, package and run a Maven or Gradle Java / Spring Boot project,
-watch it live, and hand failures straight to the agent — without leaving the chat. It
-degrades gracefully from plain Java up to a BootUI-instrumented Spring Boot app,
-surfacing richer data when the project provides it.
+lets you build, test, package and run a Maven or Gradle Java / Spring Boot / Quarkus
+project, watch it live, and hand failures straight to the agent — without leaving the
+chat. It degrades gracefully from plain Java up to a BootUI-instrumented Spring Boot
+app, surfacing richer data when the project provides it.
 
 Principles, in priority order:
 
 1. **Stay local and safe.** The loopback server binds to `127.0.0.1`; mutating
    actions are explicit; nothing leaves the machine.
 2. **Zero-config where possible.** Detect the build tool (Maven or Gradle), modules,
-   profiles, Spring Boot, Actuator and BootUI from the build files and the running app
-   rather than asking the user.
+   profiles, Spring Boot / Quarkus, Actuator and BootUI from the build files and the
+   running app rather than asking the user.
 3. **Fast inner loop.** Parallel Build/Test/Package and Run lanes, optional warm
    JVM via `mvnd` / the Gradle daemon, live streaming output.
 4. **Useful failures.** Every failure offers a context-rich "Fix with Copilot".
@@ -31,13 +31,16 @@ Shipped in the extension today:
   (`./mvnw` / `./gradlew`) is preferred over a system `mvn` / `gradle`, cross-platform.
 - Build group (Build/Test/Package) running independently of the long-lived Run lane.
 - Module scan for runnable apps (Maven reactor / Gradle subprojects), Spring Boot
-  detection, and Spring + Maven profile discovery (Maven only).
-- Plain-Java fallback (build + `java -jar`) when a module is not a Spring Boot app.
+  and Quarkus detection, and run-profile discovery (Spring `application-<profile>.*`
+  files and Maven profiles for Maven; Quarkus `dev`/`test`/`prod` + `%<profile>.` keys).
+- Plain-Java fallback (build + `java -jar`) when a module is neither a Spring Boot
+  nor a Quarkus app.
 - Optional warm builds via the Maven Daemon (`mvnd`) or the Gradle daemon,
   cross-platform detected.
-- Live JVM metrics tiered BootUI → Actuator → process, with a source badge.
-- "Fix with Copilot" for compile, package, test, plain-Java and Spring startup
-  failures, and for BootUI advisor-scan findings.
+- Live JVM metrics tiered BootUI → Actuator → Quarkus Micrometer/health → process,
+  with a source badge.
+- "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
+  startup failures, and for BootUI advisor-scan findings.
 - BootUI MCP server toggle + advisor scans when the running app exposes BootUI.
 - Per-project persisted settings (warm JVM, Spring profiles, devtools, random port,
   auto-open browser) and an always-visible Settings panel.
@@ -54,8 +57,9 @@ Shipped in the extension today:
 - **Run output is raw build-tool / app stdout** — unlike BootUI's API it is not run
   through a secret masker, so build output could echo secrets. Hardening this means
   masking before streaming to the iframe and before sending "fix" context.
-- **Port detection is log-regex based** (Tomcat / Netty / Undertow). A custom
-  startup banner can hide the port, in which case metrics simply stay unavailable.
+- **Port detection is log-regex based** (Tomcat / Netty / Undertow, plus Quarkus'
+  "Listening on" banner). A custom startup banner can hide the port, in which case
+  metrics simply stay unavailable.
 - **No live per-test progress for Gradle.** Maven's Surefire console output drives the
   class-by-class progress bar; Gradle's graphical test view fills in from the final
   JUnit XML report instead.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 **Coffilot** is a [GitHub Copilot **canvas extension**](https://docs.github.com/en/copilot/how-tos/github-copilot-app/working-with-canvas-extensions)
-that turns a Maven- or Gradle-based Java / Spring Boot project into an interactive
-console in the Copilot app's side panel. Build, test, package and run your app, watch
-live JVM metrics, and — when something breaks — push the failure straight back to the
-agent with **Fix with Copilot**.
+that turns a Maven- or Gradle-based Java / Spring Boot / Quarkus project into an
+interactive console in the Copilot app's side panel. Build, test, package and run your
+app, watch live JVM metrics, and — when something breaks — push the failure straight
+back to the agent with **Fix with Copilot**.
 
 > Coffee for your Copilot: brew, taste and ship your Java app without leaving the chat. ☕
 
@@ -26,17 +26,20 @@ wins; when neither is found the console says so and stays disabled until one is 
 - **Package** &mdash; Maven `./mvnw -ntp package` or Gradle `./gradlew assemble`,
   streamed live like Build.
 - **Run** &mdash; `spring-boot:run` (Maven) / `bootRun` (Gradle) for a Spring Boot
-  module (+ Spring profiles), or **build + `java -jar`** for a plain-Java module.
+  module, `quarkus:dev` (Maven) / `quarkusDev` (Gradle) for a Quarkus module (both
+  with a configurable run profile), or **build + `java -jar`** for a plain-Java module.
   Optionally opens a browser window at the app once it is up.
 - **Parallel lanes** &mdash; Build / Test / Package share one build lane while Run
   is independent, so you can keep the app running while you re-test.
 - **Stop** &mdash; terminates the running app / build process.
-- **Profiles** &mdash; for Maven projects the toolbar scans the reactor for available
-  **Spring Boot profiles** and **Maven profiles** and offers each as an editable
-  dropdown. (Gradle has no profile concept, so the Maven-profiles control is hidden.)
+- **Profiles** &mdash; the toolbar scans the project for available run profiles —
+  **Spring Boot** profiles (`application-<profile>.*`) or **Quarkus** profiles
+  (`dev` / `test` / `prod` plus any `%<profile>.` keys) — and, for Maven, the reactor's
+  **Maven profiles**, offering each as an editable dropdown. (Gradle has no Maven-profile
+  concept, so that control is hidden.)
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,
   threads, health, profiles and startup info, sourced from the richest endpoint
-  available (BootUI → Actuator → process).
+  available (BootUI → Actuator → Quarkus Micrometer/health → process).
 - **Fix with Copilot** &mdash; on a compile error, failing tests, or a startup
   crash, a button pushes a context-rich request back into the chat so the agent
   can diagnose and fix it.
@@ -55,17 +58,19 @@ wins; when neither is found the console says so and stays disabled until one is 
 The console adapts to whatever the project provides, detected from the build files
 (static) and confirmed against the running app (runtime):
 
-| Tier                   | Detected from                                    | What the console offers                                                                                                                                |
-| ---------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **(none)**             | no Maven or Gradle markers                       | A "needs Maven or Gradle" notice; the Build / Test / Package / Run actions stay disabled                                                               |
-| **Java** (base)        | `pom.xml` / `mvnw` or `build.gradle` / `gradlew` | Build, Test (graphical JUnit report), Package                                                                                                          |
-| **Spring Boot**        | Spring Boot Maven plugin / Gradle plugin         | Run via `spring-boot:run` (Maven) or `bootRun` (Gradle) + editable Spring profiles. (No Spring Boot ⇒ Run builds the module and launches `java -jar`.) |
-| **Actuator** (runtime) | `/actuator/*` answers                            | Live metrics normalized from Actuator (heap, threads, health, uptime)                                                                                  |
-| **BootUI** (runtime)   | `/bootui/api/*` answers                          | Rich BootUI metrics **and** the MCP advisor-scan panel                                                                                                 |
+| Tier                          | Detected from                                     | What the console offers                                                                                                                              |
+| ----------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **(none)**                    | no Maven or Gradle markers                        | A "needs Maven or Gradle" notice; the Build / Test / Package / Run actions stay disabled                                                             |
+| **Java** (base)               | `pom.xml` / `mvnw` or `build.gradle` / `gradlew`  | Build, Test (graphical JUnit report), Package                                                                                                        |
+| **Spring Boot**               | Spring Boot Maven plugin / Gradle plugin          | Run via `spring-boot:run` (Maven) or `bootRun` (Gradle) + editable Spring profiles. (No framework ⇒ Run builds the module and launches `java -jar`.) |
+| **Quarkus**                   | Quarkus Maven plugin / `io.quarkus` Gradle plugin | Run via `quarkus:dev` (Maven) or `quarkusDev` (Gradle) — dev mode with built-in live reload — + editable Quarkus profile                             |
+| **Actuator** (runtime)        | `/actuator/*` answers                             | Live metrics normalized from Actuator (heap, threads, health, uptime)                                                                                |
+| **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health                                                                       |
+| **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the MCP advisor-scan panel                                                                                               |
 
 A capability summary is shown in the status bar (including the active build tool), and
-the metrics panel carries a small badge (`BootUI` / `Actuator` / `process`) indicating
-which source is live.
+the metrics panel carries a small badge (`BootUI` / `Actuator` / `Quarkus` / `process`)
+indicating which source is live.
 
 ## Requirements
 
@@ -122,10 +127,10 @@ automatically (`canvasId: java-app`).
 In a Copilot app session on a Maven or Gradle project, open the **Coffilot** canvas, then:
 
 1. **Build** to compile the project (first run), or **Run** to start an app (pick a
-   module and Spring profiles).
+   module and a run profile).
 2. Watch the console stream the build-tool / app output.
 3. Once the app is up, watch the **Live JVM metrics** panel populate (badge:
-   `BootUI` / `Actuator` / `process`).
+   `BootUI` / `Actuator` / `Quarkus` / `process`).
 4. If something fails, click **Fix with Copilot** to hand the error to the agent.
 5. **Stop** when done.
 
@@ -144,7 +149,8 @@ Coffilot is a Node process (the extension) that:
   graphical test view;
 - once an app is up, polls it for live metrics from the richest source available,
   proxying [BootUI](https://github.com/jdubois/boot-ui)'s sanitized `/bootui/api/**`
-  DTOs when present and falling back to Actuator, then to coarse process metrics;
+  DTOs when present and falling back to Spring Boot Actuator, then to Quarkus
+  Micrometer/health (`/q/*`), then to coarse process metrics;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 
 The loopback HTTP server that backs the iframe binds to `127.0.0.1` only. See

--- a/extension.mjs
+++ b/extension.mjs
@@ -1,11 +1,11 @@
 // Extension: coffilot
 //
 // Coffilot — a GitHub Copilot canvas extension that turns a Maven- or Gradle-based
-// Java / Spring Boot project into an interactive console: Build, Test, Package, Run
-// and Stop the app, watch the build output stream live, and — once the app is up —
-// read live JVM metrics from the richest source available (BootUI → Actuator →
-// process). Failures surface a "Fix with Copilot" button that pushes the error
-// context back into the chat.
+// Java / Spring Boot / Quarkus project into an interactive console: Build, Test,
+// Package, Run and Stop the app, watch the build output stream live, and — once the
+// app is up — read live JVM metrics from the richest source available (BootUI →
+// Actuator → Quarkus Micrometer/health → process). Failures surface a "Fix with
+// Copilot" button that pushes the error context back into the chat.
 //
 // The build tool is auto-detected from the project: Maven (pom.xml / ./mvnw) is
 // preferred when present, otherwise Gradle (build.gradle[.kts] / ./gradlew). When
@@ -18,8 +18,9 @@
 //   * Live JVM metrics are read from a running app: when the app exposes BootUI
 //     (https://github.com/jdubois/boot-ui) it serves sanitized record DTOs at
 //     /bootui/api/overview, /live-memory, /health, /threads, which this canvas
-//     proxies and renders; otherwise it falls back to Actuator, then to coarse
-//     process metrics. BootUI also unlocks the MCP advisor-scan panel.
+//     proxies and renders; otherwise it falls back to Spring Boot Actuator, then to
+//     Quarkus Micrometer/health (/q/*), then to coarse process metrics. BootUI also
+//     unlocks the MCP advisor-scan panel.
 
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -744,16 +745,21 @@ let lastTestTotal = loadLastTestTotal();
 
 // the UI can offer a dropdown instead of a free-text module box. Each module is
 // tagged with the capabilities detectable from its own build file: "runnable"
-// (a Spring Boot app, so it can be launched with spring-boot:run / bootRun),
-// springBoot, actuator, devtools, and bootui. These drive graceful UI degradation.
+// (a Spring Boot or Quarkus app, so it can be launched with spring-boot:run /
+// bootRun or quarkus:dev / quarkusDev), springBoot, quarkus, actuator, devtools,
+// and bootui. These drive graceful UI degradation.
 let projectModules = null;
 
 // Per-pom capability flags, derived purely from the pom text (cheap + offline).
 function pomCaps(xml, name) {
+  const quarkus = /quarkus-maven-plugin|io\.quarkus/.test(xml);
   return {
     name,
-    runnable: xml.includes("spring-boot-maven-plugin"),
+    // A module is runnable when its build owns a launch plugin: the Spring Boot
+    // plugin (spring-boot:run) or the Quarkus plugin (quarkus:dev).
+    runnable: xml.includes("spring-boot-maven-plugin") || xml.includes("quarkus-maven-plugin"),
     springBoot: xml.includes("spring-boot-maven-plugin") || xml.includes("org.springframework.boot"),
+    quarkus,
     actuator: xml.includes("spring-boot-starter-actuator"),
     devtools: xml.includes("spring-boot-devtools"),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(xml),
@@ -761,12 +767,15 @@ function pomCaps(xml, name) {
 }
 
 // Per-build-file capability flags for Gradle, derived from the build script text
-// (Groovy or Kotlin DSL). Spring Boot is detected from its Gradle plugin id.
+// (Groovy or Kotlin DSL). Spring Boot and Quarkus are detected from their Gradle
+// plugin ids (org.springframework.boot / io.quarkus).
 function gradleCaps(text, name) {
+  const quarkus = text.includes("io.quarkus");
   return {
     name,
-    runnable: text.includes("org.springframework.boot"),
+    runnable: text.includes("org.springframework.boot") || quarkus,
     springBoot: text.includes("org.springframework.boot"),
+    quarkus,
     actuator: text.includes("spring-boot-starter-actuator"),
     devtools: text.includes("spring-boot-devtools"),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(text),
@@ -966,6 +975,7 @@ function capabilitiesSnapshot() {
     gradle: buildTool === "gradle",
     java: detectJavaVersion(),
     springBoot: mods.some((m) => m.springBoot),
+    quarkus: mods.some((m) => m.quarkus),
     runnable: mods.some((m) => m.runnable),
     actuator: mods.some((m) => m.actuator),
     devtools: mods.some((m) => m.devtools),
@@ -1031,6 +1041,40 @@ function listSpringProfiles() {
   return springProfiles;
 }
 
+// Quarkus config profiles. Quarkus has three built-in profiles (dev / test /
+// prod) and lets you define more inline with a `%<profile>.` key prefix in
+// application.properties / .yml (rather than per-profile files like Spring).
+// We always offer the built-ins and merge in any custom prefixes we can find.
+let quarkusProfiles = null;
+const QUARKUS_PROFILE_RE = /^%([A-Za-z0-9_-]+)\./gm;
+function listQuarkusProfiles() {
+  if (quarkusProfiles) return quarkusProfiles;
+  const names = new Set(["dev", "test", "prod"]);
+  const dirs = [workspacePath, ...listModules().map((m) => path.join(workspacePath, m.name))];
+  for (const dir of dirs) {
+    for (const sub of ["src/main/resources", "src/main/resources/config"]) {
+      let entries;
+      try {
+        entries = readdirSync(path.join(dir, sub));
+      } catch {
+        continue;
+      }
+      for (const f of entries) {
+        if (!/^application\.(?:properties|ya?ml)$/.test(f)) continue;
+        let text;
+        try {
+          text = readFileSync(path.join(dir, sub, f), "utf8");
+        } catch {
+          continue;
+        }
+        for (const m of text.matchAll(QUARKUS_PROFILE_RE)) names.add(m[1]);
+      }
+    }
+  }
+  quarkusProfiles = [...names].sort();
+  return quarkusProfiles;
+}
+
 // ---------------------------------------------------------------------------
 // Runner state (workspace-global: one app run at a time, like a dev inner loop)
 // ---------------------------------------------------------------------------
@@ -1066,7 +1110,7 @@ const lanes = {
 
 // Run-lane application state (only meaningful while the app is up).
 const app = {
-  runMode: null, // spring | java — how the app was launched (for run failures)
+  runMode: null, // spring | quarkus | java — how the app was launched (for run failures)
   appPort: null,
   appUp: false,
   appReachedUp: false, // app served a metrics endpoint at least once this run
@@ -1258,7 +1302,8 @@ function finishRecompile() {
 }
 
 // Start the live-reload watcher if DevTools is enabled and a Spring app with the
-// DevTools dependency is currently running. Safe to call repeatedly.
+// DevTools dependency is currently running. Safe to call repeatedly. (Quarkus dev
+// mode has its own built-in live reload, so it never needs this watcher.)
 function maybeStartLiveReload() {
   if (!settings.devtools) return;
   if (lanes.run.phase !== "running" || app.runMode !== "spring") return;
@@ -1331,9 +1376,9 @@ function fixInfo(op) {
     }
   }
   if (op === "run" && lane.phase === "failed") {
-    return app.runMode === "java"
-      ? { kind: "run-java", label: "Fix startup failure with Copilot" }
-      : { kind: "run-spring", label: "Fix Spring Boot startup with Copilot" };
+    if (app.runMode === "java") return { kind: "run-java", label: "Fix startup failure with Copilot" };
+    if (app.runMode === "quarkus") return { kind: "run-quarkus", label: "Fix Quarkus startup with Copilot" };
+    return { kind: "run-spring", label: "Fix Spring Boot startup with Copilot" };
   }
   return null;
 }
@@ -1385,6 +1430,7 @@ function envSnapshot() {
     mavenProfiles: listMavenProfiles(),
     profilesSupported: buildTool === "maven",
     springProfiles: listSpringProfiles(),
+    quarkusProfiles: listQuarkusProfiles(),
     capabilities: capabilitiesSnapshot(),
     settings: settingsSnapshot(),
     // Warm-JVM tier (mvnd for Maven, daemon for Gradle).
@@ -1737,10 +1783,12 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   csrfToken = null;
   lastMetrics = { appUp: false };
 
-  // Pick the run strategy: explicit mode wins, else infer from whether the
-  // chosen module applies the Spring Boot plugin.
+  // Pick the run strategy: explicit mode wins, else infer from the chosen
+  // module's framework — Quarkus (quarkus:dev / quarkusDev) and Spring Boot
+  // (spring-boot:run / bootRun) are both "runnable"; anything else is plain Java.
   const mod = listModules().find((m) => m.name === module);
-  const resolved = mode === "java" || mode === "spring" ? mode : mod && mod.runnable ? "spring" : "java";
+  const inferred = mod && mod.quarkus ? "quarkus" : mod && mod.runnable ? "spring" : "java";
+  const resolved = mode === "java" || mode === "spring" || mode === "quarkus" ? mode : inferred;
   app.runMode = resolved;
   app.module = module || "";
   app.mavenProfiles = mavenProfiles || null;
@@ -1804,6 +1852,53 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
       startLiveReload({ module: module || "", mavenProfiles, bin: lr.bin, label: lr.label });
     }
     return { ok: true, started: true, mode: "spring", command: `${baseRunner().label} ${args.join(" ")}` };
+  }
+
+  if (resolved === "quarkus") {
+    // Quarkus dev mode (quarkus:dev / quarkusDev) runs the app in the foreground
+    // with built-in live reload — no DevTools-style recompile loop needed. The
+    // active config profile and HTTP port flow through -D / env vars.
+    const r = resolveRunner(false);
+
+    if (buildTool === "gradle") {
+      const args = [gradleTaskPath(module, "quarkusDev"), "--console=plain"];
+      const extra = {};
+      if (profiles) extra.QUARKUS_PROFILE = profiles;
+      if (settings.randomPort) {
+        let port = 0;
+        try {
+          port = await freePort();
+        } catch {
+          /* fall back: leave QUARKUS_HTTP_PORT unset and keep the default */
+        }
+        if (port) {
+          extra.QUARKUS_HTTP_PORT = String(port);
+          pushConsole(`[coffilot] using HTTP port ${port} via QUARKUS_HTTP_PORT.`, "stdout", "run");
+        }
+      }
+      spawnTool("run", args, "running", { bin: r.bin, label: r.label, env: toolEnv(extra), onLine: detectPort });
+      return { ok: true, started: true, mode: "quarkus", command: `${r.label} ${args.join(" ")}` };
+    }
+
+    const args = ["-ntp"];
+    if (module) args.push("-pl", module);
+    if (mavenProfiles && mavenProfiles.trim()) args.push("-P", mavenProfiles.trim());
+    if (profiles) args.push(`-Dquarkus.profile=${profiles}`);
+    if (settings.randomPort) {
+      let port = 0;
+      try {
+        port = await freePort();
+      } catch {
+        /* fall back: keep the default port */
+      }
+      if (port) {
+        args.push(`-Dquarkus.http.port=${port}`);
+        pushConsole(`[coffilot] using HTTP port ${port} via quarkus.http.port.`, "stdout", "run");
+      }
+    }
+    args.push("quarkus:dev");
+    spawnTool("run", args, "running", { onLine: detectPort }); // fire-and-forget
+    return { ok: true, started: true, mode: "quarkus", command: `${baseRunner().label} ${args.join(" ")}` };
   }
 
   // Pure-Java: build the module, then launch its jar with `java -jar`.
@@ -1964,6 +2059,8 @@ const PORT_PATTERNS = [
   /Tomcat (?:started|initialized).*?port[s]?(?:\(s\))?:?\s*(\d+)/i,
   /Netty started on port[s]?(?:\(s\))?:?\s*(\d+)/i,
   /Undertow.*?port[s]?(?:\(s\))?:?\s*(\d+)/i,
+  // Quarkus dev/prod startup banner, e.g. "Listening on: http://0.0.0.0:8080".
+  /Listening on:\s*https?:\/\/[^\s:/]+:(\d+)/i,
   /started on port[s]?(?:\(s\))?:?\s*(\d+)/i,
 ];
 
@@ -1976,7 +2073,7 @@ function detectPort(line) {
     const m = line.match(re);
     if (m) {
       app.appPort = Number(m[1]);
-      pushConsole(`[coffilot] detected app port ${app.appPort}; polling /bootui/api`, "stdout", "run");
+      pushConsole(`[coffilot] detected app port ${app.appPort}; polling for live metrics`, "stdout", "run");
       broadcast("status", statusSnapshot());
       startMetricsPolling();
       return;
@@ -2186,6 +2283,17 @@ async function fetchJson(base, p) {
   }
 }
 
+/** Fetch a text/plain body (e.g. a Prometheus exposition), or null. */
+async function fetchText(base, p) {
+  try {
+    const res = await fetch(base + p, { headers: { Accept: "text/plain" } });
+    if (!res.ok) return null;
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
 /** Pull a single Micrometer actuator metric's VALUE measurement (or null). */
 async function actuatorMetric(base, name, tag) {
   const q = tag ? `?tag=${encodeURIComponent(tag)}` : "";
@@ -2226,6 +2334,78 @@ async function actuatorMetrics(base, health) {
   };
 }
 
+// --- Quarkus metrics tier --------------------------------------------------
+// Quarkus exposes Micrometer JVM metrics in Prometheus text format at
+// /q/metrics (when quarkus-micrometer-registry-prometheus is present) and
+// SmallRye Health JSON at /q/health. The metric names match Spring's
+// Micrometer output, so we normalize them into the same shape as the BootUI /
+// Actuator tiers.
+
+/** Parse Prometheus exposition lines for one metric into {labels, value} samples. */
+function promSamples(text, metric) {
+  const out = [];
+  if (!text) return out;
+  const re = new RegExp(`^${metric.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\{[^}]*\\})?\\s+([-+0-9.eE]+)`, "gm");
+  let m;
+  while ((m = re.exec(text))) out.push({ labels: m[1] || "", value: Number(m[2]) });
+  return out;
+}
+
+/** Sum the (non-negative) samples of a metric, optionally filtered by a label substring. */
+function promSum(text, metric, labelFilter) {
+  return promSamples(text, metric)
+    .filter((s) => (labelFilter ? s.labels.includes(labelFilter) : true))
+    .reduce((acc, s) => (Number.isFinite(s.value) && s.value >= 0 ? acc + s.value : acc), 0);
+}
+
+/** First sample value of a metric (for single-series gauges), or null. */
+function promValue(text, metric) {
+  const s = promSamples(text, metric);
+  return s.length && Number.isFinite(s[0].value) ? s[0].value : null;
+}
+
+/** Read a label off a metric's first sample (e.g. jvm_info{version="21"}). */
+function promLabel(text, metric, label) {
+  const s = promSamples(text, metric);
+  if (!s.length) return null;
+  const m = s[0].labels.match(new RegExp(`${label}="([^"]*)"`));
+  return m ? m[1] : null;
+}
+
+/** Normalize Quarkus /q/metrics + /q/health into the same shape as the other tiers. */
+function quarkusMetrics(metricsText, health) {
+  const out = {
+    appUp: true,
+    metricsTier: "quarkus",
+    overview: {
+      applicationName: null,
+      springBootVersion: null,
+      javaVersion: promLabel(metricsText, "jvm_info", "version"),
+      activeProfiles: [],
+      startupTimeMillis: null,
+    },
+    memory: null,
+    health: health ? { status: health.status } : null,
+    threads: null,
+  };
+  if (metricsText) {
+    const heapUsed = promSum(metricsText, "jvm_memory_used_bytes", 'area="heap"');
+    const heapMax = promSum(metricsText, "jvm_memory_max_bytes", 'area="heap"');
+    const nonHeapUsed = promSum(metricsText, "jvm_memory_used_bytes", 'area="nonheap"');
+    const threadsLive = promValue(metricsText, "jvm_threads_live_threads");
+    const threadsDaemon = promValue(metricsText, "jvm_threads_daemon_threads");
+    const uptime = promValue(metricsText, "process_uptime_seconds");
+    const usedPercent = heapUsed && heapMax ? Math.round((heapUsed / heapMax) * 100) : null;
+    out.overview.startupTimeMillis = uptime != null ? Math.round(uptime * 1000) : null;
+    out.memory = {
+      heap: { usedBytes: heapUsed || null, maxBytes: heapMax || null, usedPercent },
+      nonHeap: { usedBytes: nonHeapUsed || null },
+    };
+    out.threads = threadsLive != null ? { totalThreads: threadsLive, daemonThreads: threadsDaemon ?? 0 } : null;
+  }
+  return out;
+}
+
 async function refreshMetrics() {
   if (!app.appPort) return null;
   const base = `http://127.0.0.1:${app.appPort}`;
@@ -2250,7 +2430,14 @@ async function refreshMetrics() {
     return finishMetrics();
   }
 
-  // Tier 3 — process only: the port is open but no diagnostics endpoint answered.
+  // Tier 3 — Quarkus: SmallRye Health + Micrometer/Prometheus under /q/*.
+  const [qHealth, qMetrics] = await Promise.all([fetchJson(base, "/q/health"), fetchText(base, "/q/metrics")]);
+  if (qHealth || qMetrics) {
+    lastMetrics = quarkusMetrics(qMetrics, qHealth);
+    return finishMetrics();
+  }
+
+  // Tier 4 — process only: the port is open but no diagnostics endpoint answered.
   lastMetrics = { appUp: true, metricsTier: "process" };
   return finishMetrics();
 }
@@ -2302,7 +2489,14 @@ function errorLines(op, max = 60) {
 }
 
 // Map a fix kind to the lane whose console/command/exit code is relevant.
-const FIX_OP = { compile: "build", package: "package", test: "test", "run-java": "run", "run-spring": "run" };
+const FIX_OP = {
+  compile: "build",
+  package: "package",
+  test: "test",
+  "run-java": "run",
+  "run-spring": "run",
+  "run-quarkus": "run",
+};
 
 function buildFixPrompt(kind, extra = {}) {
   const op = FIX_OP[kind] || "build";
@@ -2347,6 +2541,15 @@ function buildFixPrompt(kind, extra = {}) {
     case "run-spring":
       return [
         "The Spring Boot application failed to start. Diagnose the startup failure (bean wiring, missing/invalid configuration, failed auto-configuration, port already in use, datasource, etc.) and fix it.",
+        where,
+        "Recent output:",
+        codeBlock(tail("run", 90)),
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    case "run-quarkus":
+      return [
+        "The Quarkus application failed to start in dev mode (quarkus:dev / quarkusDev). Diagnose the startup failure (CDI bean wiring, missing/invalid configuration in application.properties, failed extension/build-step initialization, port already in use, datasource, etc.) and fix it.",
         where,
         "Recent output:",
         codeBlock(tail("run", 90)),
@@ -2866,7 +3069,7 @@ function makeCanvas() {
     id: "java-app",
     displayName: "Coffilot",
     description:
-      "Build, test, package and run a Maven or Gradle Java/Spring Boot app, watch live JVM metrics, run advisor scans, and push fixes back to the agent. Degrades gracefully by capability (plain Java → Spring Boot → Actuator → BootUI).",
+      "Build, test, package and run a Maven or Gradle Java/Spring Boot/Quarkus app, watch live JVM metrics, run advisor scans, and push fixes back to the agent. Degrades gracefully by capability (plain Java → Spring Boot / Quarkus → Actuator / Quarkus metrics → BootUI).",
     inputSchema: { type: "object", properties: {} },
     actions: [
       {
@@ -2945,14 +3148,15 @@ function makeCanvas() {
       {
         name: "start_app",
         description:
-          "Launch the app (returns immediately; output streams to the canvas). Spring Boot modules run via spring-boot:run (Maven) or bootRun (Gradle); otherwise the module is built and run with java -jar. Use the 'dev' profile so BootUI activates and live metrics become available.",
+          "Launch the app (returns immediately; output streams to the canvas). Spring Boot modules run via spring-boot:run (Maven) / bootRun (Gradle); Quarkus modules via quarkus:dev (Maven) / quarkusDev (Gradle) with built-in live reload; otherwise the module is built and run with java -jar. Spring Boot's 'dev' profile activates BootUI for the richest live metrics.",
         inputSchema: {
           type: "object",
           properties: {
             module: { type: "string", description: "Module to run (Maven -pl / Gradle subproject, e.g. 'web')." },
             profiles: {
               type: "string",
-              description: "Spring profiles to activate (default 'dev'); ignored for non-Spring runs.",
+              description:
+                "Config profile(s) to activate (default 'dev'): Spring profiles via spring-boot.run.profiles, or the Quarkus profile via quarkus.profile. Ignored for plain-Java runs.",
             },
             mavenProfiles: {
               type: "string",
@@ -2960,7 +3164,7 @@ function makeCanvas() {
             },
             mode: {
               type: "string",
-              enum: ["spring", "java"],
+              enum: ["spring", "quarkus", "java"],
               description: "Force the run strategy; defaults to auto-detect from the module.",
             },
           },
@@ -2997,20 +3201,20 @@ function makeCanvas() {
       {
         name: "get_metrics",
         description:
-          "Return live JVM metrics from the running app. Uses BootUI (/bootui/api) when present, else Spring Boot Actuator (/actuator), else process-only. appUp=false if it is not running.",
+          "Return live JVM metrics from the running app. Uses BootUI (/bootui/api) when present, else Spring Boot Actuator (/actuator), else Quarkus Micrometer/health (/q/*), else process-only. appUp=false if it is not running.",
         inputSchema: { type: "object", properties: {} },
         handler: async () => (await refreshMetrics()) || lastMetrics,
       },
       {
         name: "fix_issue",
         description:
-          "Send a context-rich request into this chat asking to fix the current problem. Kind: compile (build failed), package (package failed), test (failing tests), run-java/run-spring (startup failure), or mcp (advisor scan findings).",
+          "Send a context-rich request into this chat asking to fix the current problem. Kind: compile (build failed), package (package failed), test (failing tests), run-java/run-spring/run-quarkus (startup failure), or mcp (advisor scan findings).",
         inputSchema: {
           type: "object",
           properties: {
             kind: {
               type: "string",
-              enum: ["compile", "package", "test", "run-java", "run-spring", "mcp"],
+              enum: ["compile", "package", "test", "run-java", "run-spring", "run-quarkus", "mcp"],
               description: "Which failure to fix.",
             },
             tool: { type: "string", description: "For kind=mcp: the scan tool name." },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "coffilot",
   "version": "0.1.0",
   "private": true,
-  "description": "A GitHub Copilot canvas extension to build, test, package, run and fix Maven or Gradle Java / Spring Boot apps from the Copilot app side panel.",
+  "description": "A GitHub Copilot canvas extension to build, test, package, run and fix Maven or Gradle Java / Spring Boot / Quarkus apps from the Copilot app side panel.",
   "license": "Apache-2.0",
   "author": "Julien Dubois",
   "homepage": "https://github.com/jdubois/coffilot#readme",
@@ -20,7 +20,8 @@
     "java",
     "maven",
     "gradle",
-    "spring-boot"
+    "spring-boot",
+    "quarkus"
   ],
   "scripts": {
     "check": "node --check extension.mjs",

--- a/public/app.js
+++ b/public/app.js
@@ -31,6 +31,7 @@ const warmInfo = document.getElementById("warm-info");
 const moduleSelect = document.getElementById("in-module");
 const springInput = document.getElementById("in-profiles");
 const springMenu = document.getElementById("spring-menu");
+const lblProfiles = document.getElementById("lbl-profiles");
 const mavenMenu = document.getElementById("maven-menu");
 const mvnProfilesInput = document.getElementById("in-mvn-profiles");
 const mvnProfilesLabel = document.getElementById("lbl-mvn-profiles");
@@ -343,21 +344,22 @@ function renderMetrics(m) {
     metricsSrc.hidden = true;
     renderMcp(null);
     metricsEl.innerHTML =
-      '<p class="muted">App not running. Click <strong>Run</strong> to start it (dev profile activates BootUI).</p>';
+      '<p class="muted">App not running. Click <strong>Run</strong> to start it (Spring\u2019s <code>dev</code> profile activates BootUI).</p>';
     metricsHint.innerHTML =
-      "Run a Spring Boot module with the <code>dev</code> profile for rich BootUI metrics, or any app exposing Actuator for a subset.";
+      "Run a Spring Boot app with the <code>dev</code> profile for rich BootUI metrics, a Quarkus app for Micrometer metrics, or anything exposing Actuator for a subset.";
     return;
   }
   const tier = m.metricsTier || "process";
   metricsSrc.hidden = false;
   metricsSrc.className = "src " + tier;
-  metricsSrc.textContent = tier === "bootui" ? "BootUI" : tier === "actuator" ? "Actuator" : "process";
+  metricsSrc.textContent =
+    tier === "bootui" ? "BootUI" : tier === "actuator" ? "Actuator" : tier === "quarkus" ? "Quarkus" : "process";
 
   if (tier === "process") {
     metricsEl.innerHTML =
-      '<p class="muted">App is running, but no <code>/bootui/api</code> or <code>/actuator</code> endpoint answered, so live JVM metrics aren\u2019t available.</p>';
+      '<p class="muted">App is running, but no <code>/bootui/api</code>, <code>/actuator</code> or <code>/q/metrics</code> endpoint answered, so live JVM metrics aren\u2019t available.</p>';
     metricsHint.innerHTML =
-      "Add <code>spring-boot-starter-actuator</code> (or BootUI) to surface heap, threads and health here.";
+      "Add <code>spring-boot-starter-actuator</code> / BootUI (Spring) or <code>quarkus-micrometer-registry-prometheus</code> (Quarkus) to surface heap, threads and health here.";
     renderMcp(null);
     return;
   }
@@ -386,6 +388,10 @@ function renderMetrics(m) {
     metricsHint.innerHTML =
       "Rich metrics read from the running app\u2019s <code>/bootui/api/**</code> endpoints \u2014 reused directly from BootUI.";
     renderMcp(m.mcp);
+  } else if (tier === "quarkus") {
+    metricsHint.innerHTML =
+      "Metrics read from Quarkus Micrometer (<code>/q/metrics</code>) and SmallRye Health (<code>/q/health</code>).";
+    renderMcp(null);
   } else {
     metricsHint.innerHTML =
       "Metrics normalized from Spring Boot <code>/actuator/**</code>. Add BootUI for advisor scans and richer detail.";
@@ -660,16 +666,25 @@ let moduleList = [];
 
 // Per selected module (one reactor can mix capabilities), decide which
 // settings rows/proposals to surface:
-// - Spring Boot -> show Spring profiles, DevTools, random-port rows.
+// - Spring Boot or Quarkus -> show the run-profile + random-port rows.
+// - Spring Boot -> also show DevTools (Quarkus dev mode has live reload built
+//   in, so no DevTools row) and the BootUI / DevTools "add" proposals.
 // - Spring Boot but no BootUI starter -> offer to add BootUI.
 // - Spring Boot but no DevTools -> offer to add DevTools and disable the
 //   "Enable Spring Boot DevTools" toggle until the dependency is present.
 function updateDevSetup() {
   const mod = moduleList.find((m) => m.name === moduleSelect.value);
   const spring = !!(mod && mod.springBoot);
-  setSpring.hidden = !spring;
+  const quarkus = !!(mod && mod.quarkus);
+  const framework = spring || quarkus;
+  // Profiles + random-port apply to both frameworks; DevTools is Spring-only.
+  setSpring.hidden = !framework;
   setDevtools.hidden = !spring;
-  setRandomport.hidden = !spring;
+  setRandomport.hidden = !framework;
+
+  // Relabel the run-profile combo and swap its suggestions for the framework.
+  if (lblProfiles) lblProfiles.textContent = quarkus ? "Quarkus profile" : "Spring Boot profiles";
+  profileItems = quarkus ? quarkusItems : springItems;
 
   const showBootui = spring && !mod.bootui;
   btnAddBootui.hidden = !showBootui;
@@ -698,6 +713,9 @@ function updateDevSetup() {
 
 // Suggestion lists backing the custom comboboxes (kept editable).
 let springItems = ["dev"];
+let quarkusItems = ["dev", "test", "prod"];
+// The run-profile combo shows whichever list matches the selected module.
+let profileItems = springItems;
 let mavenItems = [];
 
 // A lightweight combobox: editable input + an in-document suggestion menu,
@@ -790,11 +808,15 @@ function applyEnv(env) {
   populateModules(env && env.modules);
   applyJdtls(env && env.jdtls);
   applyCaps(env && env.capabilities);
-  updateDevSetup();
-  // "dev" is always offered for Spring (it's the default and activates BootUI).
+  // Build the run-profile suggestion lists before updateDevSetup() picks one.
+  // "dev" is always offered for Spring (it's the default and activates BootUI);
+  // Quarkus always offers its built-in dev / test / prod profiles.
   const spring = (env && env.springProfiles) || [];
   springItems = spring.includes("dev") ? spring : ["dev", ...spring];
+  const quarkus = (env && env.quarkusProfiles) || [];
+  quarkusItems = quarkus.length ? quarkus : ["dev", "test", "prod"];
   mavenItems = (env && env.mavenProfiles) || [];
+  updateDevSetup();
 
   // Degraded mode: no Maven or Gradle project. Show the banner and disable
   // the build/test/package/run actions; nothing can be invoked without a tool.
@@ -872,11 +894,14 @@ function applyCaps(c) {
   caps = c || {};
   const toolLabel = caps.toolLabel || (caps.gradle ? "Gradle" : caps.maven ? "Maven" : null);
   const springRun = caps.gradle ? "bootRun" : "spring-boot:run";
-  // Pure-Java modules can still Run (build + java -jar); Spring-specific
+  const quarkusRun = caps.gradle ? "quarkusDev" : "quarkus:dev";
+  // Pure-Java modules can still Run (build + java -jar); framework-specific
   // settings rows are toggled per selected module in updateDevSetup().
   btnRun.title = caps.springBoot
     ? `Run the selected module with ${springRun}.`
-    : "Build the selected module and launch it with java -jar.";
+    : caps.quarkus
+      ? `Run the selected module with ${quarkusRun}.`
+      : "Build the selected module and launch it with java -jar.";
   const pill = (label, on, title) =>
     `<span class="cap ${on ? "on" : "off"}" title="${esc(title)}">${esc(label)}</span>`;
   let html = "";
@@ -895,6 +920,13 @@ function applyCaps(c) {
     "Spring Boot",
     !!caps.springBoot,
     caps.springBoot ? `${springRun} available.` : "No Spring Boot module detected; Run uses java -jar.",
+  );
+  html += pill(
+    "Quarkus",
+    !!caps.quarkus,
+    caps.quarkus
+      ? `${quarkusRun} available (dev mode with live reload).`
+      : "No Quarkus module detected; Run uses java -jar.",
   );
   html += pill("Actuator", !!caps.actuator, "Spring Boot Actuator metrics (static hint; confirmed at runtime).");
   html += pill("BootUI", !!caps.bootui, "BootUI rich metrics + MCP advisor scans.");
@@ -973,7 +1005,7 @@ function applyJdtls(j) {
 const warm = () => warmInput.checked === true;
 const mvnProfiles = () => mvnProfilesInput.value.trim();
 
-setupCombo(springInput, springMenu, () => springItems);
+setupCombo(springInput, springMenu, () => profileItems);
 setupCombo(mvnProfilesInput, mavenMenu, () => mavenItems);
 
 document.getElementById("btn-build").onclick = () => {

--- a/public/index.html
+++ b/public/index.html
@@ -201,16 +201,16 @@
             </div>
           </div>
 
-          <!-- Spring Boot profiles (Spring only) -->
+          <!-- Run config profile (Spring Boot / Quarkus only) -->
           <div class="set-row" id="set-spring" hidden>
-            <label class="cap-label">Spring Boot profiles</label>
+            <label class="cap-label" id="lbl-profiles">Spring Boot profiles</label>
             <span class="combo">
               <input
                 id="in-profiles"
                 size="14"
                 value="dev"
                 autocomplete="off"
-                title="Spring Boot profiles to activate when running (spring-boot.run.profiles)."
+                title="Config profile(s) to activate when running (Spring spring-boot.run.profiles / Quarkus quarkus.profile)."
               />
               <div class="combo-menu" id="spring-menu" hidden></div>
             </span>
@@ -251,7 +251,7 @@
             >
           </div>
 
-          <!-- Use a random HTTP port (Spring only) -->
+          <!-- Use a random HTTP port (Spring Boot / Quarkus only) -->
           <div class="set-row switch-row" id="set-randomport" hidden>
             <label class="switch" id="randomport-toggle">
               <input type="checkbox" id="in-randomport" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -420,6 +420,10 @@ aside h2 {
   color: var(--true-color-blue, #0969da);
   border-color: var(--true-color-blue, #0969da);
 }
+.src.quarkus {
+  color: var(--true-color-purple, #8250df);
+  border-color: var(--true-color-purple, #8250df);
+}
 .src.process {
   color: var(--text-color-muted, #656d76);
 }


### PR DESCRIPTION
## Summary

Coffilot already treats Spring Boot as a first-class framework tier. This PR brings Quarkus to parity so Quarkus projects get the same auto-detected build/test/package/run/metrics experience without any manual configuration.

Quarkus support is woven through every layer where Spring Boot appears:

- **Detection** - each module is probed for Quarkus (`quarkus-maven-plugin` / `io.quarkus`) and marked runnable; a `quarkus` capability and the discovered profiles (`dev`/`test`/`prod` plus `%<profile>.` keys) are surfaced to the UI.
- **Run** - a new `quarkus` run mode launches `quarkus:dev` (Maven) or `quarkusDev` (Gradle) with profile and random-port flags, and the port banner is detected from Quarkus' "Listening on" line. Quarkus' built-in live reload means no DevTools watcher is started.
- **Metrics** - a new tier sits between Actuator and the process fallback, parsing Quarkus' Micrometer Prometheus output (`/q/metrics`) and SmallRye Health (`/q/health`) into the same shape as the Spring tier (heap/non-heap, threads, uptime, Java version, health).
- **Fix** - a `run-quarkus` fix kind flows through `fixInfo` / `FIX_OP` / `buildFixPrompt` and the `fix_issue` / `start_app` action schemas.
- **UI** - a Quarkus capability pill, run-button title, purple metrics badge, and a framework-aware profiles row that relabels and swaps suggestions; DevTools/BootUI rows stay Spring-only.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

The metrics tier and port logic were validated with a standalone Prometheus-parser test rather than a running Quarkus app, since `@github/copilot-sdk` is only resolved by the Copilot CLI at runtime and there is no offline Quarkus sample under `integration-tests/`. A live smoke test against a real Quarkus project (reload extensions + re-open the canvas) is the one remaining unchecked verification box.

A couple of deliberate trade-offs worth a look:

- The default Quarkus management path is `/q/` (current Quarkus). Older Quarkus that serves `/health` + `/metrics` at the root degrades to the process tier rather than the Quarkus tier, consistent with the graceful-degradation philosophy.
- The persisted profiles setting key stays `springProfiles` and is reused generically to avoid a settings migration.
- Spring-without-Actuator and plain-Java apps now make two extra failing `/q/*` fetches per 2.5s poll - harmless on loopback.