### PR TITLE
Add async-profiler flame graph to the Run tab

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -41,16 +41,22 @@ Shipped in the extension today:
   cross-platform detected.
 - Live JVM metrics tiered BootUI → Actuator → Quarkus Micrometer/health → process,
   with a source badge.
+- On-demand CPU / allocation / wall-clock / lock-contention flame graph of the
+  running app via async-profiler (`asprof`), rendered interactively (zoom, hover,
+  search) in the Run tab with a top-hotspots list; an "Automatically record at
+  startup" toggle (off by default) records on each app start. Detected and degraded
+  gracefully when the profiler is absent (and unavailable on Windows).
 - "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
-  startup failures, and for BootUI advisor-scan findings.
+  startup failures, for flame-graph hotspots, and for BootUI advisor-scan findings.
 - BootUI MCP server toggle + advisor scans when the running app exposes BootUI.
 - Per-project persisted settings (warm JVM, Spring profiles, devtools, random port,
-  auto-open browser) and an always-visible Settings panel.
+  auto-open browser, auto-record flame graph at startup) and an always-visible
+  Settings panel.
 - `--enable-native-access=ALL-UNNAMED` applied to the build-tool JVM (via
   `MAVEN_OPTS` / `GRADLE_OPTS`) and, for Maven, the app JVM to silence JDK
   native-access warnings.
 - Agent-facing actions: `build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`.
+  `stop_app`, `get_status`, `get_metrics`, `profile_app`, `fix_issue`, `run_scan`.
 
 ## Known limitations
 
@@ -65,6 +71,11 @@ Shipped in the extension today:
 - **No live per-test progress for Gradle.** Maven's Surefire console output drives the
   class-by-class progress bar; Gradle's graphical test view fills in from the final
   JUnit XML report instead.
+- **The flame graph needs async-profiler installed** and resolves the app JVM via
+  `lsof` on the detected HTTP port (falling back to the run lane's child for
+  plain-`java` runs), so a port-less app started through a forked wrapper can't be
+  attached to. On macOS the `cpu` event maps to `itimer` (no perf_events), and the
+  whole feature is unavailable on Windows (async-profiler has no Windows build).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ wins; when neither is found the console says so and stays disabled until one is 
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,
   threads, health, profiles and startup info, sourced from the richest endpoint
   available (BootUI → Actuator → Quarkus Micrometer/health → process).
