### PR TITLE
Fix premature browser auto-open before the app is serving

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -2611,6 +2611,25 @@ async function fetchText(base, p) {
   }
 }
 
+/**
+ * Confirm the app is actually answering HTTP before we treat it as "up". The
+ * app port is first discovered by scraping a startup log line, which can be
+ * printed a beat before the server is ready to accept requests; without this
+ * probe the process-only tier flips appUp=true (firing the "open browser when
+ * the app starts" action) while the app is still starting. Any HTTP response —
+ * even a 404 — proves the server is live; a connection error or timeout means
+ * it is not serving yet.
+ */
+async function appAnswersHttp(base) {
+  try {
+    const res = await fetch(base + "/", { signal: AbortSignal.timeout(2000) });
+    res.body?.cancel().catch(() => {});
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Actuator can live under different base paths depending on the app's config
 // (Spring Boot defaults to /actuator; JHipster relocates it to /management).
 const ACTUATOR_PREFIXES = ["/actuator", "/management"];
@@ -2819,8 +2838,20 @@ async function refreshMetrics() {
     return finishMetrics();
   }
 
-  // Tier 4 — process only: the port is open but no diagnostics endpoint answered.
-  lastMetrics = { appUp: true, metricsTier: "process" };
+  // Tier 4 — process only: the port is known but no diagnostics endpoint
+  // answered. The port was scraped from a startup log line, which can be printed
+  // just before the server starts accepting requests, so confirm the app answers
+  // an HTTP request before reporting it up (and firing the "open browser when the
+  // app starts" action). Once it has served at least once this run, skip the probe
+  // to avoid flicker if a single request later times out.
+  if (app.appReachedUp || (await appAnswersHttp(base))) {
+    lastMetrics = { appUp: true, metricsTier: "process" };
+    return finishMetrics();
+  }
+
+  // Port detected from logs but the app is not answering HTTP yet: stay
+  // "starting" so the next poll retries and the browser opens only once it is up.
+  lastMetrics = { appUp: false, metricsTier: "process" };
   return finishMetrics();
 }
 


### PR DESCRIPTION
## Summary

The "Open browser when the app starts" setting was firing too early: the browser often opened on an app that was not yet running.

The root cause is that the auto-open is gated on `appUp`, and the process-only metrics tier (Tier 4) flipped `appUp = true` the instant a port number was scraped from a startup log line. That log line is typically printed a beat before the server actually starts accepting requests, so the browser opened on a not-yet-ready app (connection refused / blank page).

The fix makes Tier 4 confirm the app is genuinely serving before reporting it up: it now probes the app root over HTTP (`GET /`, 2s timeout) and only sets `appUp = true` once it gets a real response. Any HTTP status, even a 404, counts as "live"; a connection error or timeout keeps it in the starting state and the 2.5s poll retries. Once the app has answered at least once this run, the probe is skipped to avoid flicker if a later request momentarily times out.

Tiers 1-3 (BootUI / Actuator / Quarkus) were already correct because they only set `appUp` after a real HTTP response; the premature path was Tier 4 only.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (No doc change needed; README already says the browser opens "once it is up", which is now accurate.)
- [x] No secrets committed.

## Notes for reviewers

The new `appAnswersHttp()` helper uses `AbortSignal.timeout(2000)` (Node 20+) and cancels the response body so the probe does not download large root payloads. The behaviour change is scoped to the process-only tier; the manual "Open in browser" button stays user-driven and is intentionally left keyed on port detection.