### PR TITLE
Live log viewer, runtime log levels, and a collapsible Live JVM panel

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -41,6 +41,10 @@ Shipped in the extension today:
   cross-platform detected.
 - Live JVM metrics tiered BootUI → Actuator → Quarkus Micrometer/health → process,
   with a source badge.
+- Live log viewer on the Run console (minimum-severity filter + text search, with
+  severity-colored lines and inherited levels for stack traces) and runtime log-level
+  control via Spring Boot Actuator `/loggers` (a Loggers side tab + the `set_log_level`
+  action), so loggers can be changed live without a restart.
 - "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
   startup failures, and for BootUI advisor-scan findings.
 - BootUI MCP server toggle + advisor scans when the running app exposes BootUI.
@@ -50,7 +54,7 @@ Shipped in the extension today:
   `MAVEN_OPTS` / `GRADLE_OPTS`) and, for Maven, the app JVM to silence JDK
   native-access warnings.
 - Agent-facing actions: `build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`.
+  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`, `set_log_level`.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,22 @@ wins; when neither is found the console says so and stays disabled until one is 
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,
   threads, health, profiles and startup info, sourced from the richest endpoint
   available (BootUI → Actuator → Quarkus Micrometer/health → process).
+- **Live logs &amp; log levels** &mdash; the Run console doubles as a log viewer with a
+  minimum-severity filter and text search (stack-trace lines inherit their parent
+  level, and lines are colored by severity). A **Loggers** side tab lists the running
+  app's loggers from Spring Boot Actuator <code>/loggers</code> and lets you change any
+  level live &mdash; no restart &mdash; so you can flip a package to <code>DEBUG</code>,
+  reproduce, and dial it back.
 - **Fix with Copilot** &mdash; on a compile error, failing tests, or a startup
   crash, a button pushes a context-rich request back into the chat so the agent
   can diagnose and fix it.
+- **Responsive layout** &mdash; on a wide canvas the **Live JVM / Loggers / Settings**
+  panel is docked on the right; as the canvas narrows it collapses to an icon rail on
+  the right edge, and tapping an icon slides that pane out as an overlay over the main
+  console. A toggle button (the chevron in the panel's tab bar / rail) hides or shows
+  the panel on demand in any layout &mdash; even when docked &mdash; so you can give the
+  console the full width (tap a rail icon, the chevron, or press <kbd>Esc</kbd> to
+  bring it back).
 - **Keep the JVM warm** &mdash; optionally use the [Maven Daemon (`mvnd`)](https://github.com/apache/maven-mvnd)
   (Maven) or the always-on **Gradle daemon** for Build / Test / Package so repeat runs
   skip JVM startup and JIT warmup.
@@ -70,7 +83,7 @@ The console adapts to whatever the project provides, detected from the build fil
 | **Java** (base)               | `pom.xml` / `mvnw` or `build.gradle` / `gradlew`  | Build, Test (graphical JUnit report), Package                                                                                                                                                                                           |
 | **Spring Boot**               | Spring Boot Maven plugin / Gradle plugin          | Run via `spring-boot:run` (Maven) or `bootRun` (Gradle) + editable Spring profiles. (No Spring Boot ⇒ the generic runner uses the Gradle `application` plugin, an executable `java -jar`, or the configured main class via `java -cp`.) |
 | **Quarkus**                   | Quarkus Maven plugin / `io.quarkus` Gradle plugin | Run via `quarkus:dev` (Maven) or `quarkusDev` (Gradle) — dev mode with built-in live reload — + editable Quarkus profile                                                                                                                |
-| **Actuator** (runtime)        | `/actuator/*` or `/management/*` answers          | Live metrics normalized from Actuator — JSON `/metrics` endpoint or the Prometheus scrape (heap, threads, health, uptime)                                                                                                               |
+| **Actuator** (runtime)        | `/actuator/*` or `/management/*` answers          | Live metrics normalized from Actuator — JSON `/metrics` endpoint or the Prometheus scrape (heap, threads, health, uptime) — plus runtime log-level control when `/loggers` is exposed                                                   |
 | **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health                                                                                                                                                          |
 | **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the MCP advisor-scan panel                                                                                                                                                                                  |
 
@@ -141,8 +154,8 @@ In a Copilot app session on a Maven or Gradle project, open the **Coffilot** can
 5. **Stop** when done.
 
 The agent can drive the same flow with the `build_app`, `run_tests`,
-`package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`
-and `run_scan` actions.
+`package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`,
+`run_scan` and `set_log_level` actions.
 
 ## How it works
 
@@ -157,6 +170,8 @@ Coffilot is a Node process (the extension) that:
   proxying [BootUI](https://github.com/jdubois/boot-ui)'s sanitized `/bootui/api/**`
   DTOs when present and falling back to Spring Boot Actuator, then to Quarkus
   Micrometer/health (`/q/*`), then to coarse process metrics;
+- proxies Spring Boot Actuator `/loggers` so the canvas can read and change logger
+  levels on the running app without a restart;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 
 The loopback HTTP server that backs the iframe binds to `127.0.0.1` only. See

--- a/extension.mjs
+++ b/extension.mjs
@@ -1269,6 +1269,7 @@ const app = {
   appUp: false,
   appReachedUp: false, // app served a metrics endpoint at least once this run
   actuatorPrefix: null, // discovered Actuator base path this run (/actuator or /management)
+  loggersPrefix: null, // discovered Actuator base path that serves /loggers this run
   module: null, // module selected for the current run (for live reload)
   mavenProfiles: null, // Maven profiles used for the current run (for live reload)
 };
@@ -1693,6 +1694,10 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
         app.appUp = false;
         stopMetricsPolling();
         stopLiveReload();
+        // The app is gone: reset the cached metrics so the panel (and the
+        // Loggers tab, which keys off appUp) reflect "not running" instead of the
+        // last polled reading, which still said appUp:true.
+        lastMetrics = { appUp: false };
         broadcast("metrics", lastMetrics);
         // A run that exits non-zero before the app ever served metrics is a
         // startup crash (surface a Fix button); otherwise it was a clean stop.
@@ -1946,6 +1951,7 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   app.appUp = false;
   app.appReachedUp = false;
   app.actuatorPrefix = null;
+  app.loggersPrefix = null;
   csrfToken = null;
   lastMetrics = { appUp: false };
 
@@ -3427,6 +3433,119 @@ async function mcpScan(tool) {
 }
 
 // ---------------------------------------------------------------------------
+// Runtime log levels — Spring Boot Actuator /loggers (read + live change)
+// ---------------------------------------------------------------------------
+// The /loggers endpoint lists every logger with its configured/effective level
+// and accepts a POST to change a level without restarting the app — the inner-loop
+// equivalent of an IDE's runtime log-level control. It lives under the same base
+// path as the other Actuator endpoints (/actuator or /management), so we reuse the
+// prefix discovered by the metrics tier when we have it.
+
+const DEFAULT_LOG_LEVELS = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+/**
+ * Generic CSRF-aware POST against the running app: seed an XSRF-TOKEN from a prior
+ * GET on the same app (Spring Security's SPA CSRF protection), echo it back on the
+ * write, and refresh once on a 403. Self-contained so it works for a plain Actuator
+ * app (no token seeded → posts without the header, which succeeds when the endpoint
+ * isn't behind CSRF) as well as a secured one.
+ */
+async function appPostCsrf(base, seedPath, postPath, body) {
+  let token = null;
+  const seed = async () => {
+    try {
+      const res = await fetch(base + seedPath, { headers: { Accept: "application/json" } });
+      const m = (res.headers.get("set-cookie") || "").match(/XSRF-TOKEN=([^;]+)/);
+      if (m) token = decodeURIComponent(m[1]);
+      await res.text().catch(() => null);
+    } catch {
+      // No token available; the POST will surface any resulting 403.
+    }
+  };
+  const send = async () => {
+    const headers = { "Content-Type": "application/json", Accept: "application/json" };
+    if (token) {
+      headers["X-XSRF-TOKEN"] = token;
+      headers["Cookie"] = `XSRF-TOKEN=${encodeURIComponent(token)}`;
+    }
+    return fetch(base + postPath, { method: "POST", headers, body: JSON.stringify(body ?? {}) });
+  };
+  await seed();
+  let res = await send();
+  if (res.status === 403) {
+    token = null;
+    await seed();
+    res = await send();
+  }
+  return res;
+}
+
+/**
+ * Read the running app's loggers from Actuator. Returns the available levels and a
+ * normalized logger list (ROOT first, then alphabetical), or { available:false } when
+ * the app is down or exposes no /loggers endpoint.
+ */
+async function loggersStatus() {
+  const base = appBase();
+  if (!base) return { available: false };
+  // Prefer the prefix the metrics tier already confirmed, then the usual candidates.
+  const prefixes = app.actuatorPrefix
+    ? [app.actuatorPrefix, ...ACTUATOR_PREFIXES.filter((p) => p !== app.actuatorPrefix)]
+    : ACTUATOR_PREFIXES;
+  for (const prefix of prefixes) {
+    const json = await fetchJson(base, `${prefix}/loggers`);
+    if (!json || !json.loggers) continue;
+    app.loggersPrefix = prefix;
+    const levels = Array.isArray(json.levels) && json.levels.length ? json.levels : DEFAULT_LOG_LEVELS;
+    const loggers = Object.entries(json.loggers).map(([name, v]) => ({
+      name,
+      configuredLevel: (v && v.configuredLevel) || null,
+      effectiveLevel: (v && v.effectiveLevel) || null,
+    }));
+    loggers.sort((a, b) => (a.name === "ROOT" ? -1 : b.name === "ROOT" ? 1 : a.name.localeCompare(b.name)));
+    return { available: true, prefix, levels, loggers };
+  }
+  return { available: false };
+}
+
+/**
+ * Change one logger's level live. A null/empty level resets it to its default
+ * (inherited) level. Returns { ok, status } with the refreshed logger list so the UI
+ * (and agent) immediately see the new effective levels.
+ */
+async function setLoggerLevel(name, level) {
+  const base = appBase();
+  if (!base) return { ok: false, error: "App is not running." };
+  if (!name) return { ok: false, error: "No logger specified." };
+  const lvl = level ? String(level).toUpperCase() : null;
+  if (lvl && !DEFAULT_LOG_LEVELS.includes(lvl)) return { ok: false, error: `Unknown level "${level}".` };
+  // The agent's set_log_level action can run before any GET has cached the
+  // Actuator base path, so discover it now (this also rejects apps with no
+  // /loggers endpoint up front rather than blindly POSTing to /actuator).
+  if (!app.loggersPrefix) await loggersStatus();
+  if (!app.loggersPrefix) {
+    return { ok: false, error: "The app's /loggers endpoint isn't exposed (or is read-only)." };
+  }
+  const prefix = app.loggersPrefix;
+  try {
+    const res = await appPostCsrf(base, `${prefix}/loggers`, `${prefix}/loggers/${encodeURIComponent(name)}`, {
+      configuredLevel: lvl,
+    });
+    await res.text().catch(() => null);
+    if (!res.ok) {
+      const why =
+        res.status === 404
+          ? "The app's /loggers endpoint isn't exposed (or is read-only)."
+          : `Actuator returned ${res.status}.`;
+      return { ok: false, error: why, status: await loggersStatus() };
+    }
+    return { ok: true, name, level: lvl, status: await loggersStatus() };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Loopback HTTP server (iframe assets + SSE + control + metrics proxy)
 // ---------------------------------------------------------------------------
 
@@ -3632,6 +3751,16 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  if (req.method === "GET" && url.pathname === "/api/loggers") {
+    sendJson(res, 200, await loggersStatus());
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/loggers") {
+    const body = await readBody(req);
+    sendJson(res, 200, await setLoggerLevel(body.name, body.level));
+    return;
+  }
+
   res.writeHead(404);
   res.end("Not found");
 });
