### PR TITLE
Fix Stop button leaving build/test/package processes running

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -1589,6 +1589,12 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
       // mvnw.cmd / mvnd.cmd / gradlew.bat are batch scripts; modern Node refuses
       // to spawn .cmd/.bat directly, so route through the shell on Windows.
       shell: isWindows,
+      // POSIX: give the build tool its own process group so Stop can signal the
+      // whole tree. Maven Surefire (and Gradle) fork a separate test/run JVM that
+      // ignores a SIGTERM aimed only at the wrapper, so killing the single PID
+      // leaves the real work running. On Windows we kill the tree via taskkill /T
+      // instead, and `detached` there would spawn an unwanted console window.
+      detached: !isWindows,
     });
     lane.child = child;
 
@@ -2258,19 +2264,30 @@ function killChild(child) {
     } catch {
       /* ignore */
     }
-  } else {
-    child.kill("SIGTERM");
-    // Escalate if it ignores SIGTERM.
-    setTimeout(() => {
-      if (child && !child.killed) {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          /* already gone */
-        }
-      }
-    }, 5000);
+    return;
   }
+  // POSIX: the child was spawned detached, so it leads its own process group.
+  // Signalling the negative PID hits every member of that group — the wrapper
+  // plus any forked test/run JVM (Surefire, Gradle worker) — instead of only the
+  // wrapper, which is what made Stop appear to do nothing while tests kept going.
+  const signalGroup = (sig) => {
+    try {
+      process.kill(-child.pid, sig);
+    } catch {
+      // Group already gone (or never a leader): fall back to the lone process.
+      try {
+        child.kill(sig);
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+  signalGroup("SIGTERM");
+  // Escalate unconditionally after a grace period. The group can still hold a
+  // member that ignored SIGTERM even after the wrapper itself exited, so we
+  // don't gate this on the tracked child's state; SIGKILL to an empty group is
+  // a harmless ESRCH that the catch above swallows.
+  setTimeout(() => signalGroup("SIGKILL"), 5000);
 }
 
 /**
@@ -2304,8 +2321,8 @@ function stopApp(op) {
 // Process shutdown — never let a spawned Maven/Java process outlive us.
 //
 // The host stops the extension by terminating this Node process (SIGTERM, or
-// SIGINT during a Ctrl-C). Our children are spawned *attached*, but on POSIX an
-// attached child is NOT killed when its parent dies — it is reparented to
+// SIGINT during a Ctrl-C). Our children run in their own process group, and on
+// POSIX such a child is NOT killed when its parent dies — it is reparented to
 // init/launchd and keeps running, holding its HTTP port. Closing the canvas
 // panel does not stop the app either (that is intentional; a panel can be
 // reopened). So the only safe place to guarantee no orphans is here, on the way
@@ -2330,11 +2347,19 @@ process.once("SIGTERM", () => gracefulShutdown("SIGTERM"));
 process.once("SIGINT", () => gracefulShutdown("SIGINT"));
 
 // Last-ditch synchronous sweep for any other exit path (process.exit elsewhere,
-// a handled fatal error). Only synchronous work runs during "exit".
+// a handled fatal error). Only synchronous work runs during "exit", so we
+// SIGKILL the process group directly rather than spawning taskkill. We don't
+// gate on child.killed: an earlier SIGTERM sets that flag while the forked JVM
+// tree is still alive, so checking it here would skip the very processes we need
+// to reap.
 process.on("exit", () => {
   for (const o of ["build", "test", "package", "run"]) {
     const child = lanes[o].child;
-    if (child && !child.killed) {
+    if (!child || !child.pid) continue;
+    try {
+      if (isWindows) child.kill("SIGKILL");
+      else process.kill(-child.pid, "SIGKILL");
+    } catch {
       try {
         child.kill("SIGKILL");
       } catch {


### PR DESCRIPTION
## Summary

The Stop button looked broken (most visibly while tests were running): you clicked it, the button briefly showed "Stopping...", then reverted with nothing actually stopped. The root cause was not graphical: the spawned processes were not being killed, so the lane stayed busy and the UI never resolved.

Two bugs in the kill path:

- **Dead SIGKILL escalation.** `killChild` sent `SIGTERM`, then 5s later gated the `SIGKILL` escalation on `!child.killed`. Node sets `child.killed` to `true` the instant a signal is *sent* (not when the process dies), so that check was always false and `SIGKILL` never fired.
- **Only the wrapper was signaled, not the process tree.** Maven Surefire and Gradle fork a separate test/run JVM. A `SIGTERM` aimed at just the `mvnw`/`gradlew` PID left that forked JVM running (reparented to init), so the real work kept going. Build/package mostly worked because they don't fork, which is why tests were the obvious symptom.

## Approach

- Spawn build-tool children **detached** on POSIX so each leads its own process group.
- `killChild` now signals the **whole group** via the negative PID, and escalates to `SIGKILL` **unconditionally** after the grace period (a `SIGKILL` to an already-empty group is a harmless `ESRCH` that is caught). Windows continues to use `taskkill /T`.
- Fixed the same `child.killed` gating plus single-PID flaw in the exit-time last-ditch sweep so shutdown can't orphan forked JVMs either.

Once the process actually dies, the lane's existing `close` handler clears `busy` and the UI resolves the "Stopping..." button back to normal, so the fix restores the graphical behavior too. All four lanes (build, test, package, run) route through `spawnTool`, so the single spawn change covers them all.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (No doc-visible behavior change.)
- [x] No secrets committed.

Validated the kill path with process-tree reproductions: a `SIGTERM`-ignoring forked child (simulating Surefire's forked JVM) is now reaped via the group `SIGKILL` escalation, while a graceful `SIGTERM`-handling process (Spring Boot style) still exits cleanly with the later group `SIGKILL` being a no-op.

## Notes for reviewers

The unconditional `SIGKILL` to the group 5s after `SIGTERM` is intentional: when killing a group, the leader can exit while a forked member lingers, so gating escalation on the tracked child's state would skip exactly the process we need to reap. The grace window matches the prior behavior. The one path I could not exercise from here is a real live canvas run (the unchecked box above), so a manual Stop on an actual Maven/Gradle test run would be a good confirmation.