### PR TITLE
Expose Actuator metrics endpoint in test fixture

### DIFF
--- a/integration-tests/spring-mvc-actuator-devtools/src/main/resources/application.properties
+++ b/integration-tests/spring-mvc-actuator-devtools/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.application.name=spring-mvc-actuator-devtools
+
+# Spring Boot exposes only the health endpoint over HTTP by default, which leaves
+# Coffilot's Actuator metrics tier with nothing to read (empty Live JVM panel).
+# Expose the JSON metrics endpoint (plus health/info) so the tier can serve real
+# heap/thread/uptime gauges.
+management.endpoints.web.exposure.include=health,info,metrics


### PR DESCRIPTION
## Summary

While testing Coffilot's Live JVM metrics, the Actuator tier came up empty. Root cause: the `spring-mvc-actuator-devtools` integration-test fixture only set `spring.application.name`, so Spring Boot exposed only `/actuator/health` over HTTP (its default). Coffilot detected the Actuator tier via health, but every JVM metric request hit `/actuator/metrics/*` and got a 404, leaving the Live JVM panel blank.

This adds `management.endpoints.web.exposure.include=health,info,metrics` to the fixture so the tier serves real heap/thread/uptime gauges, which is what this fixture is meant to exercise per the integration-tests README.

I confirmed the extension's parsing logic was already correct: against an app that does expose `/actuator/metrics` (the BootUI fixture exposes 11 endpoints), the same code read heap/threads/uptime accurately. After the fix, re-running the Actuator fixture shows "Exposing 3 endpoints" and a fully populated normalized metrics object (heap used/max/percent, threads total/daemon, uptime). The BootUI tier was already working and is unchanged.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

Scope is limited to the test fixture's `application.properties`; no extension code changed. Note this only fixes the fixture so the Actuator tier can be exercised. Any real Spring Boot app must likewise expose `metrics` for Coffilot's Actuator tier to show data, since that is a Spring Boot default Coffilot cannot read around. A possible follow-up is a UI hint when Actuator health responds but `/actuator/metrics` 404s.

This branch also merges the latest `origin/main` (#34 UI animations); that merge is unrelated to the fixture change and introduced no conflicts.