@@ -3832,6 +3961,24 @@ function makeCanvas() {
           required: ["tool"],
         },
         handler: async (ctx) => mcpScan(ctx.input?.tool),
+      },
+      {
+        name: "set_log_level",
+        description:
+          "Change a logger's level at runtime on the running app via Spring Boot Actuator /loggers (no restart). Requires the app up with the loggers endpoint exposed. e.g. logger=com.example.service level=DEBUG. Omit level to reset the logger to its inherited default.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            logger: { type: "string", description: "Logger name, e.g. com.example.service or ROOT." },
+            level: {
+              type: "string",
+              enum: ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"],
+              description: "Level to set; omit to reset the logger to its default.",
+            },
+          },
+          required: ["logger"],
+        },
+        handler: async (ctx) => setLoggerLevel(ctx.input?.logger, ctx.input?.level || null),
       },
     ],
     open: async (ctx) => {

--- a/public/app.js
+++ b/public/app.js
@@ -196,13 +196,74 @@ function showTestView(view) {
 }
 document.querySelectorAll(".subtab").forEach((t) => (t.onclick = () => showTestView(t.dataset.tview)));
 
-// Aside sub-tabs (Live JVM Metrics / Settings)
+// Aside sub-tabs (Live JVM Metrics / Loggers / Settings) and the collapsible
+// right panel. #workspace.aside-open = expanded (the pane body is shown);
+// #workspace.aside-rail = render the vertical icon rail instead of the docked
+// panel. The rail is used automatically on a narrow canvas, or on demand (via the
+// toggle button) on a wide one. See styles.css for the matching presentation.
+const workspaceEl = document.getElementById("workspace");
+const asideToggle = document.getElementById("aside-toggle");
+const asideDrawer = window.matchMedia("(max-width: 819px)");
+
+function activeAsideTab() {
+  const t = document.querySelector(".atab.active");
+  return t ? t.dataset.atab : null;
+}
+function syncLoggersPolling() {
+  if (loggersTabActive()) startLoggersPolling();
+  else stopLoggersPolling();
+}
+// Show the rail look whenever the canvas is narrow or the panel is collapsed.
+function syncAsideMode() {
+  const open = workspaceEl.classList.contains("aside-open");
+  workspaceEl.classList.toggle("aside-rail", asideDrawer.matches || !open);
+  if (asideToggle) {
+    asideToggle.setAttribute("aria-label", open ? "Hide panel" : "Show panel");
+    asideToggle.title = open ? "Hide panel" : "Show panel";
+  }
+}
+function setAsideOpen(open) {
+  workspaceEl.classList.toggle("aside-open", open);
+  syncAsideMode();
+  syncLoggersPolling();
+}
 function showAsideTab(name) {
   document.querySelectorAll(".atab").forEach((t) => t.classList.toggle("active", t.dataset.atab === name));
   document.getElementById("atab-metrics").classList.toggle("active", name === "metrics");
+  document.getElementById("atab-loggers").classList.toggle("active", name === "loggers");
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
+  syncLoggersPolling();
 }
-document.querySelectorAll(".atab").forEach((t) => (t.onclick = () => showAsideTab(t.dataset.atab)));
+// Tab click: when collapsed, open the panel to that pane; when already expanded,
+// switch panes, or collapse if you re-tap the pane that's already showing.
+function onAsideTabClick(name) {
+  if (!workspaceEl.classList.contains("aside-open")) {
+    showAsideTab(name);
+    setAsideOpen(true);
+    return;
+  }
+  if (activeAsideTab() === name) {
+    setAsideOpen(false);
+    return;
+  }
+  showAsideTab(name);
+}
+document.querySelectorAll(".atab").forEach((t) => (t.onclick = () => onAsideTabClick(t.dataset.atab)));
+if (asideToggle) asideToggle.onclick = () => setAsideOpen(!workspaceEl.classList.contains("aside-open"));
+// Esc collapses the overlay drawer on a narrow canvas.
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && asideDrawer.matches && workspaceEl.classList.contains("aside-open")) {
+    setAsideOpen(false);
+  }
+});
+// Crossing the breakpoint resets to the natural default for that width: docked
+// and open when wide, collapsed to the rail when narrow.
+asideDrawer.addEventListener("change", () => setAsideOpen(!asideDrawer.matches));
+// Initial state: open on a wide canvas, collapsed on a narrow one. No loggers
+// sync here (it would touch state declared later in this module) — polling is
+// driven by tab activation and the metrics tab is the default.
+workspaceEl.classList.toggle("aside-open", !asideDrawer.matches);
+syncAsideMode();
 
 // Floating tooltip controller for [data-tip] elements (the settings info
 // icons). Native title tooltips don't render reliably in the canvas
