### PR TITLE
Add toolbar refresh button to re-run project discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ wins; when neither is found the console says so and stays disabled until one is 
   (`dev` / `test` / `prod` plus any `%<profile>.` keys) — and, for Maven, the reactor's
   **Maven profiles**, offering each as an editable dropdown. (Gradle has no Maven-profile
   concept, so that control is hidden.)
+- **Refresh** &mdash; the refresh button in the toolbar's top-right corner re-runs the
+  project discovery done at launch (build tool, modules, Maven/Spring/Quarkus profiles
+  and detected technologies), so changes to the build files show up without reloading
+  the extension.
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,
   threads, health, profiles and startup info, sourced from the richest endpoint
   available (BootUI → Actuator → Quarkus Micrometer/health → process).

--- a/extension.mjs
+++ b/extension.mjs
@@ -115,6 +115,7 @@ async function recheckBuildTool() {
   javaVersion = undefined;
   mavenProfiles = null;
   springProfiles = null;
+  quarkusProfiles = null;
   session.log(`[coffilot] re-checked build tool: ${TOOL_LABEL || "none"} at ${workspacePath}`, { level: "info" });
   return envSnapshot();
 }

--- a/public/app.js
+++ b/public/app.js
@@ -38,6 +38,7 @@ const mvnProfilesLabel = document.getElementById("lbl-mvn-profiles");
 const mvnProfilesCombo = document.getElementById("mvn-profiles-combo");
 const noToolBanner = document.getElementById("no-tool-banner");
 const btnRecheck = document.getElementById("btn-recheck");
+const btnRefresh = document.getElementById("btn-refresh");
 const warmBanner = document.getElementById("warm-banner");
 const warmMsg = document.getElementById("warm-msg");
 const warmCmd = document.getElementById("warm-cmd");
@@ -1277,6 +1278,27 @@ if (btnRecheck) {
     } else {
       appendLine("[canvas] still no Maven or Gradle project detected.", "stderr");
     }
+  });
+}
+
+// Header refresh button: re-run the full project discovery the extension does at
+// launch (build tool, modules, Maven/Spring/Quarkus profiles, detected
+// technologies) and re-apply it, without reloading the extension. Shares the
+// /api/recheck backend with "Check again"; the spinning icon signals progress.
+if (btnRefresh) {
+  btnRefresh.addEventListener("click", async () => {
+    if (btnRefresh.classList.contains("is-busy")) return;
+    btnRefresh.classList.add("is-busy");
+    btnRefresh.disabled = true;
+    const env = await postJson("/api/recheck");
+    if (env && !env.error) {
+      applyEnv(env);
+      appendLine(`[canvas] re-scanned project: ${env.toolLabel || env.buildTool || "no build tool"}.`, "stdout");
+    } else {
+      appendLine("[canvas] refresh failed" + (env && env.error ? `: ${env.error}` : "."), "stderr");
+    }
+    btnRefresh.classList.remove("is-busy");
+    btnRefresh.disabled = false;
   });
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,18 @@
           <div class="combo-menu" id="maven-menu" hidden></div>
         </span>
       </div>
+      <button
+        id="btn-refresh"
+        class="icon-btn"
+        title="Re-scan the project: build tool, modules, Maven/Spring/Quarkus profiles and detected technologies"
+        aria-label="Refresh project discovery"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path
+            d="M1.705 8.005a.75.75 0 0 1 .834.656 5.5 5.5 0 0 0 9.592 2.97l-1.204-1.204a.25.25 0 0 1 .177-.427h3.646a.25.25 0 0 1 .25.25v3.646a.25.25 0 0 1-.427.177l-1.38-1.38A7.002 7.002 0 0 1 1.05 8.84a.75.75 0 0 1 .656-.834ZM8 2.5a5.487 5.487 0 0 0-4.131 1.869l1.204 1.204A.25.25 0 0 1 4.896 6H1.25A.25.25 0 0 1 1 5.75V2.104a.25.25 0 0 1 .427-.177l1.38 1.38A7.002 7.002 0 0 1 14.95 7.16a.75.75 0 0 1-1.49.178A5.5 5.5 0 0 0 8 2.5Z"
+          />
+        </svg>
+      </button>
     </header>
 
     <div id="no-tool-banner" hidden>

--- a/public/styles.css
+++ b/public/styles.css
@@ -18,17 +18,53 @@ body {
   line-height: var(--leading-body-medium, 20px);
 }
 header {
-  padding: 0.75rem 1rem;
+  padding: 0.75rem 3rem 0.75rem 1rem;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
+  position: relative;
+  /* Height of the toolbar's first row, set by the Build/Test/Run button groups
+     (group border + padding wrapping a button's border + padding + line-box).
+     Used to vertically center the absolutely-positioned refresh button on that
+     same row. */
+  --toolbar-row-h: calc(4px + 1.1rem + var(--leading-body-medium, 20px));
 }
 h1 {
   font-size: var(--text-title-medium, 16px);
   font-weight: var(--font-weight-semibold, 600);
   margin: 0 0.5rem 0 0;
+}
+/* Pinned to the header's top-right corner. Re-runs project discovery (build
+   tool, modules, Maven/Spring/Quarkus profiles, detected technologies). The
+   header reserves right padding so wrapping controls never slide under it. */
+.icon-btn {
+  position: absolute;
+  /* Center on the toolbar's first row instead of pinning to the very top, so
+     the icon lines up with the Build/Test/Run controls. */
+  top: calc(0.75rem + (var(--toolbar-row-h) - 30px) / 2);
+  right: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  color: var(--text-color-muted, #8c959f);
+}
+.icon-btn svg {
+  width: 15px;
+  height: 15px;
+}
+.icon-btn:hover {
+  color: var(--text-color-default, #1f2328);
+}
+.icon-btn.is-busy {
+  cursor: progress;
+}
+.icon-btn.is-busy svg {
+  animation: cof-spin 0.7s linear infinite;
 }
 .btn-group {
   display: inline-flex;


### PR DESCRIPTION
## Summary

Coffilot discovers a project's build tool, modules, Maven/Spring/Quarkus profiles, and the technologies in use once, when the extension launches. If you edit a `pom.xml`/`build.gradle` (add a profile, pull in Spring Boot, etc.) while the canvas is open, that discovery goes stale and the only way to refresh it was reloading the extension.

This adds a refresh icon button to the top-right corner of the canvas header that re-runs the launch-time discovery on demand and re-applies it, so build-file changes show up without a reload.

The button reuses the existing `/api/recheck` backend (the same one behind the no-tool banner's "Check again") and re-applies the env snapshot via `applyEnv`, so it refreshes modules, profiles, capabilities, and the JDTLS state in one shot. While a refresh is in flight the icon spins. On the backend, `recheckBuildTool()` now also clears the Quarkus profile cache, which it was previously missing, so Quarkus profiles re-discover alongside the Maven and Spring ones.

The icon is absolutely positioned to stay pinned in the top-right corner even when the header wraps on a narrow panel. It's vertically centered on the toolbar's first row using a `--toolbar-row-h` CSS variable (the Build/Test/Run button-group height) so it lines up with the other controls regardless of the canvas theme's line-height.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the header layout and button alignment in a browser preview of the canvas UI.
- [x] Updated `README.md` (new Refresh feature bullet).
- [x] No secrets committed.

## Notes for reviewers

The vertical alignment relies on `--toolbar-row-h` matching the actual `.btn-group` height (group border + padding wrapping a button's border + padding + line-box). If the toolbar button padding changes, that variable should be kept in sync.