+- **Flame graph (with async-profiler)** &mdash; when [async-profiler](https://github.com/async-profiler/async-profiler)
+  (`asprof`) is installed, the Run tab's **Flame graph** view records an on-demand
+  CPU / allocation / wall-clock / lock-contention profile of the running app's JVM
+  and renders an interactive flame graph (zoom, hover, search) plus a **Top
+  hotspots** list. An **Analyze hotspots with Copilot** button sends the hottest
+  methods to the agent. An **Automatically record at startup** toggle (off by
+  default) kicks off a recording on its own each time the app becomes reachable.
+  Degrades gracefully with an install hint when the profiler
+  is missing (and is unavailable on Windows, which async-profiler does not support).
 - **Fix with Copilot** &mdash; on a compile error, failing tests, or a startup
   crash, a button pushes a context-rich request back into the chat so the agent
   can diagnose and fix it.
@@ -141,8 +150,8 @@ In a Copilot app session on a Maven or Gradle project, open the **Coffilot** can
 5. **Stop** when done.
 
 The agent can drive the same flow with the `build_app`, `run_tests`,
-`package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`
-and `run_scan` actions.
+`package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `profile_app`,
+`fix_issue` and `run_scan` actions.
 
 ## How it works
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -51,6 +51,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ---------------------------------------------------------------------------
 
 const isWindows = process.platform === "win32";
+const isMac = process.platform === "darwin";
 
 const session = await joinSession({ canvases: [makeCanvas()] });
 
@@ -269,6 +270,86 @@ function detectMvnd() {
   }
   mvndInfo = { available: false, path: null };
   return mvndInfo;
+}
+
+// ---------------------------------------------------------------------------
+// async-profiler (CPU/alloc/wall/lock flame graphs)
+//
+// The Run tab can attach async-profiler to the running app's JVM and render a
+// flame graph from the sampled stacks. async-profiler ships as a native tool
+// (the `asprof` CLI + libasyncProfiler), so — like mvnd — we DETECT an installed
+// copy rather than bundling one, and degrade gracefully (with an install hint)
+// when it is missing. There is no Windows build of async-profiler, so the whole
+// feature is reported unavailable there.
+// ---------------------------------------------------------------------------
+
+let asprofInfo = null;
+function detectAsprof() {
+  if (asprofInfo && asprofInfo.available) return asprofInfo;
+  if (isWindows) {
+    asprofInfo = { available: false, path: null };
+    return asprofInfo;
+  }
+  const candidates = [];
+  // Explicit overrides first: ASPROF points at the binary, ASYNC_PROFILER_HOME /
+  // ASYNC_PROFILER_DIR at an unpacked release directory.
+  if (process.env.ASPROF) candidates.push(process.env.ASPROF);
+  for (const home of [process.env.ASYNC_PROFILER_HOME, process.env.ASYNC_PROFILER_DIR]) {
+    if (home) candidates.push(path.join(home, "bin", "asprof"), path.join(home, "asprof"));
+  }
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (dir) candidates.push(path.join(dir, "asprof"));
+  }
+  // Common install locations: Homebrew (macOS/Linux) plus typical manual unpacks.
+  candidates.push(
+    "/opt/homebrew/bin/asprof",
+    "/usr/local/bin/asprof",
+    "/home/linuxbrew/.linuxbrew/bin/asprof",
+    "/opt/async-profiler/bin/asprof",
+    "/usr/local/async-profiler/bin/asprof",
+  );
+  const home = process.env.HOME || "";
+  if (home) candidates.push(path.join(home, "async-profiler", "bin", "asprof"));
+  for (const c of candidates) {
+    try {
+      if (existsSync(c)) {
+        asprofInfo = { available: true, path: c };
+        return asprofInfo;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  asprofInfo = { available: false, path: null };
+  return asprofInfo;
+}
+
+/** Install hint surfaced in the UI when async-profiler isn't found. */
+function profilerInstall() {
+  if (isMac) {
+    return { os: "macOS", cmd: "brew install async-profiler", url: "https://github.com/async-profiler/async-profiler" };
+  }
+  if (isWindows) {
+    return { os: "Windows", cmd: null, url: "https://github.com/async-profiler/async-profiler" };
+  }
+  return {
+    os: "Linux",
+    cmd: null,
+    url: "https://github.com/async-profiler/async-profiler/releases/latest",
+  };
+}
+
+/** Profiler capability the UI uses to enable/disable the flame-graph controls. */
+function profilerSnapshot() {
+  const a = detectAsprof();
+  return {
+    available: a.available,
+    supported: !isWindows, // async-profiler has no Windows build
+    // The default events the picker offers; "cpu" is mapped to itimer on macOS
+    // by the backend (no perf_events there).
+    events: ["cpu", "alloc", "wall", "lock"],
+    install: profilerInstall(),
+  };
 }
 
 // When a project ships a pom.xml but no Maven wrapper, fall back to a system
@@ -758,7 +839,16 @@ function findProjectRoot(primary) {
 // under COPILOT_HOME (not the repo) keyed by a hash of the workspace path.
 // ---------------------------------------------------------------------------
 
-const SETTINGS_KEYS = ["warm", "springProfiles", "devtools", "randomPort", "openBrowser"];
+const SETTINGS_KEYS = [
+  "warm",
+  "springProfiles",
+  "devtools",
+  "randomPort",
+  "openBrowser",
+  "autoProfile",
+  "autoProfileEvent",
+  "autoProfileDuration",
+];
 
 function settingsPaths() {
   const home = process.env.COPILOT_HOME || path.join(os.homedir(), ".copilot");
@@ -774,6 +864,9 @@ function defaultSettings() {
     devtools: false,
     randomPort: false,
     openBrowser: false,
+    autoProfile: false,
+    autoProfileEvent: "cpu",
+    autoProfileDuration: 30,
   };
 }
 
@@ -1479,6 +1572,13 @@ function applySettings(body) {
   if (typeof body.devtools === "boolean") settings.devtools = body.devtools;
   if (typeof body.randomPort === "boolean") settings.randomPort = body.randomPort;
   if (typeof body.openBrowser === "boolean") settings.openBrowser = body.openBrowser;
+  if (typeof body.autoProfile === "boolean") settings.autoProfile = body.autoProfile;
+  if (["cpu", "alloc", "wall", "lock"].includes(body.autoProfileEvent)) {
+    settings.autoProfileEvent = body.autoProfileEvent;
+  }
+  if (Number.isFinite(Number(body.autoProfileDuration))) {
+    settings.autoProfileDuration = Math.min(120, Math.max(3, Math.round(Number(body.autoProfileDuration))));
+  }
   persistSettings();
 
   if (settings.devtools !== prev.devtools) {
@@ -1588,6 +1688,8 @@ function envSnapshot() {
     quarkusProfiles: listQuarkusProfiles(),
     capabilities: capabilitiesSnapshot(),
     settings: settingsSnapshot(),
+    // CPU/alloc/wall/lock flame graphs via async-profiler (Run tab).
+    profiler: profilerSnapshot(),
     // Warm-JVM tier (mvnd for Maven, daemon for Gradle).
     warmAvailable: warm.available,
     warmKind: warm.kind,
@@ -1948,6 +2050,8 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   app.actuatorPrefix = null;
   csrfToken = null;
   lastMetrics = { appUp: false };
+  resetProfile();
+  broadcastProfile();
 
   // Pick the run strategy: explicit mode wins, else infer from the chosen
   // module's framework — Quarkus (quarkus:dev / quarkusDev) and Spring Boot
@@ -2417,6 +2521,13 @@ function stopApp(op) {
     if (o === "run") {
       stopMetricsPolling();
       stopLiveReload();
+      if (profileChild) {
+        try {
+          profileChild.kill("SIGTERM");
+        } catch {
+          /* already gone */
+        }
+      }
     }
     const lane = lanes[o];
     const child = lane.child;
@@ -3028,10 +3139,351 @@ function finishMetrics() {
       const base = appBase();
       if (base) openExternalUrl(base);
     }
+    // "Automatically record at startup" (Run tab → Flame graph): kick off a
+    // profiling run once, on the same first-reachable transition.
+    if (settings.autoProfile) startAutoProfile();
     broadcast("status", statusSnapshot());
   }
   broadcast("metrics", lastMetrics);
   return lastMetrics;
+}
+
+// ---------------------------------------------------------------------------
+// async-profiler flame-graph engine
+//
+// On demand (Run tab "Record" button or the profile_app agent action) we attach
+// async-profiler to the running app's JVM for a fixed duration and collect
+// sampled stacks in "collapsed" format. The collapsed file is parsed here into a
+// flame tree (rendered client-side) plus a self-time hotspot list (surfaced to
+// the agent), all from a single profiling run.
+// ---------------------------------------------------------------------------
+
+// Logical event -> the async-profiler event token to request. macOS has no
+// perf_events, so the CPU profile is sampled with itimer there instead of cpu.
+const PROFILE_EVENTS = { cpu: "cpu", alloc: "alloc", wall: "wall", lock: "lock" };
+function resolveProfileEvent(event) {
+  const e = PROFILE_EVENTS[event] ? event : "cpu";
+  const token = e === "cpu" && isMac ? "itimer" : e;
+  return { event: e, token };
+}
+
+// Profiling state. `flameTree`/`top`/`total` are populated once a run completes;
+// the client fetches them from /api/profile/data. Everything else is broadcast
+// over SSE so the Run tab can reflect progress live.
+let profile = {
+  status: "idle", // idle | running | done | error
+  event: null, // logical event (cpu | alloc | wall | lock)
+  duration: 0,
+  pid: null,
+  startedAt: 0,
+  finishedAt: 0,
+  error: null,
+  total: 0,
+  top: [],
+  hasGraph: false,
+};
+let flameTree = null; // { n, v, c: [...] } built from the last collapsed run
+let profileChild = null; // the running `asprof -d` process
+let profileResolve = null; // resolves the in-flight run's promise (agent action)
+
+function profilePublic() {
+  const { event, duration, status, pid, startedAt, finishedAt, error, total, hasGraph } = profile;
+  return { status, event, duration, pid, startedAt, finishedAt, error, total, hasGraph };
+}
+
+function broadcastProfile() {
+  broadcast("profile", profilePublic());
+}
+
+function resetProfile() {
+  profile = {
+    status: "idle",
+    event: null,
+    duration: 0,
+    pid: null,
+    startedAt: 0,
+    finishedAt: 0,
+    error: null,
+    total: 0,
+    top: [],
+    hasGraph: false,
+  };
+  flameTree = null;
+}
+
+/** The collapsed-stacks file async-profiler writes for this workspace. */
+function profileOutFile() {
+  const { dir } = settingsPaths();
+  const key = createHash("sha1").update(workspacePath).digest("hex").slice(0, 16);
+  return path.join(dir, `flame-${key}.collapsed`);
+}
+
+// Find the PID of the JVM actually serving the app. spring-boot:run / bootRun /
+// quarkus:dev / quarkusDev all FORK a separate app JVM, so the run lane's own
+// child is the build-tool wrapper, not the app. The listener on the app's HTTP
+// port is the app JVM, so resolve it from the port first; fall back to the lane
+// child for plain-`java` runs (which are the JVM directly, and may not open a
+// port at all).
+function pidOnPort(port) {
+  if (isWindows || !port) return null;
+  try {
+    const res = spawnSync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"], {
+      encoding: "utf8",
+      timeout: 4000,
+    });
+    if (res.status === 0 && res.stdout) {
+      for (const tok of res.stdout.split(/\s+/)) {
+        const n = Number(tok);
+        if (Number.isInteger(n) && n > 0) return n;
+      }
+    }
+  } catch {
+    /* lsof missing or failed */
+  }
+  return null;
+}
+
+function resolveAppPid() {
+  const fromPort = pidOnPort(app.appPort);
+  if (fromPort) return fromPort;
+  if (app.runMode === "java" && lanes.run.child && lanes.run.child.pid) return lanes.run.child.pid;
+  return null;
+}
+
+// Parse async-profiler "collapsed" output (one `frame1;frame2;... count` line
+// per stack) into a flame tree plus self-time hotspots. Tiny nodes (below 0.1%
+// of total samples) are pruned to keep the rendered graph and the JSON payload
+// manageable.
+function buildFlame(collapsed) {
+  const root = { n: "(total)", v: 0, c: new Map() };
+  const self = new Map();
+  let total = 0;
+  for (const raw of collapsed.split("\n")) {
+    const line = raw.trimEnd();
+    const sp = line.lastIndexOf(" ");
+    if (sp <= 0) continue;
+    const count = Number(line.slice(sp + 1));
+    if (!Number.isFinite(count) || count <= 0) continue;
+    const frames = line.slice(0, sp).split(";");
+    total += count;
+    root.v += count;
+    let node = root;
+    for (const f of frames) {
+      let child = node.c.get(f);
+      if (!child) {
+        child = { n: f, v: 0, c: new Map() };
+        node.c.set(f, child);
+      }
+      child.v += count;
+      node = child;
+    }
+    const leaf = frames[frames.length - 1];
+    self.set(leaf, (self.get(leaf) || 0) + count);
+  }
+  const minV = Math.max(1, total * 0.001);
+  const toArray = (node) => ({
+    n: node.n,
+    v: node.v,
+    c: [...node.c.values()]
+      .filter((ch) => ch.v >= minV)
+      .sort((a, b) => b.v - a.v)
+      .map(toArray),
+  });
+  const top = [...self.entries()]
+    .map(([name, samples]) => ({ name, samples, pct: total ? samples / total : 0 }))
+    .sort((a, b) => b.samples - a.samples)
+    .slice(0, 12);
+  return { tree: toArray(root), total, top };
+}
+
+function finishProfileFromFile(stderrTail) {
+  const out = profileOutFile();
+  let collapsed = "";
+  try {
+    if (existsSync(out)) collapsed = readFileSync(out, "utf8");
+  } catch {
+    /* unreadable */
+  }
+  if (collapsed.trim()) {
+    const { tree, total, top } = buildFlame(collapsed);
+    flameTree = tree;
+    profile.total = total;
+    profile.top = top;
+    profile.hasGraph = true;
+    profile.status = "done";
+    profile.error = null;
+  } else {
+    profile.status = "error";
+    profile.hasGraph = false;
+    profile.error = stderrTail || "async-profiler produced no samples.";
+  }
+  profile.finishedAt = Date.now();
+}
+
+/**
+ * Attach async-profiler to the running app for `duration` seconds and collect a
+ * flame graph. Returns the immediate validation/ack synchronously plus a `done`
+ * promise that resolves with the final summary once the run completes (used by
+ * the profile_app agent action; the HTTP endpoint ignores it and relies on SSE).
+ */
+function startProfile({ duration, event } = {}) {
+  if (profile.status === "running") {
+    return { ok: false, status: "running", error: "A profiling run is already in progress." };
+  }
+  const ap = detectAsprof();
+  if (isWindows || !ap.available) {
+    return {
+      ok: false,
+      status: "unavailable",
+      error: isWindows
+        ? "async-profiler has no Windows build, so flame graphs aren't available."
+        : "async-profiler (asprof) isn't installed. Install it to record flame graphs.",
+    };
+  }
+  if (!runLaneBusy()) {
+    return { ok: false, status: "error", error: "Start the app from the Run tab before recording a flame graph." };
+  }
+  const pid = resolveAppPid();
+  if (!pid) {
+    return {
+      ok: false,
+      status: "error",
+      error: "Couldn't find the app's JVM process to attach to (is the app fully started?).",
+    };
+  }
+  const { event: logical, token } = resolveProfileEvent(event);
+  const dur = Math.min(120, Math.max(3, Math.round(Number(duration) || 30)));
+  const out = profileOutFile();
+  try {
+    mkdirSync(path.dirname(out), { recursive: true });
+    if (existsSync(out)) unlinkSync(out);
+  } catch {
+    /* best effort */
+  }
+
+  resetProfile();
+  profile.status = "running";
+  profile.event = logical;
+  profile.duration = dur;
+  profile.pid = pid;
+  profile.startedAt = Date.now();
+  broadcastProfile();
+  pushConsole(`[coffilot] profiling pid ${pid} for ${dur}s (event=${token}) with async-profiler…`, "stdout", "run");
+
+  const done = new Promise((resolve) => (profileResolve = resolve));
+  let stderr = "";
+  try {
+    profileChild = spawn(ap.path, ["-d", String(dur), "-e", token, "-o", "collapsed", "-f", out, String(pid)], {
+      cwd: workspacePath,
+      env: process.env,
+    });
+  } catch (e) {
+    profile.status = "error";
+    profile.error = e.message;
+    profile.finishedAt = Date.now();
+    broadcastProfile();
+    if (profileResolve) profileResolve(profileSummary());
+    return { ok: false, status: "error", error: e.message, done };
+  }
+  profileChild.stderr?.on("data", (c) => (stderr += c.toString()));
+  profileChild.on("error", (err) => {
+    profileChild = null;
+    profile.status = "error";
+    profile.error = err.message;
+    profile.finishedAt = Date.now();
+    pushConsole(`[coffilot] async-profiler failed: ${err.message}`, "stderr", "run");
+    broadcastProfile();
+    if (profileResolve) profileResolve(profileSummary());
+  });
+  profileChild.on("close", () => {
+    profileChild = null;
+    const stderrTail = stderr.trim().split("\n").slice(-6).join("\n");
+    finishProfileFromFile(stderrTail);
+    if (profile.status === "done") {
+      pushConsole(
+        `[coffilot] flame graph ready — ${profile.total} samples; open the Flame graph tab in Run.`,
+        "stdout",
+        "run",
+      );
+    } else {
+      pushConsole(`[coffilot] profiling failed: ${profile.error}`, "stderr", "run");
+    }
+    broadcastProfile();
+    if (profileResolve) profileResolve(profileSummary());
+  });
+  return { ok: true, status: "running", event: logical, duration: dur, pid, done };
+}
+
+// Fired by finishMetrics when "Automatically record at startup" is on and the app
+// first becomes reachable. Records using the persisted event/duration and logs a
+// clear reason to the Run console when it can't (so it never just "does nothing").
+function startAutoProfile() {
+  if (profile.status === "running") return;
+  const ap = detectAsprof();
+  if (isWindows || !ap.available) {
+    pushConsole(
+      isWindows
+        ? "[coffilot] auto-record is on, but async-profiler has no Windows build — skipping the flame graph."
+        : "[coffilot] auto-record is on, but async-profiler (asprof) isn't installed — skipping the flame graph.",
+      "stderr",
+      "run",
+    );
+    return;
+  }
+  pushConsole('[coffilot] auto-recording a flame graph ("Automatically record at startup" is on)…', "stdout", "run");
+  const r = startProfile({ event: settings.autoProfileEvent, duration: settings.autoProfileDuration });
+  if (!r.ok && r.error) pushConsole(`[coffilot] auto-record couldn't start: ${r.error}`, "stderr", "run");
+}
+
+/** Stop an in-flight profiling run early, dumping whatever has been collected. */
+function stopProfile() {
+  if (profile.status !== "running") return { ok: false, error: "No profiling run is in progress." };
+  const ap = detectAsprof();
+  const out = profileOutFile();
+  if (ap.available && profile.pid) {
+    // Cleanly stop the session in the target JVM and dump partial results. The
+    // `-d` child then exits and its close handler parses the file.
+    try {
+      spawnSync(ap.path, ["stop", "-o", "collapsed", "-f", out, String(profile.pid)], { timeout: 8000 });
+    } catch {
+      /* fall through to killing the child */
+    }
+  }
+  if (profileChild) {
+    try {
+      profileChild.kill("SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  }
+  return { ok: true, stopping: true };
+}
+
+/** Summary returned to the agent action once a run completes. */
+function profileSummary() {
+  if (profile.status !== "done") {
+    return { ok: false, status: profile.status, error: profile.error || "Profiling did not complete." };
+  }
+  return {
+    ok: true,
+    status: "done",
+    event: profile.event,
+    durationSec: profile.duration,
+    totalSamples: profile.total,
+    topHotspots: (profile.top || []).map((h) => ({
+      method: h.name,
+      selfSamples: h.samples,
+      selfPercent: Math.round(h.pct * 1000) / 10,
+    })),
+    note: "The interactive flame graph is available in the Run tab's Flame graph view.",
+  };
+}
+
+/** Run a profiling session and wait for it to finish (for the agent action). */
+async function profileAppAwait({ duration, event } = {}) {
+  const r = startProfile({ duration, event });
+  if (!r.ok) return { ok: false, status: r.status, error: r.error };
+  return r.done;
 }
 
 /** Shape the BootUI MCP server status for the UI (enabled + advertised tools). */
@@ -3072,6 +3524,7 @@ const FIX_OP = {
   "run-java": "run",
   "run-spring": "run",
   "run-quarkus": "run",
+  profile: "run",
 };
 
 function buildFixPrompt(kind, extra = {}) {
@@ -3140,6 +3593,27 @@ function buildFixPrompt(kind, extra = {}) {
       ]
         .filter(Boolean)
         .join("\n\n");
+    case "profile": {
+      const top = profile.top || [];
+      const hotspots = top.length
+        ? top.map((h, i) => `${i + 1}. ${h.name} — ${h.samples} self samples (${(h.pct * 100).toFixed(1)}%)`).join("\n")
+        : "(no hotspots captured)";
+      const eventLabel =
+        profile.event === "alloc"
+          ? "allocation"
+          : profile.event === "wall"
+            ? "wall-clock"
+            : profile.event === "lock"
+              ? "lock-contention"
+              : "CPU";
+      return [
+        `An async-profiler ${eventLabel} flame graph of the running app (${profile.duration}s, ${profile.total} samples) highlighted these hottest methods by self time. Investigate the top entries, explain why they dominate, and propose or apply targeted optimizations (algorithmic fixes, caching, reduced allocation, avoided lock contention, etc.) without changing behavior.`,
+        "Top self-time hotspots:",
+        codeBlock(hotspots),
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
     case "install-bootui": {
       const moduleName = extra.module || "";
       if (buildTool === "gradle") {
@@ -3514,6 +3988,7 @@ const server = createServer(async (req, res) => {
     res.write(`event: status\ndata: ${JSON.stringify(statusSnapshot())}\n\n`);
     res.write(`event: metrics\ndata: ${JSON.stringify(lastMetrics)}\n\n`);
     res.write(`event: tests\ndata: ${JSON.stringify(lastTestReport)}\n\n`);
+    res.write(`event: profile\ndata: ${JSON.stringify(profilePublic())}\n\n`);
     req.on("close", () => sseClients.get(instanceId)?.delete(res));
     return;
   }
@@ -3526,6 +4001,7 @@ const server = createServer(async (req, res) => {
       // UI replays it into the right console.
       console: [...lanes.build.console, ...lanes.test.console, ...lanes.package.console, ...lanes.run.console],
       tests: lastTestReport,
+      profile: profilePublic(),
       env: envSnapshot(),
     });
     return;
@@ -3581,6 +4057,29 @@ const server = createServer(async (req, res) => {
   if (req.method === "POST" && url.pathname === "/api/restart") {
     const body = await readBody(req);
     sendJson(res, 200, await restart(body.op, body)); // stop the lane, then relaunch it
+    return;
+  }
+
+  // CPU/alloc/wall/lock flame graph via async-profiler. /api/profile starts a
+  // fixed-duration run (progress streams over SSE as `profile` events); the
+  // graph data is fetched from /api/profile/data once it completes.
+  if (req.method === "POST" && url.pathname === "/api/profile") {
+    const body = await readBody(req);
+    const { done, ...ack } = startProfile({ duration: body.duration, event: body.event });
+    void done; // fire-and-forget; the UI follows progress over SSE
+    sendJson(res, 200, ack);
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/profile/stop") {
+    sendJson(res, 200, stopProfile());
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/profile/status") {
+    sendJson(res, 200, profilePublic());
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/profile/data") {
+    sendJson(res, 200, { ...profilePublic(), flame: flameTree, top: profile.top || [] });
     return;
   }
 
@@ -3804,15 +4303,36 @@ function makeCanvas() {
         handler: async () => (await refreshMetrics()) || lastMetrics,
       },
       {
+        name: "profile_app",
+        description:
+          "Record an async-profiler flame graph of the running app and return its top self-time hotspots. Requires async-profiler (asprof) installed and the app running (started via start_app). The interactive flame graph appears in the Run tab's Flame graph view. Waits for the run to complete.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            duration: {
+              type: "number",
+              description: "Sampling duration in seconds (3–120, default 30).",
+            },
+            event: {
+              type: "string",
+              enum: ["cpu", "alloc", "wall", "lock"],
+              description:
+                "What to sample: cpu (CPU time; itimer on macOS), alloc (allocations), wall (wall-clock), lock (lock contention). Default cpu.",
+            },
+          },
+        },
+        handler: async (ctx) => profileAppAwait({ duration: ctx.input?.duration, event: ctx.input?.event }),
+      },
+      {
         name: "fix_issue",
         description:
-          "Send a context-rich request into this chat asking to fix the current problem. Kind: compile (build failed), package (package failed), test (failing tests), run-java/run-spring/run-quarkus (startup failure), or mcp (advisor scan findings).",
+          "Send a context-rich request into this chat asking to fix the current problem. Kind: compile (build failed), package (package failed), test (failing tests), run-java/run-spring/run-quarkus (startup failure), profile (optimize the flame-graph hotspots), or mcp (advisor scan findings).",
         inputSchema: {
           type: "object",
           properties: {
             kind: {
               type: "string",
-              enum: ["compile", "package", "test", "run-java", "run-spring", "run-quarkus", "mcp"],
+              enum: ["compile", "package", "test", "run-java", "run-spring", "run-quarkus", "profile", "mcp"],
               description: "Which failure to fix.",
             },
             tool: { type: "string", description: "For kind=mcp: the scan tool name." },

--- a/public/app.js
+++ b/public/app.js
@@ -64,11 +64,30 @@ const devtoolsInput = document.getElementById("in-devtools");
 const setRandomport = document.getElementById("set-randomport");
 const randomportInput = document.getElementById("in-randomport");
 const openBrowserInput = document.getElementById("in-openbrowser");
+const autoProfileInput = document.getElementById("in-autoprofile");
 const btnOpenBrowser = document.getElementById("btn-open-browser");
 const btnFix = document.getElementById("btn-fix");
 const btnStopMaven = document.getElementById("btn-stop-maven");
 const btnStopRun = document.getElementById("btn-stop-run");
 const btnRun = document.getElementById("btn-run");
+// Run-tab flame graph (async-profiler) controls.
+const flameEvent = document.getElementById("flame-event");
+const flameDuration = document.getElementById("flame-duration");
+const btnProfile = document.getElementById("btn-profile");
+const btnProfileStop = document.getElementById("btn-profile-stop");
+const flameStatus = document.getElementById("flame-status");
+const flameSearch = document.getElementById("flame-search");
+const btnFlameReset = document.getElementById("btn-flame-reset");
+const btnFlameFix = document.getElementById("btn-flame-fix");
+const flameUnavailable = document.getElementById("flame-unavailable");
+const flameMsg = document.getElementById("flame-msg");
+const flameCmd = document.getElementById("flame-cmd");
+const flameCopied = document.getElementById("flame-copied");
+const flameDocs = document.getElementById("flame-docs");
+const flameEmpty = document.getElementById("flame-empty");
+const flameInfo = document.getElementById("flame-info");
+const flameGraph = document.getElementById("flame-graph");
+const flameHotspots = document.getElementById("flame-hotspots");
 // Running spinners on each trigger button and tab. The Test tab keeps its
 // badge/progress feedback too; the spinner shows only while the run is busy.
 const btnSpin = {
@@ -148,6 +167,22 @@ if (jdtlsCmd) {
   };
 }
 
+if (flameCmd) {
+  flameCmd.onclick = async () => {
+    try {
+      await navigator.clipboard.writeText(flameCmd.textContent.trim());
+      flameCopied.hidden = false;
+      setTimeout(() => (flameCopied.hidden = true), 1500);
+    } catch {
+      const r = document.createRange();
+      r.selectNodeContents(flameCmd);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(r);
+    }
+  };
+}
+
 // Click the status command to copy the full (untruncated) command.
 cmdEl.addEventListener("click", async () => {
   const text = cmdEl.dataset.copy;
@@ -190,11 +225,23 @@ document.querySelectorAll(".tab").forEach((t) => (t.onclick = () => showTab(t.da
 
 // Test tab: Graphical / Console sub-toggle (graphical is the default).
 function showTestView(view) {
-  document.querySelectorAll(".subtab").forEach((t) => t.classList.toggle("active", t.dataset.tview === view));
+  document
+    .querySelectorAll(".subtab[data-tview]")
+    .forEach((t) => t.classList.toggle("active", t.dataset.tview === view));
   document.getElementById("tests").classList.toggle("active", view === "graphical");
   document.getElementById("test-console").classList.toggle("active", view === "console");
 }
-document.querySelectorAll(".subtab").forEach((t) => (t.onclick = () => showTestView(t.dataset.tview)));
+document.querySelectorAll(".subtab[data-tview]").forEach((t) => (t.onclick = () => showTestView(t.dataset.tview)));
+
+// Run tab: Console / Flame graph sub-toggle (console is the default).
+function showRunView(view) {
+  document
+    .querySelectorAll(".subtab[data-rview]")
+    .forEach((t) => t.classList.toggle("active", t.dataset.rview === view));
+  document.getElementById("run-console").classList.toggle("active", view === "console");
+  document.getElementById("run-flame").classList.toggle("active", view === "flame");
+}
+document.querySelectorAll(".subtab[data-rview]").forEach((t) => (t.onclick = () => showRunView(t.dataset.rview)));
 
 // Aside sub-tabs (Live JVM Metrics / Settings)
 function showAsideTab(name) {
@@ -377,6 +424,10 @@ function renderStatus(s) {
   btnOpenBrowser.title = run.appPort
     ? `Open http://127.0.0.1:${run.appPort} in your browser`
     : "The app isn't running yet";
+  // The flame-graph Record button needs both async-profiler installed and the
+  // app actually running (the run lane busy).
+  runActive = !!(run.busy || run.appPort);
+  updateProfileButton();
   // The two grouped Stop buttons are global, not tied to the active tab:
   // the Maven Stop covers build/test/package; the Run Stop covers run.
   const mvnBusy = laneActive(s, "build") || laneActive(s, "test") || laneActive(s, "package");
@@ -947,6 +998,14 @@ function applySettingsState(s) {
   devtoolsInput.checked = s.devtools === true;
   randomportInput.checked = s.randomPort === true;
   openBrowserInput.checked = s.openBrowser === true;
+  if (autoProfileInput) autoProfileInput.checked = s.autoProfile === true;
+  if (flameEvent && typeof s.autoProfileEvent === "string" && document.activeElement !== flameEvent) {
+    flameEvent.value = s.autoProfileEvent;
+  }
+  if (flameDuration && s.autoProfileDuration != null && document.activeElement !== flameDuration) {
+    const want = String(s.autoProfileDuration);
+    if ([...flameDuration.options].some((o) => o.value === want)) flameDuration.value = want;
+  }
   if (document.activeElement !== springInput && typeof s.springProfiles === "string") {
     springInput.value = s.springProfiles;
   }
@@ -1011,6 +1070,7 @@ function applyEnv(env) {
     warmDocs.href = install.url || "https://github.com/apache/maven-mvnd";
   }
   applySettingsState(env && env.settings);
+  applyProfilerEnv(env && env.profiler);
 }
 
 async function post(path, body) {
@@ -1267,6 +1327,9 @@ function saveSettings() {
     devtools: devtoolsInput.checked,
     randomPort: randomportInput.checked,
     openBrowser: openBrowserInput.checked,
+    autoProfile: autoProfileInput ? autoProfileInput.checked : false,
+    autoProfileEvent: flameEvent ? flameEvent.value : "cpu",
+    autoProfileDuration: flameDuration ? Number(flameDuration.value) : 30,
   });
 }
 warmInput.addEventListener("change", saveSettings);
@@ -1274,6 +1337,9 @@ devtoolsInput.addEventListener("change", saveSettings);
 randomportInput.addEventListener("change", saveSettings);
 openBrowserInput.addEventListener("change", saveSettings);
 springInput.addEventListener("change", saveSettings);
+if (autoProfileInput) autoProfileInput.addEventListener("change", saveSettings);
+if (flameEvent) flameEvent.addEventListener("change", saveSettings);
+if (flameDuration) flameDuration.addEventListener("change", saveSettings);
 
 btnFix.onclick = async () => {
   const kind = btnFix.dataset.kind;
@@ -1331,6 +1397,7 @@ es.addEventListener("status", (e) => {
   followLaneActivity(s);
 });
 es.addEventListener("metrics", (e) => renderMetrics(JSON.parse(e.data)));
+es.addEventListener("profile", (e) => renderProfileState(JSON.parse(e.data)));
 es.addEventListener("test-progress", (e) => {
   renderTestProgress(JSON.parse(e.data));
 });
@@ -1373,6 +1440,7 @@ fetch(`/api/state?${qs}`)
     renderStatus(s.status);
     renderMetrics(s.metrics);
     applyEnv(s.env);
+    if (s.profile) renderProfileState(s.profile);
     if (s.status && s.status.test) lastRunnerLabel = s.status.test.runnerLabel;
     renderTests(s.tests, { runnerLabel: lastRunnerLabel });
     for (const l of s.console || []) appendLine(l.line, l.stream, l.op);
@@ -1445,3 +1513,231 @@ document.addEventListener("click", (e) => {
   e.preventDefault();
   post("/api/open-url", { url: a.href });
 });
+
+// ---------------------------------------------------------------------------
+// Run tab: async-profiler flame graph
+// ---------------------------------------------------------------------------
+let profilerEnv = null; // env.profiler capability snapshot
+let runActive = false; // app currently running (run lane busy / has a port)
+let profileState = { status: "idle" };
+let lastFlameFinishedAt = 0;
+let flameRootNode = null; // full tree root from the last run
+let flameZoomNode = null; // currently displayed (zoomed) subtree root
+let flameTotal = 0; // grand-total samples (for absolute %)
+const profileSpin = btnProfile && btnProfile.querySelector(".btn-spin");
+
+const EVENT_LABELS = { cpu: "CPU", alloc: "allocations", wall: "wall clock", lock: "lock contention" };
+const eventLabel = (e) => EVENT_LABELS[e] || e || "CPU";
+const fmtInt = (n) => Number(n || 0).toLocaleString();
+
+// Enable Record only when async-profiler is available AND the app is running AND
+// no run is already in flight.
+function updateProfileButton() {
+  if (!btnProfile) return;
+  const avail = !!(profilerEnv && profilerEnv.available && profilerEnv.supported);
+  const running = profileState.status === "running";
+  btnProfile.disabled = !avail || !runActive || running;
+  btnProfile.title = !avail
+    ? "async-profiler isn't available"
+    : !runActive
+      ? "Start the app with Run before recording a flame graph"
+      : running
+        ? "A profiling run is already in progress"
+        : "Record a flame graph from the running app";
+}
+
+// Show / hide the install banner and gate the controls on the profiler snapshot.
+function applyProfilerEnv(p) {
+  profilerEnv = p || null;
+  const supported = !!(p && p.supported);
+  const available = !!(p && p.available);
+  if (flameUnavailable) {
+    if (!supported) {
+      flameUnavailable.hidden = false;
+      flameMsg.textContent = "async-profiler has no Windows build, so flame graphs aren't available on this platform.";
+      flameCmd.hidden = true;
+      flameDocs.href = (p && p.install && p.install.url) || "https://github.com/async-profiler/async-profiler";
+    } else if (!available) {
+      flameUnavailable.hidden = false;
+      const inst = (p && p.install) || {};
+      const os = inst.os ? ` on ${inst.os}` : "";
+      flameMsg.innerHTML =
+        `<strong>async-profiler</strong> isn't installed${os}, so flame graphs are disabled. ` +
+        (inst.cmd ? "Install it to enable them:" : "Install it (and reopen the canvas) to enable them:");
+      if (inst.cmd) {
+        flameCmd.textContent = inst.cmd;
+        flameCmd.hidden = false;
+      } else {
+        flameCmd.hidden = true;
+      }
+      flameDocs.href = inst.url || "https://github.com/async-profiler/async-profiler";
+    } else {
+      flameUnavailable.hidden = true;
+    }
+  }
+  updateProfileButton();
+}
+
+// Apply a profile-state snapshot (from SSE `profile` or /api/state). Drives the
+// status line, the Stop button, the Record spinner, and triggers a data fetch
+// when a run completes.
+function renderProfileState(p) {
+  if (!p) return;
+  profileState = p;
+  const running = p.status === "running";
+  if (btnProfileStop) btnProfileStop.hidden = !running;
+  if (profileSpin) profileSpin.hidden = !running;
+  if (flameStatus) {
+    if (running) {
+      flameStatus.textContent = `Sampling ${eventLabel(p.event)}${p.pid ? ` (pid ${p.pid})` : ""} for ${p.duration}s\u2026`;
+      flameStatus.className = "muted";
+    } else if (p.status === "done") {
+      flameStatus.textContent = `${fmtInt(p.total)} samples \u00b7 ${eventLabel(p.event)} \u00b7 ${p.duration}s`;
+      flameStatus.className = "muted ok";
+    } else if (p.status === "error") {
+      flameStatus.textContent = p.error || "Profiling failed.";
+      flameStatus.className = "muted err";
+    } else {
+      flameStatus.textContent = "";
+      flameStatus.className = "muted";
+    }
+  }
+  updateProfileButton();
+  if (p.status === "done" && p.hasGraph && p.finishedAt && p.finishedAt !== lastFlameFinishedAt) {
+    lastFlameFinishedAt = p.finishedAt;
+    fetchFlameData();
+  }
+}
+
+async function fetchFlameData() {
+  try {
+    const r = await fetch(`/api/profile/data?${qs}`);
+    const d = await r.json();
+    if (d && d.flame) renderFlameData(d);
+  } catch {
+    /* leave the previous graph in place */
+  }
+}
+
+function renderFlameData(d) {
+  flameRootNode = d.flame;
+  flameZoomNode = flameRootNode;
+  flameTotal = d.total || (d.flame && d.flame.v) || 0;
+  if (flameEmpty) flameEmpty.hidden = true;
+  if (flameGraph) flameGraph.hidden = false;
+  if (flameSearch) flameSearch.hidden = false;
+  if (btnFlameReset) btnFlameReset.hidden = false;
+  if (btnFlameFix) btnFlameFix.hidden = false;
+  renderFlame();
+  renderHotspots(d.top || []);
+}
+
+// Warm-hued, stable per-frame colour (orange→yellow) derived from the name hash.
+function frameColor(name) {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  const hue = 12 + (h % 42); // 12..53: reds → oranges → yellows
+  const sat = 72 + (h % 14); // 72..85%
+  const lig = 48 + (h % 12); // 48..59%
+  return `hsl(${hue} ${sat}% ${lig}%)`;
+}
+
+const FLAME_ROW = 22;
+// Lay out the current (zoom) subtree as absolutely-positioned divs: width is the
+// fraction of the zoom root's samples, top is depth * row height.
+function renderFlame() {
+  if (!flameZoomNode || !flameGraph) return;
+  const total = flameZoomNode.v || 1;
+  const q = (flameSearch && flameSearch.value.trim().toLowerCase()) || "";
+  const rows = [];
+  let maxDepth = 0;
+  (function layout(node, depth, x0) {
+    if (depth > maxDepth) maxDepth = depth;
+    rows.push({ node, depth, x: x0, w: node.v / total });
+    let cx = x0;
+    for (const ch of node.c || []) {
+      layout(ch, depth + 1, cx);
+      cx += ch.v / total;
+    }
+  })(flameZoomNode, 0, 0);
+  flameGraph.style.height = (maxDepth + 1) * FLAME_ROW + "px";
+  const frag = document.createDocumentFragment();
+  for (const f of rows) {
+    const div = document.createElement("div");
+    div.className = "flame-frame";
+    div.style.left = (f.x * 100).toFixed(4) + "%";
+    div.style.width = Math.max(0, f.w * 100).toFixed(4) + "%";
+    div.style.top = f.depth * FLAME_ROW + "px";
+    div.style.background = frameColor(f.node.n);
+    if (q && f.node.n.toLowerCase().includes(q)) div.classList.add("match");
+    const span = document.createElement("span");
+    span.textContent = f.node.n;
+    div.appendChild(span);
+    div.title = f.node.n;
+    div.onclick = () => {
+      flameZoomNode = f.node;
+      renderFlame();
+    };
+    div.onmouseenter = () => showFrameInfo(f.node);
+    frag.appendChild(div);
+  }
+  flameGraph.replaceChildren(frag);
+}
+
+function showFrameInfo(node) {
+  if (!flameInfo) return;
+  flameInfo.hidden = false;
+  const pct = flameTotal ? (node.v / flameTotal) * 100 : 0;
+  flameInfo.innerHTML = `<code>${esc(node.n)}</code> &middot; ${fmtInt(node.v)} samples (${pct.toFixed(2)}%)`;
+}
+
+function renderHotspots(top) {
+  if (!flameHotspots) return;
+  if (!top.length) {
+    flameHotspots.innerHTML = "";
+    return;
+  }
+  const rows = top
+    .map((h) => {
+      const pct = (h.pct * 100).toFixed(1);
+      const bar = Math.min(100, h.pct * 100).toFixed(1);
+      return (
+        `<div class="hot"><span class="hot-bar" style="width:${bar}%"></span>` +
+        `<span class="hot-name" title="${esc(h.name)}">${esc(h.name)}</span>` +
+        `<span class="hot-pct">${pct}%</span></div>`
+      );
+    })
+    .join("");
+  flameHotspots.innerHTML = `<div class="hot-head">Top self-time hotspots</div>${rows}`;
+}
+
+// Start a profiling run using the currently-selected event + duration (the manual
+// Record button). Auto-record at startup is handled by the backend.
+async function startProfileRun() {
+  const event = flameEvent ? flameEvent.value : "cpu";
+  const duration = (flameDuration && Number(flameDuration.value)) || 30;
+  if (flameStatus) {
+    flameStatus.textContent = "Starting\u2026";
+    flameStatus.className = "muted";
+  }
+  const r = await postJson("/api/profile", { event, duration });
+  if (r && r.ok === false && r.error && flameStatus) {
+    flameStatus.textContent = r.error;
+    flameStatus.className = "muted err";
+  }
+}
+
+if (btnProfile) btnProfile.onclick = () => startProfileRun();
+if (btnProfileStop) btnProfileStop.onclick = () => post("/api/profile/stop", {});
+if (btnFlameReset)
+  btnFlameReset.onclick = () => {
+    if (!flameRootNode) return;
+    flameZoomNode = flameRootNode;
+    renderFlame();
+  };
+if (flameSearch) flameSearch.oninput = () => renderFlame();
+if (btnFlameFix)
+  btnFlameFix.onclick = () => {
+    post("/api/fix", { kind: "profile" });
+    appendLine("[canvas] asked Copilot to analyze the flame-graph hotspots.", "stdout", "run");
+  };

--- a/public/index.html
+++ b/public/index.html
@@ -151,7 +151,73 @@
               Open in browser
             </button>
           </div>
-          <pre id="run-console" class="term" aria-label="Run output"></pre>
+          <div class="subtabs" role="tablist" aria-label="Run view">
+            <button class="subtab active" data-rview="console">Console</button>
+            <button class="subtab" data-rview="flame">Flame graph</button>
+          </div>
+          <div class="subpane-wrap">
+            <pre id="run-console" class="tsub term active" aria-label="Run output"></pre>
+            <section id="run-flame" class="tsub" aria-label="CPU flame graph">
+              <div class="flame-bar">
+                <label class="flame-ctl">
+                  Event
+                  <select id="flame-event" title="What async-profiler samples">
+                    <option value="cpu">CPU</option>
+                    <option value="alloc">Allocations</option>
+                    <option value="wall">Wall clock</option>
+                    <option value="lock">Lock contention</option>
+                  </select>
+                </label>
+                <label class="flame-ctl">
+                  Duration
+                  <select id="flame-duration" title="Sampling duration">
+                    <option value="15">15s</option>
+                    <option value="30" selected>30s</option>
+                    <option value="60">60s</option>
+                    <option value="90">90s</option>
+                    <option value="120">120s</option>
+                  </select>
+                </label>
+                <button id="btn-profile" class="primary tiny"><span class="btn-spin" hidden></span>Record</button>
+                <button id="btn-profile-stop" class="danger tiny" hidden>Stop</button>
+                <label
+                  class="switch flame-auto"
+                  id="autoprofile-toggle"
+                  title="Automatically start a recording when the app becomes reachable"
+                >
+                  <input type="checkbox" id="in-autoprofile" />
+                  <span class="track"><span class="thumb"></span></span>
+                  <span class="switch-label">Automatically record at startup</span>
+                </label>
+                <span id="flame-status" class="muted"></span>
+                <input
+                  id="flame-search"
+                  class="flame-search"
+                  type="search"
+                  placeholder="Search frames…"
+                  hidden
+                  autocomplete="off"
+                />
+                <button id="btn-flame-reset" class="tiny" hidden title="Reset zoom">Reset zoom</button>
+                <button id="btn-flame-fix" class="fix tiny" hidden style="margin-left: auto">
+                  Analyze hotspots with Copilot
+                </button>
+              </div>
+              <div id="flame-unavailable" class="banner setting-banner" hidden>
+                <span id="flame-msg"></span>
+                <code id="flame-cmd" title="Click to copy" hidden></code>
+                <span id="flame-copied" class="copied" hidden>copied</span>
+                <a id="flame-docs" href="#" target="_blank" rel="noopener">install guide</a>
+              </div>
+              <p id="flame-empty" class="muted flame-empty">
+                Start the app with <strong>Run</strong>, then click <strong>Record</strong> to capture a flame graph
+                from the live JVM.
+              </p>
+              <div id="flame-info" class="flame-info" hidden></div>
+              <div id="flame-graph" class="flame-graph" hidden></div>
+              <div id="flame-hotspots" class="flame-hotspots"></div>
+            </section>
+          </div>
         </section>
       </div>
       <aside>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1369,3 +1369,151 @@ button.is-restarting .btn-spin::before {
     scroll-behavior: auto !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Run tab: async-profiler flame graph
+--------------------------------------------------------------------------- */
+#run-flame {
+  display: none;
+  padding: 0.75rem;
+}
+#run-flame.active {
+  display: block;
+}
+.flame-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.6rem;
+}
+.flame-ctl {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 12px;
+  color: var(--text-color-muted, #656d76);
+}
+.flame-ctl select {
+  font-size: 12px;
+  padding: 0.15rem 0.3rem;
+  border-radius: 5px;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  background: var(--background-color-default, #fff);
+  color: var(--text-color-default, #1f2328);
+}
+.flame-search {
+  font-size: 12px;
+  padding: 0.2rem 0.45rem;
+  border-radius: 5px;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  background: var(--background-color-default, #fff);
+  color: var(--text-color-default, #1f2328);
+  min-width: 9rem;
+}
+.flame-auto {
+  font-size: 12px;
+  color: var(--text-color-muted, #656d76);
+  gap: 0.35rem;
+}
+.muted.ok {
+  color: var(--true-color-green, #1a7f37);
+}
+.muted.err {
+  color: var(--true-color-red, #cf222e);
+}
+.flame-empty {
+  margin: 1rem 0;
+}
+.flame-info {
+  font-size: 11.5px;
+  color: var(--text-color-muted, #656d76);
+  min-height: 1.2em;
+  margin-bottom: 0.35rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.flame-info code {
+  font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+  color: var(--text-color-default, #1f2328);
+}
+.flame-graph {
+  position: relative;
+  width: 100%;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  border-radius: 6px;
+  background: var(--background-color-muted, #f6f8fa);
+  overflow: hidden;
+}
+.flame-frame {
+  position: absolute;
+  height: 21px;
+  box-sizing: border-box;
+  border: 1px solid color-mix(in srgb, #000 14%, transparent);
+  border-radius: 2px;
+  overflow: hidden;
+  cursor: pointer;
+  font-size: 11px;
+  line-height: 19px;
+  color: #1b1300;
+  transition: filter var(--dur-fast) var(--ease-out);
+}
+.flame-frame:hover {
+  filter: brightness(1.12);
+}
+.flame-frame > span {
+  display: block;
+  padding: 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+.flame-frame.match {
+  outline: 2px solid var(--true-color-blue, #0969da);
+  outline-offset: -2px;
+}
+.flame-hotspots {
+  margin-top: 0.9rem;
+}
+.hot-head {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-color-muted, #656d76);
+  margin-bottom: 0.4rem;
+}
+.hot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0.4rem;
+  font-size: 12px;
+  border-radius: 4px;
+}
+.hot-bar {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: color-mix(in srgb, var(--true-color-orange, #bc4c00) 16%, transparent);
+  border-radius: 4px;
+  z-index: 0;
+}
+.hot-name {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+  color: var(--text-color-default, #1f2328);
+}
+.hot-pct {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  color: var(--text-color-muted, #656d76);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary

Adds an on-demand flame graph to Coffilot's Run tab so you can find performance hotspots in a running app without leaving the canvas. It is powered by async-profiler (`asprof`), supports four sampling modes (CPU / allocations / wall-clock / lock contention), and degrades gracefully when the profiler is not installed.

How it fits together:

- **Detection & attach.** `asprof` is discovered on `PATH` / `ASYNC_PROFILER_HOME` / common install dirs (mirrors the `mvnd` detection). The app JVM is resolved via `lsof` on the app port, which works for forked `spring-boot:run` / `bootRun` / `quarkus:dev` / `quarkusDev`, falling back to the run lane child pid for plain `java`.
- **Record & parse.** A fixed-duration run uses async-profiler's collapsed output, parsed server-side into a flame tree plus top self-time hotspots. Progress streams to the client over SSE.
- **UI.** The Run pane gains Console / Flame graph subtabs with an interactive flamegraph (zoom, hover, search), a hotspots list, and an "Analyze with Copilot" bridge. A new `profile_app` agent action and a `fix_issue` "profile" kind expose the same capability to the agent.
- **Auto-record.** An optional "Automatically record at startup" toggle (off by default) records once when the app first becomes reachable. The trigger is backend-driven from `finishMetrics` (the authoritative "app is up" moment) rather than a fragile frontend edge, and it logs a clear reason to the Run console when it cannot record.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

- **Platform support.** CPU sampling maps to `itimer` on macOS (perf_events is unavailable there), so macOS CPU graphs are timer-based. async-profiler has no Windows build, so the feature shows an install/unsupported hint there.
- **Default duration.** Sampling defaults to 30s (options 15/30/60/90/120s, clamped 3-120s on the backend). 15s was too short to produce a representative graph; 30s balances interactive feedback against sample quality, with longer captures available for low-traffic apps.
- The auto-record event/duration follow the same dropdowns and persist across reloads. Stale saved durations that are no longer dropdown options are ignored rather than blanking the control.