@@ -247,12 +308,79 @@ document.addEventListener("focusout", hideTip);
 function appendLine(line, stream, op) {
   const el = consoleFor(op);
   const span = document.createElement("span");
-  if (stream === "stderr") span.className = "err";
+  let cls = stream === "stderr" ? "err" : "";
+  if (el === runConsoleEl) {
+    // Tag each run-console line with a severity (continuation/stack-trace lines
+    // inherit the previous line's level) so the log filter and per-level coloring
+    // can work without re-parsing.
+    let level = parseLogLevel(line);
+    if (level) lastRunLevel = level;
+    else level = lastRunLevel;
+    span.dataset.level = level;
+    span.dataset.text = line.toLowerCase();
+    cls = (cls ? cls + " " : "") + "lvl-" + level.toLowerCase();
+    if (!lineMatchesLogFilter(level, span.dataset.text)) span.hidden = true;
+  }
+  if (cls) span.className = cls;
   span.textContent = line + "\n";
   el.appendChild(span);
   while (el.childNodes.length > 2000) el.removeChild(el.firstChild);
   el.scrollTop = el.scrollHeight;
+  if (el === runConsoleEl) updateLogCount();
 }
+
+// ---- Run console log filtering -----------------------------------------
+// The Run console is the app's live log. A minimum-severity select and a text
+// search filter it client-side; nothing leaves the iframe.
+const logLevelSelect = document.getElementById("in-log-level");
+const logSearchInput = document.getElementById("in-log-search");
+const logCountEl = document.getElementById("log-count");
+const LOG_RANK = { TRACE: 0, DEBUG: 1, INFO: 2, WARN: 3, ERROR: 4 };
+let runMinLevel = ""; // "" = show all severities
+let runSearch = "";
+let lastRunLevel = "INFO"; // inherited level for lines without their own
+
+function parseLogLevel(line) {
+  const m = line.match(/\b(TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|SEVERE|FATAL)\b/);
+  if (!m) return null;
+  const t = m[1];
+  if (t === "WARNING") return "WARN";
+  if (t === "SEVERE" || t === "FATAL") return "ERROR";
+  return t;
+}
+
+function lineMatchesLogFilter(level, lowerText) {
+  if (runMinLevel && (LOG_RANK[level] ?? 2) < LOG_RANK[runMinLevel]) return false;
+  if (runSearch && !lowerText.includes(runSearch)) return false;
+  return true;
+}
+
+function applyLogFilter() {
+  runMinLevel = logLevelSelect ? logLevelSelect.value : "";
+  runSearch = logSearchInput ? logSearchInput.value.trim().toLowerCase() : "";
+  for (const span of runConsoleEl.childNodes) {
+    if (span.nodeType !== 1) continue;
+    span.hidden = !lineMatchesLogFilter(span.dataset.level || "INFO", span.dataset.text || "");
+  }
+  updateLogCount();
+}
+
+function updateLogCount() {
+  if (!logCountEl) return;
+  if (!runMinLevel && !runSearch) {
+    logCountEl.textContent = "";
+    return;
+  }
+  const spans = runConsoleEl.querySelectorAll("span");
+  let shown = 0;
+  spans.forEach((s) => {
+    if (!s.hidden) shown++;
+  });
+  logCountEl.textContent = spans.length ? `showing ${shown} / ${spans.length}` : "";
+}
+
+if (logLevelSelect) logLevelSelect.addEventListener("change", applyLogFilter);
+if (logSearchInput) logSearchInput.addEventListener("input", applyLogFilter);
 
 // Last status snapshot ({ build, test, package, run, reload }).
 // (declared above, near activeTab, so showTab can read it)
