### PR TITLE
Add restart-in-place for build/test/package/run lanes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ verification in a live canvas is still expected for UI changes.
 ## Safety notes when testing
 
 The loopback control endpoints are mostly safe to `curl` for inspection
-(`/api/state`, `/api/settings`, `/api/recheck`, `/api/build`, `/api/test`, `/api/run`, `/api/stop`,
+(`/api/state`, `/api/settings`, `/api/recheck`, `/api/build`, `/api/test`, `/api/run`, `/api/stop`, `/api/restart`,
 `/events`, …), but **`/api/fix` and `/api/mcp/scan` fire prompts / scans into the
 conversation** — don't call them casually. The HTTP server binds to `127.0.0.1`
 only; keep it that way.

--- a/extension.mjs
+++ b/extension.mjs
@@ -2381,6 +2381,58 @@ function stopApp(op) {
   return stopped ? { ok: true, stopped: true } : { ok: true, stopped: false, note: "Nothing was running." };
 }
 
+// Resolve once `predicate()` is false — i.e. the lane's child has fully exited.
+// Restart relies on this because the start functions guard on `lane.child !==
+// null`: relaunching before the old process is gone would be rejected as "already
+// running". Resolves false if the wait exceeds `timeoutMs` (the SIGTERM→SIGKILL
+// escalation in killChild is 5s, so 15s leaves ample headroom).
+function waitForLaneIdle(predicate, timeoutMs = 15000) {
+  if (!predicate()) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const tick = () => {
+      if (!predicate()) return resolve(true);
+      if (Date.now() - startedAt >= timeoutMs) return resolve(false);
+      setTimeout(tick, 100);
+    };
+    tick();
+  });
+}
+
+/**
+ * Stop a lane's current process and relaunch it once it has fully exited — the
+ * "click the trigger again to restart" path. `op` is "build" | "test" |
+ * "package" | "run", and `params` carries the same inputs the start endpoints
+ * accept (warm/mavenProfiles for the build group; module/profiles/mavenProfiles/
+ * mode for run). Build/test/package share one lane, so restarting any of them
+ * stops whatever build-group process is live before starting the requested op.
+ */
+async function restart(op, params = {}) {
+  if (!buildTool) {
+    pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", op === "run" ? "run" : op || "build");
+    return noToolResult();
+  }
+  if (op === "run") {
+    stopApp("run");
+    if (!(await waitForLaneIdle(runLaneBusy))) {
+      return { ok: false, error: "Timed out stopping the app; press Stop, then Run." };
+    }
+    return startApp(params);
+  }
+  if (!["build", "test", "package"].includes(op)) {
+    return { ok: false, error: `Cannot restart "${op}".` };
+  }
+  stopApp("maven");
+  if (!(await waitForLaneIdle(mvnLaneBusy))) {
+    return { ok: false, error: "Timed out stopping the build; press Stop, then re-run." };
+  }
+  // Fire-and-forget, like the /api/build|test|package handlers: progress streams
+  // over SSE, so the relaunch must not block the HTTP response until it finishes.
+  const startFn = op === "build" ? build : op === "test" ? test : packageApp;
+  startFn(null, params.warm === true, params.mavenProfiles);
+  return { ok: true, restarted: true, op };
+}
+
 // ---------------------------------------------------------------------------
 // Process shutdown — never let a spawned Maven/Java process outlive us.
 //
