### PR TITLE
Enable Stop button during build/test/package

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -1582,7 +1582,6 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
     lane.exitCode = null;
     broadcast("reset", { op });
     lane.console = [];
-    broadcast("status", statusSnapshot());
     session.log(`[coffilot] ${lane.command}`, { level: "info", ephemeral: true });
 
     const child = spawn(toolBin, withJLineDumbFlag(args, toolBin), {
@@ -1599,6 +1598,11 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
       detached: !isWindows,
     });
     lane.child = child;
+    // Broadcast status only after the child is tracked: statusSnapshot() reports a
+    // lane as busy via `lane.child !== null`, so emitting it earlier would mark the
+    // lane idle for the whole run, leaving the Stop button disabled (and the running
+    // spinner / button-greying off) until the process exits.
+    broadcast("status", statusSnapshot());
 
     const wire = (stream, name) => {
       let buf = "";


### PR DESCRIPTION
## Summary

The Stop button next to Build/Test/Package was disabled while a build was actually running, so there was no way to cancel an in-flight build/test/package from the canvas.

The root cause was an ordering bug in `spawnTool()`: the status snapshot was broadcast *before* `lane.child` was assigned. `statusSnapshot()` derives a lane's `busy` flag from `lane.child !== null`, so that snapshot reported the lane as idle, and no further status event was emitted until the process closed. For the entire run the canvas believed nothing was running, which kept the Maven Stop button disabled (and also suppressed the running spinner and the greying of the sibling buttons).

The fix moves the `broadcast("status", statusSnapshot())` call to after `lane.child = child`, so the snapshot reports the lane as busy as soon as the process starts. The Stop button then enables and routes to the existing `stopApp("maven")` path that kills the build/test/package process (and its warm daemon). The Run lane uses the same code path and benefits too.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A - no documented behavior changed.)
- [x] No secrets committed.

## Notes for reviewers

One-line reordering in `spawnTool()`. The earlier `broadcast("status", ...)` was redundant once the child is tracked, since `phase` and `command` are already set before the spawn and the snapshot is emitted immediately after. Reload the extension and re-open the canvas to pick up the change.