@@ -473,6 +601,12 @@ function row(k, v) {
 }
 
 function renderMetrics(m) {
+  const nowUp = !!(m && m.appUp);
+  if (nowUp !== appRunning) {
+    appRunning = nowUp;
+    // Reflect the app coming up / going down in the Loggers tab if it's open.
+    if (loggersTabActive()) loadLoggers();
+  }
   if (!m || !m.appUp) {
     metricsSrc.hidden = true;
     renderMcp(null);
@@ -650,6 +784,139 @@ async function runScan(tool) {
     };
 }
 let lastScan = null;
+
+// ---- Runtime log levels (Loggers aside tab) ----------------------------
+// Lists the running app's loggers from Spring Boot Actuator /loggers and lets
+// you change a level live (no restart). Self-describes by capability: degrades to
+// a hint when the app is down or exposes no /loggers endpoint.
+const loggersListEl = document.getElementById("loggers-list");
+const loggersControls = document.getElementById("loggers-controls");
+const loggersSearch = document.getElementById("loggers-search");
+const loggersSrc = document.getElementById("loggers-src");
+const LOGGER_LEVELS = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+let appRunning = false;
+let loggersData = null;
+let loggersTimer = null;
+
+function loggersTabActive() {
+  const pane = document.getElementById("atab-loggers");
+  // offsetParent is null when the pane (or its collapsed drawer) is display:none,
+  // so this also stops polling when the narrow-canvas rail is collapsed.
+  return !!(pane && pane.classList.contains("active") && pane.offsetParent !== null);
+}
+
+function startLoggersPolling() {
+  loadLoggers();
+  if (loggersTimer) return;
+  // Light refresh so externally-changed levels (or the app starting/stopping)
+  // are reflected while the tab is open.
+  loggersTimer = setInterval(loadLoggers, 5000);
+}
+
+function stopLoggersPolling() {
+  if (loggersTimer) {
+    clearInterval(loggersTimer);
+    loggersTimer = null;
+  }
+}
+
+async function loadLoggers() {
+  if (!appRunning) {
+    renderLoggers({ available: false, appDown: true });
+    return;
+  }
+  renderLoggers(await getJson("/api/loggers"));
+}
+
+function renderLoggers(data, force) {
+  if (!data || data.appDown || (!data.available && !appRunning)) {
+    loggersSrc.hidden = true;
+    loggersControls.hidden = true;
+    loggersListEl.innerHTML =
+      '<p class="muted">App not running. Click <strong>Run</strong> to control its log levels.</p>';
+    loggersData = null;
+    return;
+  }
+  if (!data.available) {
+    loggersSrc.hidden = true;
+    loggersControls.hidden = true;
+    loggersListEl.innerHTML =
+      '<p class="muted">No Spring Boot Actuator <code>/loggers</code> endpoint is exposed on the running app, so log ' +
+      "levels can\u2019t be changed here. Add <code>spring-boot-starter-actuator</code> and expose it " +
+      "(<code>management.endpoints.web.exposure.include=loggers</code>).</p>";
+    loggersData = null;
+    return;
+  }
+  loggersData = data;
+  loggersSrc.hidden = false;
+  loggersSrc.className = "src actuator";
+  loggersSrc.textContent = "Actuator";
+  loggersControls.hidden = false;
+  // Don't rebuild the list out from under the user while they're using it
+  // (an open select or focused search box) unless explicitly forced.
+  if (!force && loggersListEl.contains(document.activeElement)) return;
+  renderLoggersList();
+}
+
+function renderLoggersList() {
+  if (!loggersData || !loggersData.available) return;
+  const levels = loggersData.levels && loggersData.levels.length ? loggersData.levels : LOGGER_LEVELS;
+  const term = (loggersSearch.value || "").trim().toLowerCase();
+  // No search: show ROOT plus loggers with an explicit level (the interesting
+  // ones). With a search: reveal any matching package/class so its level can be set.
+  let list = term
+    ? loggersData.loggers.filter((l) => l.name.toLowerCase().includes(term))
+    : loggersData.loggers.filter((l) => l.name === "ROOT" || l.configuredLevel);
+  const CAP = 200;
+  const extra = list.length - CAP;
+  if (extra > 0) list = list.slice(0, CAP);
+  if (!list.length) {
+    loggersListEl.innerHTML = `<p class="muted">${
+      term
+        ? "No loggers match \u201C" + esc(term) + "\u201D."
+        : "No explicitly-configured loggers. Search to set a level on any package."
+    }</p>`;
+    return;
+  }
+  const note = extra > 0 ? `<p class="hint">${extra} more match \u2014 refine your search.</p>` : "";
+  loggersListEl.innerHTML = list.map((l) => loggerRow(l, levels)).join("") + note;
+  loggersListEl.querySelectorAll("select[data-logger]").forEach((sel) => {
+    sel.addEventListener("change", () => changeLoggerLevel(sel.dataset.logger, sel.value));
+  });
+}
+
+function loggerRow(l, levels) {
+  const cur = l.configuredLevel || "";
+  const inheritLabel = l.configuredLevel ? "Inherit" : `Inherit (${esc(l.effectiveLevel || "?")})`;
+  const opts =
+    `<option value="">${inheritLabel}</option>` +
+    levels.map((lv) => `<option value="${lv}"${lv === cur ? " selected" : ""}>${lv}</option>`).join("");
+  const eff = (l.configuredLevel || l.effectiveLevel || "").toLowerCase();
+  const name = l.name === "ROOT" ? "ROOT" : esc(l.name);
+  return (
+    `<div class="logger-row"><span class="logger-name" title="${esc(l.name)}">${name}</span>` +
+    `<select class="logger-level lvl-${eff}" data-logger="${esc(l.name)}">${opts}</select></div>`
+  );
+}
+
+async function changeLoggerLevel(name, level) {
+  const r = await postJson("/api/loggers", { name, level: level || null });
+  if (!r || r.ok === false) {
+    appendLine(
+      `[canvas] couldn't set ${name} \u2192 ${level || "inherit"}: ${(r && r.error) || "request failed"}`,
+      "stderr",
+      "run",
+    );
+  }
+  if (r && r.status) {
+    loggersData = r.status;
+    renderLoggersList();
+  } else {
+    loadLoggers();
+  }
+}
+
+if (loggersSearch) loggersSearch.addEventListener("input", () => renderLoggersList());
 
 function statusDot(st) {
   return `<span class="dot ${st}"></span>`;
@@ -1336,6 +1603,10 @@ es.addEventListener("reset", (e) => {
   } catch {}
   const el = consoles[op];
   if (el) el.innerHTML = "";
+  if (op === "run") {
+    lastRunLevel = "INFO";
+    updateLogCount();
+  }
 });
 
 // Full-cover loading overlay: dismissed once the first /api/state lands (or a

--- a/public/app.js
+++ b/public/app.js
@@ -666,10 +666,9 @@ function renderMetrics(m) {
     lastHeapPct = 0;
     metricsSrc.hidden = true;
     renderMcp(null);
-    metricsEl.innerHTML =
-      '<p class="muted">App not running. Click <strong>Run</strong> to start it (Spring\u2019s <code>dev</code> profile activates BootUI).</p>';
+    metricsEl.innerHTML = '<p class="muted">Application isn\u2019t running or doesn\u2019t expose metrics.</p>';
     metricsHint.innerHTML =
-      "Run a Spring Boot app with the <code>dev</code> profile for rich BootUI metrics, a Quarkus app for Micrometer metrics, or anything exposing Actuator for a subset.";
+      'To get metrics, add <strong>Spring Boot Actuator</strong> or <strong>Quarkus Micrometer/health</strong>. For even richer metrics with Spring Boot, add <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a>.';
     return;
   }
   const tier = m.metricsTier || "process";

--- a/public/index.html
+++ b/public/index.html
@@ -121,7 +121,7 @@
       </button>
     </div>
 
-    <div id="workspace">
+    <div id="workspace" class="aside-rail">
       <div id="left">
         <pre id="build-console" class="lpane term active" aria-label="Build output"></pre>
 
@@ -151,10 +151,23 @@
               Open in browser
             </button>
           </div>
+          <div class="log-bar" id="log-bar">
+            <label class="log-level-label" for="in-log-level">Level</label>
+            <select id="in-log-level" title="Show this severity and above">
+              <option value="">All</option>
+              <option value="ERROR">Error</option>
+              <option value="WARN">Warn</option>
+              <option value="INFO">Info</option>
+              <option value="DEBUG">Debug</option>
+              <option value="TRACE">Trace</option>
+            </select>
+            <input id="in-log-search" type="search" placeholder="Filter log text…" autocomplete="off" />
+            <span id="log-count" class="muted log-count"></span>
+          </div>
           <pre id="run-console" class="term" aria-label="Run output"></pre>
         </section>
       </div>
-      <aside>
+      <aside id="aside">
         <div class="aside-tabs">
           <button class="atab active" data-atab="metrics">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
@@ -166,7 +179,15 @@
                 d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A8 8 0 0 1 0 10m8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3"
               />
             </svg>
-            Live JVM
+            <span class="atab-label">Live JVM</span>
+          </button>
+          <button class="atab" data-atab="loggers">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M5 11.5a.5.5 0 0 1 .5-.5h9a.5.5 0 0 1 0 1h-9a.5.5 0 0 1-.5-.5m-3-4a.5.5 0 0 1 .5-.5h12a.5.5 0 0 1 0 1H2.5a.5.5 0 0 1-.5-.5m-2-4a.5.5 0 0 1 .5-.5h15a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5"
+              />
+            </svg>
+            <span class="atab-label">Loggers</span>
           </button>
           <button class="atab" data-atab="settings">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
@@ -177,145 +198,172 @@
                 d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 0 0 2.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 0 0 1.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 0 0-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 0 0-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 0 0-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 0 0 1.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 0 0 3.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 0 0 2.692-1.115z"
               />
             </svg>
-            Settings
+            <span class="atab-label">Settings</span>
+          </button>
+          <button id="aside-toggle" class="aside-toggle" type="button" aria-label="Hide panel" title="Hide panel">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 1 1-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06"
+              />
+            </svg>
           </button>
         </div>
 
-        <div id="atab-metrics" class="apane active">
-          <h2>Live JVM metrics<span id="metrics-src" class="src" hidden></span></h2>
-          <div id="metrics">
-            <p class="muted">App not running. Click <strong>Run</strong> to start it (dev profile activates BootUI).</p>
+        <div class="aside-body">
+          <div id="atab-metrics" class="apane active">
+            <h2>Live JVM metrics<span id="metrics-src" class="src" hidden></span></h2>
+            <div id="metrics">
+              <p class="muted">
+                App not running. Click <strong>Run</strong> to start it (dev profile activates BootUI).
+              </p>
+            </div>
+            <p class="hint" id="metrics-hint">
+              Metrics are read from the running app's <code>/bootui/api/**</code> endpoints &mdash; reused directly from
+              BootUI.
+            </p>
           </div>
-          <p class="hint" id="metrics-hint">
-            Metrics are read from the running app's <code>/bootui/api/**</code> endpoints &mdash; reused directly from
-            BootUI.
-          </p>
-        </div>
 
-        <div id="atab-settings" class="apane">
-          <!-- Java language server (JDTLS): powers Copilot's Java code
+          <div id="atab-loggers" class="apane">
+            <h2>Log levels<span id="loggers-src" class="src" hidden></span></h2>
+            <div id="loggers-controls" hidden>
+              <input id="loggers-search" type="search" placeholder="Search a package or class…" autocomplete="off" />
+              <p class="hint loggers-help">
+                Configured loggers are listed below. Search to set a level on any package; changes apply live, no
+                restart.
+              </p>
+            </div>
+            <div id="loggers-list">
+              <p class="muted">App not running. Click <strong>Run</strong> to control its log levels.</p>
+            </div>
+          </div>
+
+          <div id="atab-settings" class="apane">
+            <!-- Java language server (JDTLS): powers Copilot's Java code
                intelligence (go-to-definition, find references, hover). Not part
                of this extension — the CLI launches it — so we report whether
                it's actually available and offer to set it up if not. Kept at the
                top so its status is the first thing visible in Settings. -->
-          <div class="set-row jdtls-row" id="set-jdtls" hidden>
-            <div class="switch-row">
-              <span class="jdtls-dot" id="jdtls-dot"></span>
-              <span class="switch-label">Java IntelliSense (JDTLS)</span>
-              <span id="jdtls-state" class="mcp-state"></span>
-              <span
-                class="info"
-                id="jdtls-info"
-                tabindex="0"
-                data-tip="JDTLS gives Copilot Java go-to-definition, find references and hover. Checking availability…"
-                >&#9432;</span
-              >
+            <div class="set-row jdtls-row" id="set-jdtls" hidden>
+              <div class="switch-row">
+                <span class="jdtls-dot" id="jdtls-dot"></span>
+                <span class="switch-label">Java IntelliSense (JDTLS)</span>
+                <span id="jdtls-state" class="mcp-state"></span>
+                <span
+                  class="info"
+                  id="jdtls-info"
+                  tabindex="0"
+                  data-tip="JDTLS gives Copilot Java go-to-definition, find references and hover. Checking availability…"
+                  >&#9432;</span
+                >
+              </div>
+              <button id="btn-setup-jdtls" class="fix tiny" hidden>Set up JDTLS</button>
+              <div id="jdtls-banner" class="banner setting-banner" hidden>
+                <span id="jdtls-msg"></span>
+                <code id="jdtls-cmd" title="Click to copy" hidden></code>
+                <span id="jdtls-copied" class="copied" hidden>copied</span>
+                <a id="jdtls-docs" href="#" target="_blank" rel="noopener">docs</a>
+              </div>
             </div>
-            <button id="btn-setup-jdtls" class="fix tiny" hidden>Set up JDTLS</button>
-            <div id="jdtls-banner" class="banner setting-banner" hidden>
-              <span id="jdtls-msg"></span>
-              <code id="jdtls-cmd" title="Click to copy" hidden></code>
-              <span id="jdtls-copied" class="copied" hidden>copied</span>
-              <a id="jdtls-docs" href="#" target="_blank" rel="noopener">docs</a>
+
+            <!-- Run config profile (Spring Boot / Quarkus only) -->
+            <div class="set-row" id="set-spring" hidden>
+              <label class="cap-label" id="lbl-profiles">Spring Boot profiles</label>
+              <span class="combo">
+                <input
+                  id="in-profiles"
+                  size="14"
+                  value="dev"
+                  autocomplete="off"
+                  title="Config profile(s) to activate when running (Spring spring-boot.run.profiles / Quarkus quarkus.profile)."
+                />
+                <div class="combo-menu" id="spring-menu" hidden></div>
+              </span>
             </div>
-          </div>
 
-          <!-- Run config profile (Spring Boot / Quarkus only) -->
-          <div class="set-row" id="set-spring" hidden>
-            <label class="cap-label" id="lbl-profiles">Spring Boot profiles</label>
-            <span class="combo">
-              <input
-                id="in-profiles"
-                size="14"
-                value="dev"
-                autocomplete="off"
-                title="Config profile(s) to activate when running (Spring spring-boot.run.profiles / Quarkus quarkus.profile)."
-              />
-              <div class="combo-menu" id="spring-menu" hidden></div>
-            </span>
-          </div>
-
-          <!-- Keep JVM warm -->
-          <div class="set-row switch-row">
-            <label class="switch disabled" id="warm-toggle">
-              <input type="checkbox" id="in-warm" disabled />
-              <span class="track"><span class="thumb"></span></span>
-              <span class="switch-label" id="warm-label">Keep JVM warm</span>
-            </label>
-            <span class="info" id="warm-info" tabindex="0" data-tip="Checking the warm-JVM tier…">&#9432;</span>
-          </div>
-          <div id="warm-banner" class="banner setting-banner" hidden>
-            <span id="warm-msg"
-              >The Maven Daemon (<strong>mvnd</strong>) isn't installed, so <strong>Keep&nbsp;JVM&nbsp;warm</strong> is
-              disabled.</span
-            >
-            <code id="warm-cmd" title="Click to copy" hidden></code>
-            <span id="warm-copied" class="copied" hidden>copied</span>
-            <a id="warm-docs" href="#" target="_blank" rel="noopener">install guide</a>
-          </div>
-
-          <!-- Enable Spring Boot DevTools (Spring only) -->
-          <div class="set-row switch-row" id="set-devtools" hidden>
-            <label class="switch" id="devtools-toggle">
-              <input type="checkbox" id="in-devtools" />
-              <span class="track"><span class="thumb"></span></span>
-              <span class="switch-label">Enable Spring Boot DevTools</span>
-            </label>
-            <span
-              class="info"
-              id="devtools-info"
-              tabindex="0"
-              data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
-              >&#9432;</span
-            >
-          </div>
-
-          <!-- Use a random HTTP port (Spring Boot / Quarkus only) -->
-          <div class="set-row switch-row" id="set-randomport" hidden>
-            <label class="switch" id="randomport-toggle">
-              <input type="checkbox" id="in-randomport" />
-              <span class="track"><span class="thumb"></span></span>
-              <span class="switch-label">Use a random HTTP port</span>
-            </label>
-            <span
-              class="info"
-              tabindex="0"
-              data-tip="Run the app on a free port the console picks (server.port) instead of the default, to avoid conflicts."
-              >&#9432;</span
-            >
-          </div>
-
-          <!-- Dev setup proposals (moved here from the top banners) -->
-          <div class="set-row set-proposals">
-            <button id="btn-add-bootui" class="fix tiny" hidden>Add BootUI to dev profile</button>
-            <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
-          </div>
-
-          <!-- BootUI MCP server (advisor scans); the toggle is enabled once a
-               running BootUI app (dev profile) exposes its MCP endpoint. -->
-          <div id="mcp" class="mcp-settings">
-            <div class="switch-row">
-              <label class="switch disabled" id="mcp-toggle-label">
-                <input type="checkbox" id="mcp-toggle" disabled />
+            <!-- Keep JVM warm -->
+            <div class="set-row switch-row">
+              <label class="switch disabled" id="warm-toggle">
+                <input type="checkbox" id="in-warm" disabled />
                 <span class="track"><span class="thumb"></span></span>
-                <span class="switch-label">BootUI MCP server</span>
+                <span class="switch-label" id="warm-label">Keep JVM warm</span>
               </label>
-              <span id="mcp-state" class="mcp-state"></span>
+              <span class="info" id="warm-info" tabindex="0" data-tip="Checking the warm-JVM tier…">&#9432;</span>
+            </div>
+            <div id="warm-banner" class="banner setting-banner" hidden>
+              <span id="warm-msg"
+                >The Maven Daemon (<strong>mvnd</strong>) isn't installed, so
+                <strong>Keep&nbsp;JVM&nbsp;warm</strong> is disabled.</span
+              >
+              <code id="warm-cmd" title="Click to copy" hidden></code>
+              <span id="warm-copied" class="copied" hidden>copied</span>
+              <a id="warm-docs" href="#" target="_blank" rel="noopener">install guide</a>
+            </div>
+
+            <!-- Enable Spring Boot DevTools (Spring only) -->
+            <div class="set-row switch-row" id="set-devtools" hidden>
+              <label class="switch" id="devtools-toggle">
+                <input type="checkbox" id="in-devtools" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Enable Spring Boot DevTools</span>
+              </label>
+              <span
+                class="info"
+                id="devtools-info"
+                tabindex="0"
+                data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
+                >&#9432;</span
+              >
+            </div>
+
+            <!-- Use a random HTTP port (Spring Boot / Quarkus only) -->
+            <div class="set-row switch-row" id="set-randomport" hidden>
+              <label class="switch" id="randomport-toggle">
+                <input type="checkbox" id="in-randomport" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Use a random HTTP port</span>
+              </label>
               <span
                 class="info"
                 tabindex="0"
-                data-tip="Run BootUI's MCP server inside the running app so its advisor scans (architecture, security, Hibernate, …) can analyze the project from this console."
+                data-tip="Run the app on a free port the console picks (server.port) instead of the default, to avoid conflicts."
                 >&#9432;</span
               >
-              <button id="mcp-register" class="fix tiny" style="margin-left: auto" hidden>Register with Copilot</button>
             </div>
-            <div id="mcp-scans" class="scans">
-              <span class="muted" style="font-size: 12px"
-                >Start a BootUI app (dev profile) with <strong>Run</strong> to manage its MCP server and advisor
-                scans.</span
-              >
+
+            <!-- Dev setup proposals (moved here from the top banners) -->
+            <div class="set-row set-proposals">
+              <button id="btn-add-bootui" class="fix tiny" hidden>Add BootUI to dev profile</button>
+              <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
             </div>
-            <div id="mcp-result"></div>
+
+            <!-- BootUI MCP server (advisor scans); the toggle is enabled once a
+               running BootUI app (dev profile) exposes its MCP endpoint. -->
+            <div id="mcp" class="mcp-settings">
+              <div class="switch-row">
+                <label class="switch disabled" id="mcp-toggle-label">
+                  <input type="checkbox" id="mcp-toggle" disabled />
+                  <span class="track"><span class="thumb"></span></span>
+                  <span class="switch-label">BootUI MCP server</span>
+                </label>
+                <span id="mcp-state" class="mcp-state"></span>
+                <span
+                  class="info"
+                  tabindex="0"
+                  data-tip="Run BootUI's MCP server inside the running app so its advisor scans (architecture, security, Hibernate, …) can analyze the project from this console."
+                  >&#9432;</span
+                >
+                <button id="mcp-register" class="fix tiny" style="margin-left: auto" hidden>
+                  Register with Copilot
+                </button>
+              </div>
+              <div id="mcp-scans" class="scans">
+                <span class="muted" style="font-size: 12px"
+                  >Start a BootUI app (dev profile) with <strong>Run</strong> to manage its MCP server and advisor
+                  scans.</span
+                >
+              </div>
+              <div id="mcp-result"></div>
+            </div>
           </div>
         </div>
       </aside>

--- a/public/index.html
+++ b/public/index.html
@@ -281,13 +281,12 @@
           <div id="atab-metrics" class="apane active">
             <h2>Live JVM metrics<span id="metrics-src" class="src" hidden></span></h2>
             <div id="metrics">
-              <p class="muted">
-                App not running. Click <strong>Run</strong> to start it (dev profile activates BootUI).
-              </p>
+              <p class="muted">Application isn&rsquo;t running or doesn&rsquo;t expose metrics.</p>
             </div>
             <p class="hint" id="metrics-hint">
-              Metrics are read from the running app's <code>/bootui/api/**</code> endpoints &mdash; reused directly from
-              BootUI.
+              To get metrics, add <strong>Spring Boot Actuator</strong> or <strong>Quarkus Micrometer/health</strong>.
+              For even richer metrics with Spring Boot, add
+              <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a>.
             </p>
           </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -271,11 +271,11 @@ select {
   grid-template-columns: 1fr 320px;
   gap: 0;
   height: calc(100vh - 130px);
+  position: relative;
 }
-@media (max-width: 760px) {
+@media (max-width: 819px) {
   #workspace {
     grid-template-columns: 1fr;
-    height: auto;
   }
 }
 #left {
@@ -283,12 +283,6 @@ select {
   overflow: hidden;
   min-width: 0;
   min-height: 0;
-}
-@media (max-width: 760px) {
-  #left {
-    height: auto;
-    overflow: visible;
-  }
 }
 /* Left column panes (Build / Test / Run) swap in place; the aside stays put. */
 .lpane {
@@ -309,14 +303,6 @@ select {
   display: flex;
   flex-direction: column;
 }
-@media (max-width: 760px) {
-  .lpane {
-    height: auto;
-  }
-  .lpane.col.active {
-    height: auto;
-  }
-}
 /* Shared console (build/test/run) styling. */
 .term {
   margin: 0;
@@ -334,11 +320,6 @@ select {
 #run-console {
   flex: 1 1 auto;
   min-height: 0;
-}
-@media (max-width: 760px) {
-  #run-console {
-    flex: none;
-  }
 }
 
 /* Test tab: Graphical / Console sub-toggle */
@@ -373,11 +354,6 @@ select {
 .tsub.active {
   display: block;
 }
-@media (max-width: 760px) {
-  .subpane-wrap {
-    min-height: 50vh;
-  }
-}
 
 /* Run tab: browser controls bar */
 .run-bar {
@@ -389,10 +365,57 @@ select {
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
   flex: 0 0 auto;
 }
+/* Run tab: live log filter bar (severity + text search) */
+.log-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
+}
+.log-level-label {
+  font-size: 12px;
+  color: var(--text-color-muted, #656d76);
+}
+.log-bar select {
+  font-size: 12px;
+  padding: 0.1rem 0.3rem;
+}
+.log-bar #in-log-search {
+  flex: 1 1 140px;
+  min-width: 100px;
+  font-size: 12px;
+  padding: 0.1rem 0.4rem;
+}
+.log-count {
+  font-size: 11px;
+  white-space: nowrap;
+}
+/* Per-severity coloring of run-console lines (level is tagged on append). */
+.term .lvl-error {
+  color: var(--true-color-red, #cf222e);
+}
+.term .lvl-warn {
+  color: var(--true-color-orange, #bc4c00);
+}
+.term .lvl-debug,
+.term .lvl-trace {
+  color: var(--text-color-muted, #656d76);
+}
 aside {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   border-left: 1px solid var(--border-color-default, #d0d7de);
-  padding: 0.75rem 1rem;
+  background: var(--background-color-default, #ffffff);
+}
+.aside-body {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
+  padding: 0.75rem 1rem;
 }
 aside h2 {
   font-size: 12px;
@@ -1040,8 +1063,10 @@ button.is-restarting .btn-spin::before {
 .aside-tabs {
   display: flex;
   gap: 0.25rem;
-  margin: 0 0 0.75rem;
+  margin: 0;
+  padding: 0.75rem 1rem 0.5rem;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
 }
 .atab {
   border: none;
@@ -1057,6 +1082,7 @@ button.is-restarting .btn-spin::before {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
+  white-space: nowrap;
 }
 .atab svg {
   width: 13px;
@@ -1072,11 +1098,81 @@ button.is-restarting .btn-spin::before {
   color: var(--text-color-default, #1f2328);
   border-bottom-color: var(--true-color-blue, #0969da);
 }
+.aside-toggle {
+  border: none;
+  background: none;
+  color: var(--text-color-muted, #656d76);
+  padding: 0.25rem;
+  margin-left: auto;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.aside-toggle:hover {
+  color: var(--text-color-default, #1f2328);
+  background: var(--background-color-muted, #eaeef2);
+}
+.aside-toggle svg {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.15s ease;
+}
+#workspace:not(.aside-open) .aside-toggle svg {
+  transform: rotate(180deg);
+}
 .apane {
   display: none;
 }
 .apane.active {
   display: block;
+}
+
+/* Loggers tab: runtime log-level control */
+#loggers-controls #loggers-search {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 12px;
+  padding: 0.2rem 0.4rem;
+}
+.loggers-help {
+  margin-top: 0.4rem;
+}
+#loggers-list {
+  margin-top: 0.5rem;
+}
+.logger-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px dashed var(--border-color-muted, #d8dee4);
+}
+.logger-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, "SFMono-Regular", Consolas, "Liberation Mono", monospace);
+  font-size: 12px;
+}
+.logger-level {
+  flex: 0 0 auto;
+  font-size: 12px;
+  padding: 0.1rem 0.3rem;
+  font-weight: 600;
+}
+.logger-level.lvl-error {
+  color: var(--true-color-red, #cf222e);
+}
+.logger-level.lvl-warn {
+  color: var(--true-color-orange, #bc4c00);
+}
+.logger-level.lvl-debug,
+.logger-level.lvl-trace {
+  color: var(--true-color-blue, #0969da);
 }
 
 /* Settings rows */
@@ -1134,4 +1230,92 @@ button.is-restarting .btn-spin::before {
   flex-wrap: wrap;
   margin: 0.4rem 0 0;
   padding: 0.45rem 0.6rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Collapsible right panel. The panel collapses to an IntelliJ-style vertical
+   icon rail — automatically on a narrow canvas, or on demand via the toggle
+   button on a wide one. #workspace.aside-open = expanded (pane body shown);
+   #workspace.aside-rail = render the rail (set by JS for narrow OR collapsed).
+   --------------------------------------------------------------------------- */
+#workspace.aside-rail aside {
+  flex-direction: row-reverse;
+}
+#workspace.aside-rail .aside-tabs {
+  flex-direction: column;
+  align-items: center;
+  width: 44px;
+  margin: 0;
+  padding: 0.5rem 0;
+  gap: 0.4rem;
+  border-bottom: none;
+}
+#workspace.aside-rail .atab {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+  border-bottom: none;
+  border-radius: 6px;
+}
+#workspace.aside-rail .atab svg {
+  width: 16px;
+  height: 16px;
+}
+#workspace.aside-rail .atab.active {
+  border-bottom: none;
+  background: var(--background-color-muted, #eaeef2);
+  color: var(--text-color-default, #1f2328);
+}
+#workspace.aside-rail .atab-label {
+  display: none;
+}
+#workspace.aside-rail .aside-toggle {
+  order: -1;
+  width: 32px;
+  height: 32px;
+  margin: 0 0 0.25rem;
+}
+#workspace.aside-rail .aside-body {
+  flex: 0 0 auto;
+  width: min(310px, 80vw);
+  border-left: 1px solid var(--border-color-default, #d0d7de);
+}
+#workspace.aside-rail:not(.aside-open) .aside-body {
+  display: none;
+}
+
+/* Wide canvas, voluntarily collapsed: the rail sits in-flow as a slim column so
+   the main panel simply widens (no overlay). */
+@media (min-width: 820px) {
+  #workspace.aside-rail {
+    grid-template-columns: 1fr max-content;
+  }
+}
+
+/* Narrow canvas: the panel floats over the main area as an overlay drawer, and
+   the main console keeps room for the rail on its right. */
+@media (max-width: 819px) {
+  #workspace {
+    grid-template-columns: 1fr;
+  }
+  #left {
+    box-sizing: border-box;
+    padding-right: 44px;
+  }
+  aside {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    border-left: none;
+    padding: 0;
+    z-index: 20;
+  }
+  .aside-tabs {
+    border-left: 1px solid var(--border-color-default, #d0d7de);
+  }
+  #workspace.aside-open aside {
+    box-shadow: -10px 0 28px rgba(31, 35, 40, 0.18);
+  }
 }


### PR DESCRIPTION
## Summary

Brings IDE-style live observability to the Run lane and makes the right-hand tool panel usable on a narrow canvas.

- **Live logs and log levels.** The Run console doubles as a log viewer with a minimum-severity filter and text search (lines are colored by severity, and stack-trace/continuation lines inherit their parent level). A new **Loggers** side tab reads and writes the running app's logger levels through Spring Boot Actuator `/loggers` (discovering the `/management` prefix for JHipster-style apps), exposed to the agent via a `set_log_level` action, so you can flip a package to `DEBUG` live and dial it back without a restart.
- **Collapsible right panel.** The Live JVM / Loggers / Settings panel docks on a wide canvas and collapses to an IntelliJ-style 44px icon rail when the canvas is narrow (tap an icon to overlay the pane, Esc to close). A chevron toggle hides or shows the panel on demand in any layout, including when docked, so the console can take the full width.
- **Accurate empty states.** Reset stale metrics on app stop/crash so the panel and Loggers tab correctly show "not running", and reword the Live JVM empty state to describe the real tiered metrics sourcing (add Actuator or Quarkus Micrometer/health, or BootUI for the richest Spring metrics) instead of implying a Spring `dev` profile is required.

This branch also merges `origin/main` (async-profiler flame graph and friends); the net diff here is just the feature work. The Run console's log-filter bar was folded into the new Console subtab so it hides when the Flame graph subtab is active.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (verified with `npx prettier --check`).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

- Verified with headless Chrome (puppeteer-core) at wide and narrow widths: docked panel, collapse-to-rail (the main panel widens), re-dock via a rail icon, narrow overlay, Console/Flame subtab switching (log bar shows on Console, hides on Flame), and single-line tab labels. Not yet exercised in a live canvas because the installed extension symlink currently points at a different worktree.
- The `origin/main` merge conflicted in PLAN.md, README.md, public/index.html and public/styles.css; resolved by keeping both feature sets (brace balance on styles.css double-checked).
- The Loggers tab and `set_log_level` require the target app to expose Actuator `/loggers`; without it the tab degrades to a clear "not available" state.