@@ -3474,6 +3526,11 @@ const server = createServer(async (req, res) => {
   if (req.method === "POST" && url.pathname === "/api/stop") {
     const body = await readBody(req);
     sendJson(res, 200, stopApp(body.op)); // op omitted -> stop all lanes
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/restart") {
+    const body = await readBody(req);
+    sendJson(res, 200, await restart(body.op, body)); // stop the lane, then relaunch it
     return;
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -90,6 +90,15 @@ const mvnButtons = {
   test: document.getElementById("btn-test"),
   package: document.getElementById("btn-package"),
 };
+// While a lane is restarting, the trigger keeps its label (no width change) and
+// shows a rotating restart glyph in the spinner slot; this maps op -> button so
+// we can toggle that state class.
+const triggerButton = {
+  build: mvnButtons.build,
+  test: mvnButtons.test,
+  package: mvnButtons.package,
+  run: btnRun,
+};
 const capsEl = document.getElementById("caps");
 const metricsSrc = document.getElementById("metrics-src");
 const metricsHint = document.getElementById("metrics-hint");
@@ -296,9 +305,63 @@ function applyStopButton(btn, which, busy) {
   }
 }
 
+// Optimistic "restarting" state for the trigger buttons. Clicking a trigger
+// while its lane is busy stops the running process and relaunches it; the lane
+// briefly reports idle/failed between the two, so we mask that transition until
+// the new run reports busy. Two phases: "stopping" (waiting for the old process
+// to exit) flips to "starting" the first time the lane reports not-busy, then
+// clears once the relaunch reports busy. A safety timeout is the backstop in
+// case the restart never starts (e.g. it timed out server-side).
+const restarting = { build: false, test: false, package: false, run: false };
+const restartTimers = { build: null, test: null, package: null, run: null };
+
+function markRestarting(op) {
+  if (restarting[op]) return;
+  restarting[op] = "stopping";
+  appendLine("[canvas] restarting\u2026", "stdout", op);
+  clearTimeout(restartTimers[op]);
+  // Backstop: if the relaunch never reports busy again (e.g. the server-side
+  // restart timed out or failed), clear the mask and re-render so the trigger
+  // doesn't stay stuck disabled/"Restarting…" — mirrors the Stop backstop.
+  restartTimers[op] = setTimeout(() => {
+    if (!restarting[op]) return;
+    clearRestarting(op);
+    if (statusSnap) renderStatus(statusSnap);
+  }, 20000);
+}
+
+function clearRestarting(op) {
+  restarting[op] = false;
+  clearTimeout(restartTimers[op]);
+  restartTimers[op] = null;
+}
+
+// Advance the restart state machine from the raw (server-reported) busy flags,
+// so the mask drops exactly when the relaunched process is up.
+function syncRestarting(s) {
+  for (const op of ["build", "test", "package", "run"]) {
+    const busy = !!(s[op] && s[op].busy);
+    if (restarting[op] === "stopping" && !busy) restarting[op] = "starting";
+    else if (restarting[op] === "starting" && busy) clearRestarting(op);
+  }
+}
+
+// True while the lane is genuinely busy OR mid-restart, so the toolbar stays
+// stable (siblings disabled, Stop active, spinner on) across the brief gap.
+function laneActive(s, op) {
+  return !!(s && s[op] && s[op].busy) || !!restarting[op];
+}
+
+// Raw server-reported busy for one lane (no restart masking) — used to decide
+// whether a trigger click should start the lane or restart it.
+const laneBusy = (op) => !!(statusSnap && statusSnap[op] && statusSnap[op].busy);
+
 function renderStatus(s) {
   if (!s) return;
   statusSnap = s;
+  // Advance any in-flight restart before rendering so the toolbar uses the
+  // masked "active" state across the stop→start gap.
+  syncRestarting(s);
   // Live reload pill is global, not per-tab.
   const reload = s.reload;
   if (reload && reload.active) {
@@ -316,33 +379,55 @@ function renderStatus(s) {
     : "The app isn't running yet";
   // The two grouped Stop buttons are global, not tied to the active tab:
   // the Maven Stop covers build/test/package; the Run Stop covers run.
-  const mvnBusy = (s.build && s.build.busy) || (s.test && s.test.busy) || (s.package && s.package.busy);
+  const mvnBusy = laneActive(s, "build") || laneActive(s, "test") || laneActive(s, "package");
   applyStopButton(btnStopMaven, "maven", mvnBusy);
-  applyStopButton(btnStopRun, "run", !!(run && run.busy));
-  // Per-lane running spinners on the trigger buttons and tabs (global, so
-  // they reflect activity regardless of which tab is showing).
+  applyStopButton(btnStopRun, "run", laneActive(s, "run"));
+  // Per-lane spinners on the trigger buttons and tabs (global, so they reflect
+  // activity regardless of which tab is showing). The `is-restarting` class
+  // turns the trigger's spinner into a rotating restart glyph without touching
+  // the label, so the button keeps its width.
   for (const op of ["build", "test", "package", "run"]) {
-    const busy = !!(s[op] && s[op].busy);
-    if (btnSpin[op]) btnSpin[op].hidden = !busy;
-    if (tabSpin[op]) tabSpin[op].hidden = !busy;
+    const active = laneActive(s, op);
+    if (btnSpin[op]) btnSpin[op].hidden = !active;
+    if (tabSpin[op]) tabSpin[op].hidden = !active;
+    if (triggerButton[op]) {
+      triggerButton[op].classList.toggle("is-restarting", !!restarting[op]);
+    }
   }
   // While a build op runs the lane is serialized, so grey out the other
-  // Build/Test/Package buttons (the running one stays active with its spinner).
-  // Everything is also disabled when no build tool is present (degraded mode).
-  const busyMvnOp = ["build", "test", "package"].find((op) => s[op] && s[op].busy);
+  // Build/Test/Package buttons (the running one stays active — click it again
+  // to restart). Everything is disabled when no build tool is present.
+  const busyMvnOp = ["build", "test", "package"].find((op) => laneActive(s, op));
   for (const op of ["build", "test", "package"]) {
     const btn = mvnButtons[op];
     if (!btn) continue;
-    btn.disabled = !toolPresent || (!!busyMvnOp && op !== busyMvnOp);
+    // The running op stays clickable (to restart); idle siblings are greyed out
+    // until it stops, and the op itself is locked while its restart is in flight.
+    btn.disabled = !toolPresent || (!!busyMvnOp && op !== busyMvnOp) || !!restarting[op];
     btn.title = !toolPresent
       ? "Coffilot needs a Maven or Gradle project."
-      : btn.disabled
-        ? `Stop the running ${busyMvnOp} first`
-        : "";
+      : restarting[op]
+        ? "Restarting\u2026"
+        : op === busyMvnOp
+          ? `Restart the running ${op}`
+          : btn.disabled
+            ? `Stop the running ${busyMvnOp} first`
+            : "";
   }
   if (!toolPresent) btnRun.disabled = true;
-  // Header (phase / command / exit / fix) follows the active tab.
-  renderLaneHeader(s[activeTab] || {});
+  else btnRun.disabled = !!restarting.run;
+  if (toolPresent) {
+    btnRun.title = restarting.run ? "Restarting\u2026" : laneActive(s, "run") ? "Restart the running app" : "";
+  }
+  // Header (phase / command / exit / fix) follows the active tab; while the
+  // active tab's lane is restarting, show a steady "restarting" phase instead of
+  // the momentary failed/idle flicker (and no stale Fix button).
+  const activeLane = s[activeTab] || {};
+  if (restarting[activeTab]) {
+    renderLaneHeader({ phase: "restarting", command: activeLane.command });
+  } else {
+    renderLaneHeader(activeLane);
+  }
 }
 
 // Render the per-lane header bits for one op (build | test | package | run).
@@ -1060,21 +1145,47 @@ const mvnProfiles = () => mvnProfilesInput.value.trim();
 setupCombo(springInput, springMenu, () => profileItems);
 setupCombo(mvnProfilesInput, mavenMenu, () => mavenItems);
 
+// Each trigger button starts its lane, or — if that lane is already busy —
+// restarts it (stop the current process, then relaunch with the same inputs).
+function triggerLane(op, startPath, body) {
+  if (restarting[op]) return; // a restart is already in flight (either phase)
+  const busy = op === "run" ? laneBusy("run") : laneBusy("build") || laneBusy("test") || laneBusy("package");
+  if (busy) {
+    markRestarting(op);
+    if (statusSnap) renderStatus(statusSnap); // reflect "Restarting…" without waiting for the next event
+    restartLane(op, body);
+  } else {
+    post(startPath, body);
+  }
+}
+
+async function restartLane(op, body) {
+  const res = await postJson("/api/restart", { op, ...body });
+  // On success the relaunch is in flight and syncRestarting clears the mask when
+  // it reports busy. On failure (e.g. the stop timed out), drop the mask now
+  // instead of leaving the trigger stuck until the 20s backstop.
+  if (res && res.ok === false) {
+    appendLine("[canvas] restart failed: " + (res.error || "unknown error"), "stderr", op);
+    clearRestarting(op);
+    if (statusSnap) renderStatus(statusSnap);
+  }
+}
+
 document.getElementById("btn-build").onclick = () => {
   showTab("build");
-  post("/api/build", { warm: warm(), mavenProfiles: mvnProfiles() });
+  triggerLane("build", "/api/build", { warm: warm(), mavenProfiles: mvnProfiles() });
 };
 document.getElementById("btn-test").onclick = () => {
   showTab("test");
-  post("/api/test", { warm: warm(), mavenProfiles: mvnProfiles() });
+  triggerLane("test", "/api/test", { warm: warm(), mavenProfiles: mvnProfiles() });
 };
 document.getElementById("btn-package").onclick = () => {
   showTab("package");
-  post("/api/package", { warm: warm(), mavenProfiles: mvnProfiles() });
+  triggerLane("package", "/api/package", { warm: warm(), mavenProfiles: mvnProfiles() });
 };
 document.getElementById("btn-run").onclick = () => {
   showTab("run");
-  post("/api/run", {
+  triggerLane("run", "/api/run", {
     module: document.getElementById("in-module").value.trim(),
     profiles: document.getElementById("in-profiles").value.trim(),
     mavenProfiles: mvnProfiles(),
@@ -1087,11 +1198,14 @@ btnStopMaven.onclick = () => {
   if (btnStopMaven.disabled) return;
   const s = statusSnap || {};
   const op = ["build", "test", "package"].find((o) => s[o] && s[o].busy) || activeTab;
+  // A Stop wins over any in-flight restart of the build group.
+  ["build", "test", "package"].forEach(clearRestarting);
   markStopping("maven", op);
   post("/api/stop", { op: "maven" });
 };
 btnStopRun.onclick = () => {
   if (btnStopRun.disabled) return;
+  clearRestarting("run");
   markStopping("run", "run");
   post("/api/stop", { op: "run" });
 };

--- a/public/styles.css
+++ b/public/styles.css
@@ -130,6 +130,13 @@ button.danger.is-stopping:hover {
   background: var(--true-color-red, #cf222e);
   border-color: var(--true-color-red, #cf222e);
 }
+/* A trigger button mid-restart (stopping the old process before relaunching):
+   keep it looking busy rather than greyed out so the click clearly registered. */
+button.is-restarting,
+button.is-restarting:hover {
+  opacity: 0.9;
+  cursor: progress;
+}
 button.fix {
   border-color: var(--true-color-orange, #bc4c00);
   color: var(--color-white, #fff);
@@ -225,7 +232,8 @@ select {
 }
 .pill.building,
 .pill.testing,
-.pill.packaging {
+.pill.packaging,
+.pill.restarting {
   color: var(--true-color-blue, #0969da);
   border-color: var(--true-color-blue, #0969da);
 }
@@ -855,6 +863,25 @@ aside h2 {
 .btn-spin {
   margin-right: 0.4rem;
   vertical-align: -1px;
+}
+/* While a trigger is mid-restart, swap its loader ring for a rotating restart
+   glyph in the same fixed-size slot — distinct from a fresh run, and with no
+   width change to the button (the label stays put). */
+button.is-restarting .btn-spin {
+  position: relative;
+  border: 0;
+  animation: none;
+}
+button.is-restarting .btn-spin::before {
+  content: "\21BB";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  line-height: 1;
+  animation: cof-spin 0.9s linear infinite;
 }
 .tab-spin {
   margin-left: 0.1rem;


### PR DESCRIPTION
## Summary

Restarting a build, test, package, or run used to be a two-step chore: click Stop, wait, then click the trigger again. A second click on a busy lane was simply a no-op (the start functions bail with "already running"). This PR makes each trigger button double as a restart: clicking Build/Test/Package/Run while that lane is busy stops the current process, waits for it to fully exit, then relaunches with the same inputs.

**Server.** Adds `waitForLaneIdle()`, `restart(op, params)`, and a `POST /api/restart` route. `restart()` calls `stopApp`, then awaits the child's exit before relaunching, because the start functions guard on `lane.child !== null` and would reject a relaunch that races the asynchronous process exit. It re-dispatches the same way the existing endpoints do: `startApp` for run, fire-and-forget for the shared build/test/package lane (so the HTTP response is never held open for the duration of a build).

**Client.** Trigger buttons route to `/api/restart` when their lane is busy. A small two-phase optimistic "restarting" state (stopping -> starting -> cleared), driven from the SSE status stream, masks the brief idle/failed flicker between stop and start so the toolbar (sibling buttons, Stop, spinners, header) stays stable.

**UI.** The button keeps its label and width: instead of swapping the text to "Restarting..." (which made the button grow), the spinner slot shows a rotating restart glyph distinct from a fresh-run loader. The header pill reads "restarting" and the tooltip spells it out.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

- The build/test/package lanes share one serialized process, so only the running op's trigger is enabled; restarting it stops whatever build-group process is live before relaunching the requested op.
- A code-review pass caught that the 20s safety backstop cleared the restart mask without re-rendering, which could leave a trigger stuck disabled if a restart failed server-side. Fixed: the backstop now re-renders, and failures clear immediately by reading the `/api/restart` response.
- `CONTRIBUTING.md` gains `/api/restart` in the list of safe-to-inspect loopback endpoints. `public/index.html` has no net change.