### PR TITLE
Add affected-test selection and continuous testing to the Test tab

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,8 +49,9 @@ are both first-class build tools, auto-detected per project.
 ## How it works (orientation)
 
 - `extension.mjs`: `joinSession({ canvases: [makeCanvas()] })`, the canvas
-  declaration + agent actions (`build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`), the build-tool
+  declaration + agent actions (`build_app`, `run_tests`, `run_affected_tests`,
+  `package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`,
+  `run_scan`), the build-tool
   runner (`spawn` of `./mvnw`/`mvnd` for Maven or `./gradlew`/`gradle` for Gradle,
   with `--enable-native-access=ALL-UNNAMED` via `MAVEN_OPTS` / `GRADLE_OPTS`), the run
   modes (`spring-boot:run`/`bootRun` for Spring Boot, `quarkus:dev`/`quarkusDev` for

--- a/.github/extensions/coffilot/extension.mjs
+++ b/.github/extensions/coffilot/extension.mjs
@@ -1,0 +1,13 @@
+// Project-scoped entry point for the Coffilot canvas extension.
+//
+// The Copilot CLI auto-discovers extensions in `.github/extensions/<name>/`, so
+// keeping this file here makes Coffilot load by default whenever this repository
+// is opened in the Copilot app — no manual install step is required.
+//
+// The real implementation lives at the repository root (`../../../extension.mjs`)
+// to keep a single source of truth alongside its `public/` assets and
+// `package.json`. This thin wrapper only imports that module for its side effects
+// (the root module calls `joinSession(...)` at load time). Because every ES module
+// keeps its own `import.meta.url`, the root module still resolves `public/`
+// relative to the repo root even when it is loaded through this wrapper.
+import "../../../extension.mjs";

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,16 @@ copilot-extension.json   Manifest ({ "name": "coffilot", "version": 1 }) used by
 ## Develop and test
 
 The extension is discovered from `.github/extensions/<name>/` (relative to a git
-root) or `$COPILOT_HOME/extensions/<name>/`. Coffilot drives a _separate_ Maven or
-Gradle project, so develop against a checkout of a Java app:
+root) or `$COPILOT_HOME/extensions/<name>/`.
+
+This repo ships a `.github/extensions/coffilot/extension.mjs` wrapper that loads
+the root `extension.mjs`, so **opening this repository** in the Copilot app loads
+Coffilot automatically — handy for verifying it boots. (If you also keep a
+`~/.copilot/extensions/coffilot` symlink, remove it while working here so Coffilot
+isn't loaded twice.)
+
+Coffilot drives a _separate_ Maven or Gradle project, so to exercise it against a
+real build, develop against a checkout of a Java app:
 
 1. Symlink or copy this repo into the target project's extensions folder:
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,8 +49,9 @@ Shipped in the extension today:
 - `--enable-native-access=ALL-UNNAMED` applied to the build-tool JVM (via
   `MAVEN_OPTS` / `GRADLE_OPTS`) and, for Maven, the app JVM to silence JDK
   native-access warnings.
-- Agent-facing actions: `build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`.
+- Agent-facing actions: `build_app`, `run_tests`, `run_affected_tests`,
+  `package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`,
+  `run_scan`.
 
 ## Known limitations
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ wins; when neither is found the console says so and stays disabled until one is 
   the JUnit results parsed into a graphical, per-test view (summary chips, per-suite
   grouping, expandable failure stack traces) and a live progress bar. A console toggle
   shows the raw output.
-- **Run affected** &mdash; an [Infinitest](https://infinitest.github.io/)-style mode
+- **Run affected** &mdash; a mode
   that runs only the tests relevant to your **uncommitted changes** (git working tree
   vs `HEAD`) instead of the whole suite. Coffilot builds a dependency graph from the
   compiled `.class` files (reading each class's constant pool, no extra dependencies)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ wins; when neither is found the console says so and stays disabled until one is 
   the JUnit results parsed into a graphical, per-test view (summary chips, per-suite
   grouping, expandable failure stack traces) and a live progress bar. A console toggle
   shows the raw output.
+- **Run affected** &mdash; an [Infinitest](https://infinitest.github.io/)-style mode
+  that runs only the tests relevant to your **uncommitted changes** (git working tree
+  vs `HEAD`) instead of the whole suite. Coffilot builds a dependency graph from the
+  compiled `.class` files (reading each class's constant pool, no extra dependencies)
+  and runs just the test classes that transitively depend on the changed code — via
+  Surefire `-Dtest=…` (Maven) or `--tests …` (Gradle). Build once for
+  dependency-accurate selection; before the first compile it falls back to a name-based
+  mapping (`Foo` → `FooTest` / `FooTests` / `FooIT`).
 - **Package** &mdash; Maven `./mvnw -ntp package` or Gradle `./gradlew assemble`,
   streamed live like Build.
 - **Run** &mdash; `spring-boot:run` (Maven) / `bootRun` (Gradle) for a Spring Boot
@@ -128,6 +136,15 @@ cp -R extension.mjs copilot-extension.json public ~/.copilot/extensions/coffilot
 Reload extensions (or restart the session); Coffilot is then discovered
 automatically (`canvasId: java-app`).
 
+### This repository
+
+This repo dog-foods Coffilot: it ships a tiny
+`.github/extensions/coffilot/extension.mjs` wrapper that loads the root
+`extension.mjs`, so opening **this** repository in the Copilot app loads Coffilot
+by default — no manual install or `~/.copilot/extensions/coffilot` symlink needed.
+If you already have such a user-scope symlink, remove it when working in this repo
+so Coffilot isn't loaded twice.
+
 ## Use
 
 In a Copilot app session on a Maven or Gradle project, open the **Coffilot** canvas, then:
@@ -141,8 +158,8 @@ In a Copilot app session on a Maven or Gradle project, open the **Coffilot** can
 5. **Stop** when done.
 
 The agent can drive the same flow with the `build_app`, `run_tests`,
-`package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`
-and `run_scan` actions.
+`run_affected_tests`, `package_app`, `start_app`, `stop_app`, `get_status`,
+`get_metrics`, `fix_issue` and `run_scan` actions.
 
 ## How it works
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -1768,6 +1768,396 @@ function withMavenProfiles(args, mavenProfiles) {
   return p ? [...args, "-P", p] : args;
 }
 
+// ---------------------------------------------------------------------------
+// Affected-test selection (Infinitest-style)
+//
+// Like Infinitest, "Run affected" runs only the tests relevant to the
+// developer's current changes instead of the whole suite. The approach mirrors
+// Infinitest's:
+//   1. Build a dependency graph from the compiled .class files. Each class's
+//      constant pool lists every other class it references, so an edge A→B means
+//      "A uses B". (Infinitest does this with Javassist; we parse the constant
+//      pool directly so Coffilot needs no extra dependencies.)
+//   2. Find what changed: the uncommitted working-tree changes vs HEAD (git),
+//      mapped from .java/.kt/… source paths to fully-qualified class names.
+//   3. Walk the graph backwards from the changed classes to every class that
+//      depends on them (transitively), then keep the ones that are tests — those
+//      are the only tests that need to run.
+// When the project hasn't been compiled yet (no .class files) we fall back to a
+// name-based mapping (Foo → FooTest / FooTests / FooIT) so the feature still
+// narrows the run, and tell the developer to Build for accurate selection.
+// ---------------------------------------------------------------------------
+
+// Annotation/base-class markers that identify a JUnit/TestNG test class. They
+// show up in a compiled test's constant pool (as `Lorg/junit/...;` annotation
+// descriptors or a `TestCase` superclass reference), so detecting a test is just
+// a constant-pool lookup — no classloading required.
+const TEST_MARKERS = new Set([
+  "org.junit.jupiter.api.Test",
+  "org.junit.jupiter.api.TestFactory",
+  "org.junit.jupiter.api.TestTemplate",
+  "org.junit.jupiter.api.RepeatedTest",
+  "org.junit.jupiter.api.Nested",
+  "org.junit.jupiter.params.ParameterizedTest",
+  "org.junit.Test",
+  "junit.framework.TestCase",
+  "org.testng.annotations.Test",
+]);
+
+// Tests that load classes dynamically (e.g. ArchUnit scanning a package) have no
+// statically computable dependencies, so — like Infinitest — we always run them.
+const DYNAMIC_TEST_PREFIXES = ["com.tngtech.archunit"];
+
+// Turn an internal JVM class/type descriptor into a dotted class name, or null
+// for primitives/arrays-of-primitives. Handles `com/example/Foo`, `Lcom/...;`
+// and array forms like `[Lcom/...;`.
+function internalToDotted(name) {
+  if (!name) return null;
+  let s = name;
+  while (s.startsWith("[")) s = s.slice(1);
+  if (s.startsWith("L") && s.endsWith(";")) s = s.slice(1, -1);
+  if (s.length <= 1) return null; // primitive descriptor (I, J, Z, …) or empty
+  return s.replace(/\//g, ".");
+}
+
+// Parse a .class file's constant pool and return the set of dotted class names it
+// references (its "imports", in Infinitest terms). We only need the constant pool,
+// so we stop before the field/method/attribute tables. Returns null if the bytes
+// are not a recognisable class file.
+function parseClassRefs(buf) {
+  if (buf.length < 10 || buf.readUInt32BE(0) !== 0xcafebabe) return null;
+  const cpCount = buf.readUInt16BE(8);
+  let off = 10;
+  const classNameIndices = [];
+  const utf8 = new Map();
+  try {
+    for (let i = 1; i < cpCount; i++) {
+      const tag = buf[off++];
+      switch (tag) {
+        case 1: {
+          // CONSTANT_Utf8
+          const len = buf.readUInt16BE(off);
+          off += 2;
+          utf8.set(i, buf.toString("utf8", off, off + len));
+          off += len;
+          break;
+        }
+        case 7: // CONSTANT_Class → name_index
+          classNameIndices.push(buf.readUInt16BE(off));
+          off += 2;
+          break;
+        case 8: // String
+        case 16: // MethodType
+        case 19: // Module
+        case 20: // Package
+          off += 2;
+          break;
+        case 15: // MethodHandle
+          off += 3;
+          break;
+        case 3: // Integer
+        case 4: // Float
+        case 9: // Fieldref
+        case 10: // Methodref
+        case 11: // InterfaceMethodref
+        case 12: // NameAndType
+        case 17: // Dynamic
+        case 18: // InvokeDynamic
+          off += 4;
+          break;
+        case 5: // Long  (occupies two pool slots)
+        case 6: // Double
+          off += 8;
+          i++;
+          break;
+        default:
+          return null; // unknown tag → can't trust further offsets
+      }
+    }
+  } catch {
+    return null; // truncated/garbled class file
+  }
+
+  const refs = new Set();
+  for (const idx of classNameIndices) {
+    const d = internalToDotted(utf8.get(idx));
+    if (d) refs.add(d);
+  }
+  // CONSTANT_Class entries miss types that only appear inside descriptors (field
+  // types, method params/returns, annotation types). Scan every Utf8 for `L…;`
+  // descriptors to recover them. This over-approximates, which is safe: we only
+  // keep edges to classes that are actually in the project index.
+  for (const s of utf8.values()) {
+    if (s.indexOf("L") === -1) continue;
+    const re = /L([^;<]+);/g;
+    let m;
+    while ((m = re.exec(s)) !== null) {
+      const d = internalToDotted("L" + m[1] + ";");
+      if (d) refs.add(d);
+    }
+  }
+  return refs;
+}
+
+// The compiled-output directories to index, per build tool, tagged with whether
+// they hold main or test classes and which module they belong to ("" = root).
+function outputClassDirs() {
+  const mods = listModules();
+  const bases = (mods.length ? mods : [{ name: "" }]).map((m) => ({
+    module: m.name || "",
+    dir: path.join(workspacePath, m.name || ""),
+  }));
+  const dirs = [];
+  for (const { module, dir } of bases) {
+    if (buildTool === "gradle") {
+      for (const lang of ["java", "kotlin", "groovy", "scala"]) {
+        dirs.push({ dir: path.join(dir, "build", "classes", lang, "main"), kind: "main", module });
+        dirs.push({ dir: path.join(dir, "build", "classes", lang, "test"), kind: "test", module });
+        dirs.push({ dir: path.join(dir, "build", "classes", lang, "integrationTest"), kind: "test", module });
+      }
+    } else {
+      dirs.push({ dir: path.join(dir, "target", "classes"), kind: "main", module });
+      dirs.push({ dir: path.join(dir, "target", "test-classes"), kind: "test", module });
+    }
+  }
+  return dirs.filter((d) => existsSync(d.dir));
+}
+
+// Recursively list every .class file under a directory (skips inner-class noise
+// is not needed — inner classes carry their own dependency edges).
+function walkClassFiles(root, acc = []) {
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const e of entries) {
+    const full = path.join(root, e.name);
+    if (e.isDirectory()) walkClassFiles(full, acc);
+    else if (e.isFile() && e.name.endsWith(".class")) acc.push(full);
+  }
+  return acc;
+}
+
+// Dotted class name for a .class file, derived from its path under the output
+// root: target/classes/com/example/Foo$Bar.class → com.example.Foo$Bar.
+function classNameFromFile(rootDir, file) {
+  const rel = path.relative(rootDir, file).replace(/\\/g, "/");
+  return rel.replace(/\.class$/, "").replace(/\//g, ".");
+}
+
+// Build the project class index: name → { kind, module, refs, isTest, dynamic }.
+function buildClassIndex() {
+  const classes = new Map();
+  for (const { dir, kind, module } of outputClassDirs()) {
+    for (const file of walkClassFiles(dir)) {
+      const name = classNameFromFile(dir, file);
+      let buf;
+      try {
+        buf = readFileSync(file);
+      } catch {
+        continue;
+      }
+      const refs = parseClassRefs(buf);
+      if (!refs) continue;
+      let isTest = false;
+      let dynamic = false;
+      if (kind === "test") {
+        for (const marker of TEST_MARKERS) {
+          if (refs.has(marker)) {
+            isTest = true;
+            break;
+          }
+        }
+        for (const ref of refs) {
+          if (DYNAMIC_TEST_PREFIXES.some((p) => ref.startsWith(p))) {
+            dynamic = true;
+            break;
+          }
+        }
+      }
+      // Prefer a test-output entry if the same name appears under both roots.
+      const prev = classes.get(name);
+      if (prev && prev.kind === "test" && kind !== "test") continue;
+      classes.set(name, { name, kind, module, refs, isTest, dynamic });
+    }
+  }
+  return classes;
+}
+
+const enclosingClass = (name) => name.split("$")[0];
+
+// Given the class index and the set of changed (dotted) class names, walk the
+// dependency graph backwards to every transitive dependent and return the test
+// classes among them (plus always-run dynamic tests). Each returned test is a
+// top-level class with its owning module.
+function affectedTestsFromIndex(index, changedClasses) {
+  // Reverse adjacency: referenced → set of referrers, restricted to project
+  // classes (Infinitest only keeps edges between indexed classes).
+  const reverse = new Map();
+  for (const [name, entry] of index) {
+    for (const ref of entry.refs) {
+      if (ref === name || !index.has(ref)) continue;
+      let set = reverse.get(ref);
+      if (!set) {
+        set = new Set();
+        reverse.set(ref, set);
+      }
+      set.add(name);
+    }
+  }
+
+  // Seed with every indexed class that IS a changed class or an inner class of
+  // one (Foo.java compiles to Foo, Foo$Bar, …).
+  const changedSet = new Set(changedClasses);
+  const seeds = new Set();
+  for (const name of index.keys()) {
+    if (changedSet.has(name) || changedSet.has(enclosingClass(name))) seeds.add(name);
+  }
+
+  // BFS over reverse edges → all transitive dependents.
+  const visited = new Set(seeds);
+  const queue = [...seeds];
+  while (queue.length) {
+    const cur = queue.shift();
+    const referrers = reverse.get(cur);
+    if (!referrers) continue;
+    for (const r of referrers) {
+      if (!visited.has(r)) {
+        visited.add(r);
+        queue.push(r);
+      }
+    }
+  }
+
+  const tests = new Map(); // top-level FQCN → module
+  for (const name of visited) {
+    const e = index.get(name);
+    if (e && e.isTest) tests.set(enclosingClass(name), e.module);
+  }
+  // Dynamic-dependency tests (ArchUnit, …) can't be selected by graph, so always
+  // include them.
+  for (const [name, e] of index) {
+    if (e.dynamic) tests.set(enclosingClass(name), e.module);
+  }
+  return [...tests].map(([fqcn, module]) => ({ fqcn, module }));
+}
+
+// Map a repo-relative source path to its class name + module + main/test kind,
+// or null for non-JVM-source files. Handles module prefixes and the standard
+// src/<sourceSet>/<lang>/ layout.
+function sourceFileToClass(rel) {
+  const norm = rel.replace(/\\/g, "/");
+  const m = norm.match(/^(?:(.+)\/)?src\/([^/]+)\/(?:java|kotlin|groovy|scala)\/(.+)\.(?:java|kt|groovy|scala)$/);
+  if (!m) return null;
+  const module = m[1] || "";
+  const sourceSet = m[2];
+  const fqcn = m[3].replace(/\//g, ".");
+  const kind = /test/i.test(sourceSet) ? "test" : "main";
+  return { module, fqcn, kind, file: rel };
+}
+
+// Uncommitted working-tree changes vs HEAD (staged + unstaged + untracked),
+// relative to the project root. Returns { ok, files, error }.
+function gitChangedFiles() {
+  const run = (args) => spawnSync("git", args, { cwd: workspacePath, encoding: "utf8", timeout: 10000 });
+  const probe = run(["rev-parse", "--is-inside-work-tree"]);
+  if (probe.error || probe.status !== 0 || !/true/.test(probe.stdout || "")) {
+    return { ok: false, files: [], error: "Not a git repository — affected-test selection needs git." };
+  }
+  const files = new Set();
+  for (const args of [
+    ["diff", "--name-only", "--relative"], // unstaged tracked
+    ["diff", "--name-only", "--relative", "--cached"], // staged
+    ["ls-files", "--others", "--exclude-standard"], // untracked
+  ]) {
+    const r = run(args);
+    if (r.status === 0 && r.stdout) {
+      for (const line of r.stdout.split("\n")) {
+        const f = line.trim();
+        if (f) files.add(f);
+      }
+    }
+  }
+  return { ok: true, files: [...files] };
+}
+
+// Name-based fallback when there are no compiled classes to graph: a changed test
+// runs itself; a changed main class Foo maps to candidate FooTest/FooTests/FooIT…
+function nameBasedTests(sources) {
+  const tests = new Map();
+  for (const s of sources) {
+    if (s.kind === "test") {
+      tests.set(enclosingClass(s.fqcn), s.module);
+      continue;
+    }
+    for (const suffix of ["Test", "Tests", "IT", "ITCase", "TestCase"]) {
+      tests.set(s.fqcn + suffix, s.module);
+    }
+  }
+  return [...tests].map(([fqcn, module]) => ({ fqcn, module }));
+}
+
+// Top-level entry point: figure out which test classes to run for the current
+// uncommitted changes. Returns a rich result the UI/agent can explain.
+function computeAffectedTests() {
+  const git = gitChangedFiles();
+  if (!git.ok) return { ok: false, reason: "not-git", message: git.error };
+
+  const sources = [];
+  const nonSource = [];
+  for (const f of git.files) {
+    const c = sourceFileToClass(f);
+    if (c) sources.push(c);
+    else nonSource.push(f);
+  }
+
+  const base = { ok: true, changedFiles: git.files, sources, nonSource };
+  if (!sources.length) {
+    return { ...base, tests: [], fallback: false, reason: git.files.length ? "no-source-changes" : "no-changes" };
+  }
+
+  const index = buildClassIndex();
+  if (!index.size) {
+    return { ...base, tests: nameBasedTests(sources), fallback: true, reason: "no-classes" };
+  }
+
+  const changedClasses = sources.map((s) => s.fqcn);
+  const tests = new Map();
+  for (const t of affectedTestsFromIndex(index, changedClasses)) tests.set(t.fqcn, t.module);
+  // A directly edited test source always runs, even if its compiled class is
+  // stale or missing from the index.
+  for (const s of sources) if (s.kind === "test") tests.set(enclosingClass(s.fqcn), s.module);
+
+  return {
+    ...base,
+    tests: [...tests].map(([fqcn, module]) => ({ fqcn, module })),
+    fallback: false,
+    reason: "graph",
+    indexedCount: index.size,
+  };
+}
+
+// Build the runner args that execute only `tests` (array of { fqcn, module }).
+function affectedTestArgs(tests, warm) {
+  if (buildTool === "gradle") {
+    // List each owning module's `test` task so a global --tests filter never hits
+    // a task with zero matches (which Gradle treats as an error). Every listed
+    // module owns ≥1 of the patterns, so each task matches at least one test.
+    const modules = [...new Set(tests.map((t) => t.module || ""))];
+    const args = modules.map((m) => gradleTaskPath(m, "test"));
+    args.push("--console=plain", ...gradleWarmFlags(warm));
+    for (const t of tests) args.push("--tests", t.fqcn);
+    return args;
+  }
+  // Surefire's -Dtest matches by simple class name (it builds **/Name.java
+  // patterns); failIfNoSpecifiedTests=false keeps reactor modules without a match
+  // from failing the run.
+  const simple = [...new Set(tests.map((t) => enclosingClass(t.fqcn).split(".").pop()))];
+  return ["-ntp", `-Dtest=${simple.join(",")}`, "-Dsurefire.failIfNoSpecifiedTests=false", "test"];
+}
+
 // Default argument vectors per lane, per tool. `warm` only affects Gradle (daemon
 // vs --no-daemon); Maven's warm tier swaps the binary (mvnd) instead.
 function defaultBuildArgs(warm) {
@@ -1827,7 +2217,7 @@ async function packageApp(extraArgs, warm, mavenProfiles) {
   };
 }
 
-async function test(extraArgs, warm, mavenProfiles) {
+async function test(extraArgs, warm, mavenProfiles, opts = {}) {
   if (!buildTool) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "test");
     return noToolResult();
@@ -1865,10 +2255,11 @@ async function test(extraArgs, warm, mavenProfiles) {
   const report = await collectSurefireReport(testRunStartedAt);
   lastTestReport = report;
   lastTest = report.summary;
-  // Persist the total only when the tool exited on its own (code is a number).
-  // A manual Stop kills the process (code === null), which would otherwise
-  // persist a partial total and skew the next run's bar.
-  if (code !== null && report.summary && report.summary.tests > 0) {
+  // Persist the total only when the tool exited on its own (code is a number)
+  // and this was a full-suite run. A manual Stop kills the process (code === null),
+  // which would otherwise persist a partial total; an affected (subset) run would
+  // otherwise shrink the full-suite estimate used to size the next run's bar.
+  if (!opts.affected && code !== null && report.summary && report.summary.tests > 0) {
     lastTestTotal = report.summary.tests;
     persistLastTestTotal(lastTestTotal);
   }
@@ -1883,6 +2274,59 @@ async function test(extraArgs, warm, mavenProfiles) {
     report: trimReportForAgent(report),
     tail: tail("test"),
   };
+}
+
+// Compute the affected-test selection for the current uncommitted changes, log a
+// human-readable summary to the Test console + a `tests-selection` event, and run
+// just those tests. Used by the Test tab's "Run affected" button and the
+// run_affected_tests agent action.
+async function runAffectedTests(warm, mavenProfiles) {
+  if (!buildTool) {
+    pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "test");
+    return noToolResult();
+  }
+  if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+
+  const sel = computeAffectedTests();
+  broadcast("tests-selection", sel);
+
+  if (!sel.ok) {
+    pushConsole(`[coffilot] Affected tests: ${sel.message}`, "stderr", "test");
+    return { ok: false, error: sel.message };
+  }
+  if (!sel.sources.length) {
+    const msg = sel.changedFiles.length
+      ? "No changed Java/Kotlin sources vs HEAD — nothing to test."
+      : "No uncommitted changes vs HEAD — nothing to test.";
+    pushConsole(`[coffilot] ${msg}`, "stdout", "test");
+    return { ok: true, skipped: true, selection: sel, message: msg };
+  }
+  if (!sel.tests.length) {
+    pushConsole(
+      `[coffilot] ${sel.sources.length} changed source(s) but no affected tests were found.`,
+      "stdout",
+      "test",
+    );
+    if (sel.fallback) {
+      pushConsole(
+        "[coffilot] Compiled classes not found — run Build for dependency-accurate selection.",
+        "stdout",
+        "test",
+      );
+    }
+    return { ok: true, skipped: true, selection: sel };
+  }
+
+  pushConsole(
+    `[coffilot] Infinitest-style selection: ${sel.tests.length} test class(es) affected by ${sel.sources.length} changed source(s)${sel.fallback ? " (name-based fallback — run Build for accurate selection)" : ""}.`,
+    "stdout",
+    "test",
+  );
+  for (const t of sel.tests) pushConsole(`  • ${t.fqcn}`, "stdout", "test");
+
+  const args = withMavenProfiles(affectedTestArgs(sel.tests, warm), mavenProfiles);
+  const result = await test(args, warm, mavenProfiles, { affected: true });
+  return { ...result, selection: sel };
 }
 
 async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
@@ -3447,7 +3891,10 @@ const server = createServer(async (req, res) => {
   }
   if (req.method === "POST" && url.pathname === "/api/test") {
     const body = await readBody(req);
-    test(null, body.warm === true, body.mavenProfiles);
+    // affected:true runs only the tests relevant to the current uncommitted
+    // changes (Infinitest-style); otherwise the full suite runs.
+    if (body.affected === true) runAffectedTests(body.warm === true, body.mavenProfiles);
+    else test(null, body.warm === true, body.mavenProfiles);
     sendJson(res, 200, { ok: true });
     return;
   }
@@ -3598,6 +4045,26 @@ function makeCanvas() {
           },
         },
         handler: async (ctx) => test(splitArgs(ctx.input?.args), ctx.input?.warm === true, ctx.input?.mavenProfiles),
+      },
+      {
+        name: "run_affected_tests",
+        description:
+          "Run only the tests affected by the current uncommitted changes (git working tree vs HEAD), Infinitest-style: Coffilot builds a dependency graph from the compiled .class files and runs just the test classes that transitively depend on the changed code — much faster than the full suite. Requires a prior compile (build_app/run_tests) for dependency-accurate selection; otherwise it falls back to name-based mapping (Foo → FooTest). Returns the parsed JUnit report for the tests it ran, plus the selection details.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            mavenProfiles: {
+              type: "string",
+              description: "Maven build profiles to activate via -P (Maven projects only; ignored for Gradle).",
+            },
+            warm: {
+              type: "boolean",
+              description:
+                "Keep the JVM warm between runs (Maven Daemon mvnd when available, or the Gradle daemon) for faster startup.",
+            },
+          },
+        },
+        handler: async (ctx) => runAffectedTests(ctx.input?.warm === true, ctx.input?.mavenProfiles),
       },
       {
         name: "package_app",

--- a/extension.mjs
+++ b/extension.mjs
@@ -1566,6 +1566,7 @@ let continuousPending = false;
 let continuousDebounce = null;
 let continuousProfiles = undefined; // Maven profiles captured when the mode was enabled
 let continuousSuspendDepth = 0; // >0 while a manual/agent build-group op holds priority
+let agentTurnSuspended = false; // true while the suspend gate is held for an in-flight agent turn
 
 function continuousStatus() {
   return { enabled: !!continuousWatcher, busy: continuousBusy };
@@ -1580,8 +1581,8 @@ function sourceWatchRoots() {
   return [...new Set(bases)].filter((d) => existsSync(d));
 }
 
-function startContinuousTesting(mavenProfiles) {
-  stopContinuousTesting({ silent: true });
+async function startContinuousTesting(mavenProfiles) {
+  await stopContinuousTesting({ silent: true });
   const roots = sourceWatchRoots();
   if (!roots.length) {
     pushConsole("[continuous] no src directory to watch; continuous testing not started.", "stderr", "test");
@@ -1616,11 +1617,15 @@ function startContinuousTesting(mavenProfiles) {
   return { ok: true, continuous: continuousStatus() };
 }
 
-function stopContinuousTesting({ silent = false } = {}) {
+async function stopContinuousTesting({ silent = false } = {}) {
   if (continuousDebounce) {
     clearTimeout(continuousDebounce);
     continuousDebounce = null;
   }
+  // Drop any deferred re-run so turning continuous off fully quiets the loop —
+  // otherwise a pending flag could re-arm a run after we've stopped.
+  continuousPending = false;
+  const wasOn = !!continuousWatcher;
   if (continuousWatcher) {
     try {
       continuousWatcher.close();
@@ -1628,6 +1633,17 @@ function stopContinuousTesting({ silent = false } = {}) {
       /* ignore */
     }
     continuousWatcher = null;
+  }
+  // If an automatic run is in flight, pre-empt it so turning continuous off
+  // immediately frees the shared Maven lane. Otherwise the in-flight run keeps the
+  // lane busy and the next manual Build/Test/Package is rejected as "already
+  // running" and silently no-ops — the canvas then looks stuck/empty.
+  if (continuousBusy) {
+    stopApp("maven");
+    await waitForLaneIdle(mvnLaneBusy, 8000);
+    continuousBusy = false;
+  }
+  if (wasOn) {
     if (!silent) pushConsole("[continuous] stopped.", "stdout", "test");
     broadcast("status", statusSnapshot());
   }
@@ -1692,6 +1708,42 @@ async function preemptContinuous() {
   stopApp("maven");
   await waitForLaneIdle(mvnLaneBusy, 8000);
 }
+
+// Pause continuous testing for the whole time the agent is working a request.
+// The agent mutates the working tree directly — editing files, reverting via
+// `git checkout`, the Fix-with-Copilot flow — outside any agent action, so those
+// raw changes would otherwise fire the src watcher and start a continuous run that
+// races (and can hang) Maven against files being rewritten/reverted underneath it.
+// We suspend on the first assistant turn and lift the gate once when the session
+// goes idle (the whole agentic loop, including tool calls and git ops, has
+// settled), so continuous testing re-runs exactly once against the agent's final
+// state instead of racing every intermediate edit. `assistant.turn_start` fires
+// per assistant turn (several times within one request), so a flag collapses the
+// many turn_starts into a single suspend that the idle event balances.
+function suspendContinuousForAgentTurn() {
+  if (agentTurnSuspended) return;
+  agentTurnSuspended = true;
+  if (continuousWatcher) {
+    pushConsole(
+      "[continuous] paused while Copilot works on your request; will re-run once it finishes.",
+      "stdout",
+      "test",
+    );
+  }
+  suspendContinuous().catch((e) =>
+    session.log(`[coffilot] agent-turn suspend failed: ${e.message}`, { level: "warn" }),
+  );
+}
+
+function resumeContinuousAfterAgentTurn() {
+  if (!agentTurnSuspended) return;
+  agentTurnSuspended = false;
+  if (continuousWatcher) pushConsole("[continuous] resuming now that Copilot has finished.", "stdout", "test");
+  resumeContinuous();
+}
+
+session.on("assistant.turn_start", suspendContinuousForAgentTurn);
+session.on("session.idle", resumeContinuousAfterAgentTurn);
 
 // Start the live-reload watcher if DevTools is enabled and a Spring app with the
 // DevTools dependency is currently running. Safe to call repeatedly. (Quarkus dev
@@ -2535,7 +2587,14 @@ async function test(extraArgs, warm, mavenProfiles, opts = {}) {
   const gated = !opts.fromContinuous;
   if (gated) await suspendContinuous();
   try {
-    if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+    if (mvnLaneBusy()) {
+      pushConsole(
+        "[coffilot] A build, test or package is already running — stop it first, then click Test again.",
+        "stderr",
+        "test",
+      );
+      return { ok: false, error: "A build, test or package is already running. Stop it first." };
+    }
     const r = resolveRunner(warm);
     const base = extraArgs && extraArgs.length ? extraArgs : defaultTestArgs(r.warm);
     const args = withMavenProfiles(base, mavenProfiles);
@@ -2566,6 +2625,11 @@ async function test(extraArgs, warm, mavenProfiles, opts = {}) {
       broadcastTestProgress();
     }
     const report = await collectSurefireReport(testRunStartedAt);
+    // Tag the report with the tool's exit code so the graphical view can tell a
+    // genuine "no tests" run apart from a build/compile failure (non-zero exit with
+    // no Surefire reports), which otherwise looks like Coffilot ran nothing. null =
+    // killed/stopped, which must not be shown as a build failure.
+    report.buildExit = code;
     lastTestReport = report;
     lastTest = report.summary;
     // Persist the total only when the tool exited on its own (code is a number)
@@ -2652,69 +2716,107 @@ async function runAffectedTests(warm, mavenProfiles, opts = {}) {
 }
 
 async function runAffectedTestsCore(warm, mavenProfiles, opts = {}) {
-  if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
-
-  // Continuous mode compiles the changed sources first so the selection below sees
-  // the just-saved edit (new classes / new dependency edges land in the .class index
-  // the graph is built from). A compile failure surfaces in the Test console and
-  // stops the run — the tests couldn't have compiled anyway, and it re-runs on the
-  // next save. Manual / agent affected runs skip this and stay fast.
-  if (opts.fromContinuous) {
-    const code = await compileForSelection(warm, mavenProfiles);
-    if (code === null) return { ok: false, error: "Interrupted." };
-    if (code !== 0) {
+  if (mvnLaneBusy()) {
+    if (!opts.fromContinuous) {
       pushConsole(
-        "[continuous] compilation failed — fix the errors above; tests re-run on the next save.",
+        "[coffilot] A build, test or package is already running — stop it first, then click Test again.",
         "stderr",
         "test",
       );
-      return { ok: false, error: "Compilation failed.", compileFailed: true };
     }
+    return { ok: false, error: "A build, test or package is already running. Stop it first." };
   }
 
-  const sel = computeAffectedTests();
-  broadcast("tests-selection", sel);
+  // Only test() refreshes the graphical test view (it broadcasts a "tests" event).
+  // In continuous mode, compileForSelection below runs on the test lane in phase
+  // "testing", which makes followLaneActivity show the "Running tests…" placeholder.
+  // If we flash that placeholder but then exit early (interrupted, compile failure, or
+  // no affected tests after compiling) without handing off to test(), the finally
+  // re-broadcasts the last report so the placeholder clears. When we never touch the
+  // lane (e.g. nothing changed vs HEAD) we leave the view as it is — blanking it to
+  // "No test run yet" would look broken.
+  let suiteRan = false;
+  let flashedLane = false;
+  try {
+    // Continuous mode compiles the changed sources first so the selection below sees
+    // the just-saved edit (new classes / new dependency edges land in the .class index
+    // the graph is built from). A compile failure surfaces in the Test console and
+    // stops the run — the tests couldn't have compiled anyway, and it re-runs on the
+    // next save. Manual / agent affected runs skip this and stay fast.
+    if (opts.fromContinuous) {
+      // Skip the compile entirely when nothing changed vs HEAD (e.g. the agent
+      // reverted the edit via git): there's nothing to compile or test, and a no-op
+      // compile would needlessly flash the test lane through its "testing" phase.
+      const git = gitChangedFiles();
+      const hasChangedSource = git.ok && git.files.some((f) => sourceFileToClass(f));
+      if (hasChangedSource) {
+        flashedLane = true;
+        const code = await compileForSelection(warm, mavenProfiles);
+        if (code === null) return { ok: false, error: "Interrupted." };
+        if (code !== 0) {
+          pushConsole(
+            "[continuous] compilation failed — fix the errors above; tests re-run on the next save.",
+            "stderr",
+            "test",
+          );
+          return { ok: false, error: "Compilation failed.", compileFailed: true };
+        }
+      }
+    }
 
-  if (!sel.ok) {
-    pushConsole(`[coffilot] Affected tests: ${sel.message}`, "stderr", "test");
-    return { ok: false, error: sel.message };
-  }
-  if (!sel.sources.length) {
-    const msg = sel.changedFiles.length
-      ? "No changed Java/Kotlin sources vs HEAD — nothing to test."
-      : "No uncommitted changes vs HEAD — nothing to test.";
-    pushConsole(`[coffilot] ${msg}`, "stdout", "test");
-    return { ok: true, skipped: true, selection: sel, message: msg };
-  }
-  if (!sel.tests.length) {
-    pushConsole(
-      `[coffilot] ${sel.sources.length} changed source(s) but no affected tests were found.`,
-      "stdout",
-      "test",
-    );
-    if (sel.fallback) {
+    const sel = computeAffectedTests();
+    broadcast("tests-selection", sel);
+
+    if (!sel.ok) {
+      pushConsole(`[coffilot] Affected tests: ${sel.message}`, "stderr", "test");
+      return { ok: false, error: sel.message };
+    }
+    if (!sel.sources.length) {
+      const msg = sel.changedFiles.length
+        ? "No changed Java/Kotlin sources vs HEAD — nothing to test."
+        : "No uncommitted changes vs HEAD — nothing to test.";
+      pushConsole(`[coffilot] ${msg}`, "stdout", "test");
+      return { ok: true, skipped: true, selection: sel, message: msg };
+    }
+    if (!sel.tests.length) {
       pushConsole(
-        "[coffilot] Compiled classes not found — run Build for dependency-accurate selection.",
+        `[coffilot] ${sel.sources.length} changed source(s) but no affected tests were found.`,
         "stdout",
         "test",
       );
+      if (sel.fallback) {
+        pushConsole(
+          "[coffilot] Compiled classes not found — run Build for dependency-accurate selection.",
+          "stdout",
+          "test",
+        );
+      }
+      return { ok: true, skipped: true, selection: sel };
     }
-    return { ok: true, skipped: true, selection: sel };
+
+    pushConsole(
+      `[coffilot] Affected-test selection: ${sel.tests.length} test class(es) affected by ${sel.sources.length} changed source(s)${sel.fallback ? " (name-based fallback — run Build for accurate selection)" : ""}.`,
+      "stdout",
+      "test",
+    );
+    for (const t of sel.tests) pushConsole(`  • ${t.fqcn}`, "stdout", "test");
+
+    const args = withMavenProfiles(affectedTestArgs(sel.tests, warm), mavenProfiles);
+    const result = await test(args, warm, mavenProfiles, {
+      affected: true,
+      fromContinuous: opts.fromContinuous === true,
+    });
+    // test() only refreshes the view when it actually spawned the suite (its result
+    // carries an exitCode); if it bailed early — e.g. the lane was grabbed during the
+    // await above — fall through to the finally so the view still recovers.
+    suiteRan = result != null && "exitCode" in result;
+    return { ...result, selection: sel };
+  } finally {
+    // Only recover the view if we actually flashed the "Running tests…" placeholder
+    // (a continuous compile) but never handed off to test(); otherwise leave whatever
+    // the view was showing so a no-op run never blanks the last results.
+    if (flashedLane && !suiteRan) broadcast("tests", lastTestReport);
   }
-
-  pushConsole(
-    `[coffilot] Affected-test selection: ${sel.tests.length} test class(es) affected by ${sel.sources.length} changed source(s)${sel.fallback ? " (name-based fallback — run Build for accurate selection)" : ""}.`,
-    "stdout",
-    "test",
-  );
-  for (const t of sel.tests) pushConsole(`  • ${t.fqcn}`, "stdout", "test");
-
-  const args = withMavenProfiles(affectedTestArgs(sel.tests, warm), mavenProfiles);
-  const result = await test(args, warm, mavenProfiles, {
-    affected: true,
-    fromContinuous: opts.fromContinuous === true,
-  });
-  return { ...result, selection: sel };
 }
 
 async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
@@ -4721,7 +4823,8 @@ const server = createServer(async (req, res) => {
     // Toggle the continuous-testing watcher: on saves it re-runs the affected
     // tests. Always uses affected selection (the Full build toggle is disabled
     // in the UI while this is on).
-    const result = body.enabled === true ? startContinuousTesting(body.mavenProfiles) : stopContinuousTesting();
+    const result =
+      body.enabled === true ? await startContinuousTesting(body.mavenProfiles) : await stopContinuousTesting();
     sendJson(res, 200, result);
     return;
   }

--- a/extension.mjs
+++ b/extension.mjs
@@ -758,7 +758,7 @@ function findProjectRoot(primary) {
 // under COPILOT_HOME (not the repo) keyed by a hash of the workspace path.
 // ---------------------------------------------------------------------------
 
-const SETTINGS_KEYS = ["warm", "springProfiles", "devtools", "randomPort", "openBrowser"];
+const SETTINGS_KEYS = ["warm", "springProfiles", "devtools", "randomPort", "openBrowser", "fullBuild"];
 
 function settingsPaths() {
   const home = process.env.COPILOT_HOME || path.join(os.homedir(), ".copilot");
@@ -774,6 +774,9 @@ function defaultSettings() {
     devtools: false,
     randomPort: false,
     openBrowser: false,
+    // On by default: the Test button runs the whole suite. Off runs only the
+    // tests affected by the current uncommitted changes.
+    fullBuild: true,
   };
 }
 
@@ -1456,6 +1459,146 @@ function finishRecompile() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Continuous testing — re-run the affected tests whenever a source file changes.
+// Mirrors the live-reload watcher: a dependency-free recursive fs.watch over the
+// project's src roots, debounced, with a busy/pending guard so overlapping saves
+// collapse into a single follow-up run.
+// ---------------------------------------------------------------------------
+
+let continuousWatcher = null; // active watcher handle while continuous testing is on
+let continuousBusy = false;
+let continuousPending = false;
+let continuousDebounce = null;
+let continuousProfiles = undefined; // Maven profiles captured when the mode was enabled
+let continuousSuspendDepth = 0; // >0 while a manual/agent build-group op holds priority
+
+function continuousStatus() {
+  return { enabled: !!continuousWatcher, busy: continuousBusy };
+}
+
+// Watch each module's src/ (covers main + test sources). Watching src/ rather
+// than target/ or build/ avoids a feedback loop where a test run's recompiled
+// .class files would retrigger the watcher.
+function sourceWatchRoots() {
+  const mods = listModules();
+  const bases = (mods.length ? mods : [{ name: "" }]).map((m) => path.join(workspacePath, m.name || "", "src"));
+  return [...new Set(bases)].filter((d) => existsSync(d));
+}
+
+function startContinuousTesting(mavenProfiles) {
+  stopContinuousTesting({ silent: true });
+  const roots = sourceWatchRoots();
+  if (!roots.length) {
+    pushConsole("[continuous] no src directory to watch; continuous testing not started.", "stderr", "test");
+    broadcast("status", statusSnapshot());
+    return { ok: false, error: "No src directory to watch.", continuous: continuousStatus() };
+  }
+  continuousProfiles = mavenProfiles && String(mavenProfiles).trim() ? String(mavenProfiles).trim() : undefined;
+  const handles = roots.map((root) =>
+    watchTree(root, (file) => {
+      if (!SOURCE_RE.test(file)) return;
+      if (continuousDebounce) clearTimeout(continuousDebounce);
+      continuousDebounce = setTimeout(triggerContinuousRun, 450);
+    }),
+  );
+  continuousWatcher = {
+    close() {
+      for (const h of handles) {
+        try {
+          h.close();
+        } catch {
+          /* ignore */
+        }
+      }
+    },
+  };
+  pushConsole(
+    `[continuous] watching ${roots.map((r) => path.relative(workspacePath, r) || ".").join(", ")} — saving a source file recompiles it, then re-runs the affected tests.`,
+    "stdout",
+    "test",
+  );
+  broadcast("status", statusSnapshot());
+  return { ok: true, continuous: continuousStatus() };
+}
+
+function stopContinuousTesting({ silent = false } = {}) {
+  if (continuousDebounce) {
+    clearTimeout(continuousDebounce);
+    continuousDebounce = null;
+  }
+  if (continuousWatcher) {
+    try {
+      continuousWatcher.close();
+    } catch {
+      /* ignore */
+    }
+    continuousWatcher = null;
+    if (!silent) pushConsole("[continuous] stopped.", "stdout", "test");
+    broadcast("status", statusSnapshot());
+  }
+  return { ok: true, continuous: continuousStatus() };
+}
+
+function triggerContinuousRun() {
+  if (!continuousWatcher) return;
+  // Defer while a manual/agent build-group op holds priority (suspend gate), while
+  // a continuous run is already in flight, or while any build-group process holds
+  // the shared Maven lane; collapse overlapping triggers into one follow-up run.
+  if (continuousSuspendDepth > 0 || continuousBusy || mvnLaneBusy()) {
+    continuousPending = true;
+    return;
+  }
+  continuousBusy = true;
+  broadcast("status", statusSnapshot());
+  Promise.resolve(runAffectedTests(settings.warm === true, continuousProfiles, { fromContinuous: true }))
+    .catch((e) => pushConsole(`[continuous] run failed: ${e.message}`, "stderr", "test"))
+    .finally(() => {
+      continuousBusy = false;
+      broadcast("status", statusSnapshot());
+      if (continuousPending && continuousWatcher && continuousSuspendDepth === 0) {
+        continuousPending = false;
+        triggerContinuousRun();
+      }
+    });
+}
+
+// Reentrant gate that pauses continuous testing while a manual/agent build-group
+// op runs (Build/Test/Package, including agent actions and the Fix-with-Copilot
+// flow). The first suspend pre-empts any in-flight auto-run and blocks new ones
+// for the whole op; the matching resume re-arms continuous and runs once if source
+// saves landed meanwhile. A counter (not a boolean) keeps nested calls balanced —
+// e.g. runAffectedTests → test — so the gate only lifts when the outermost op ends.
+async function suspendContinuous() {
+  continuousSuspendDepth++;
+  if (continuousSuspendDepth === 1) await preemptContinuous();
+}
+
+function resumeContinuous() {
+  if (continuousSuspendDepth > 0) continuousSuspendDepth--;
+  if (continuousSuspendDepth !== 0) return;
+  // Outermost op finished: if saves were deferred (or an in-flight auto-run was
+  // pre-empted) while suspended, re-run the affected tests once. Use the watcher's
+  // debounce so a rapid next op collapses this instead of churning the lane.
+  if (continuousWatcher && continuousPending && !continuousBusy) {
+    continuousPending = false;
+    if (continuousDebounce) clearTimeout(continuousDebounce);
+    continuousDebounce = setTimeout(triggerContinuousRun, 450);
+  }
+}
+
+// Stop the in-flight continuous auto-run so a manual/agent build-group op can take
+// the shared Maven lane instead of being rejected as "already running". The killed
+// run's saved change is remembered (continuousPending) so it re-runs once the op
+// finishes (resumeContinuous drains it). Only ever called by suspendContinuous.
+async function preemptContinuous() {
+  if (!continuousBusy) return;
+  continuousPending = true;
+  pushConsole("[continuous] pausing the auto-run for a manual build/test/package…", "stdout", "test");
+  stopApp("maven");
+  await waitForLaneIdle(mvnLaneBusy, 8000);
+}
+
 // Start the live-reload watcher if DevTools is enabled and a Spring app with the
 // DevTools dependency is currently running. Safe to call repeatedly. (Quarkus dev
 // mode has its own built-in live reload, so it never needs this watcher.)
@@ -1479,6 +1622,7 @@ function applySettings(body) {
   if (typeof body.devtools === "boolean") settings.devtools = body.devtools;
   if (typeof body.randomPort === "boolean") settings.randomPort = body.randomPort;
   if (typeof body.openBrowser === "boolean") settings.openBrowser = body.openBrowser;
+  if (typeof body.fullBuild === "boolean") settings.fullBuild = body.fullBuild;
   persistSettings();
 
   if (settings.devtools !== prev.devtools) {
@@ -1570,6 +1714,7 @@ function statusSnapshot() {
     run: laneStatus("run"),
     metricsTier: lastMetrics.metricsTier || null,
     reload: liveReloadStatus(),
+    continuous: continuousStatus(),
   };
 }
 
@@ -1819,15 +1964,14 @@ function withMavenProfiles(args, mavenProfiles) {
 }
 
 // ---------------------------------------------------------------------------
-// Affected-test selection (Infinitest-style)
+// Affected-test selection
 //
-// Like Infinitest, "Run affected" runs only the tests relevant to the
-// developer's current changes instead of the whole suite. The approach mirrors
-// Infinitest's:
+// "Run affected" runs only the tests relevant to the developer's current
+// changes instead of the whole suite, using a bytecode dependency graph:
 //   1. Build a dependency graph from the compiled .class files. Each class's
 //      constant pool lists every other class it references, so an edge A→B means
-//      "A uses B". (Infinitest does this with Javassist; we parse the constant
-//      pool directly so Coffilot needs no extra dependencies.)
+//      "A uses B". (We parse the constant pool directly so Coffilot needs no
+//      extra dependencies.)
 //   2. Find what changed: the uncommitted working-tree changes vs HEAD (git),
 //      mapped from .java/.kt/… source paths to fully-qualified class names.
 //   3. Walk the graph backwards from the changed classes to every class that
@@ -1855,7 +1999,7 @@ const TEST_MARKERS = new Set([
 ]);
 
 // Tests that load classes dynamically (e.g. ArchUnit scanning a package) have no
-// statically computable dependencies, so — like Infinitest — we always run them.
+// statically computable dependencies, so we always run them.
 const DYNAMIC_TEST_PREFIXES = ["com.tngtech.archunit"];
 
 // Turn an internal JVM class/type descriptor into a dotted class name, or null
@@ -1871,7 +2015,7 @@ function internalToDotted(name) {
 }
 
 // Parse a .class file's constant pool and return the set of dotted class names it
-// references (its "imports", in Infinitest terms). We only need the constant pool,
+// references (its "imports"). We only need the constant pool,
 // so we stop before the field/method/attribute tables. Returns null if the bytes
 // are not a recognisable class file.
 function parseClassRefs(buf) {
@@ -2044,7 +2188,7 @@ const enclosingClass = (name) => name.split("$")[0];
 // top-level class with its owning module.
 function affectedTestsFromIndex(index, changedClasses) {
   // Reverse adjacency: referenced → set of referrers, restricted to project
-  // classes (Infinitest only keeps edges between indexed classes).
+  // classes (we only keep edges between indexed classes).
   const reverse = new Map();
   for (const [name, entry] of index) {
     for (const ref of entry.refs) {
@@ -2230,20 +2374,25 @@ async function build(extraArgs, warm, mavenProfiles) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "build");
     return noToolResult();
   }
-  if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
-  const r = resolveRunner(warm);
-  const base = extraArgs && extraArgs.length ? extraArgs : defaultBuildArgs(r.warm);
-  const args = withMavenProfiles(base, mavenProfiles);
-  lanes.build.warm = r.warm;
-  const code = await spawnTool("build", args, "building", { bin: r.bin, label: r.label });
-  return {
-    ok: code === 0,
-    exitCode: code,
-    command: lanes.build.command,
-    runner: r.label,
-    warm: r.warm,
-    tail: tail("build"),
-  };
+  await suspendContinuous();
+  try {
+    if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+    const r = resolveRunner(warm);
+    const base = extraArgs && extraArgs.length ? extraArgs : defaultBuildArgs(r.warm);
+    const args = withMavenProfiles(base, mavenProfiles);
+    lanes.build.warm = r.warm;
+    const code = await spawnTool("build", args, "building", { bin: r.bin, label: r.label });
+    return {
+      ok: code === 0,
+      exitCode: code,
+      command: lanes.build.command,
+      runner: r.label,
+      warm: r.warm,
+      tail: tail("build"),
+    };
+  } finally {
+    resumeContinuous();
+  }
 }
 
 async function packageApp(extraArgs, warm, mavenProfiles) {
@@ -2251,20 +2400,25 @@ async function packageApp(extraArgs, warm, mavenProfiles) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "package");
     return noToolResult();
   }
-  if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
-  const r = resolveRunner(warm);
-  const base = extraArgs && extraArgs.length ? extraArgs : defaultPackageArgs(r.warm);
-  const args = withMavenProfiles(base, mavenProfiles);
-  lanes.package.warm = r.warm;
-  const code = await spawnTool("package", args, "packaging", { bin: r.bin, label: r.label });
-  return {
-    ok: code === 0,
-    exitCode: code,
-    command: lanes.package.command,
-    runner: r.label,
-    warm: r.warm,
-    tail: tail("package"),
-  };
+  await suspendContinuous();
+  try {
+    if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+    const r = resolveRunner(warm);
+    const base = extraArgs && extraArgs.length ? extraArgs : defaultPackageArgs(r.warm);
+    const args = withMavenProfiles(base, mavenProfiles);
+    lanes.package.warm = r.warm;
+    const code = await spawnTool("package", args, "packaging", { bin: r.bin, label: r.label });
+    return {
+      ok: code === 0,
+      exitCode: code,
+      command: lanes.package.command,
+      runner: r.label,
+      warm: r.warm,
+      tail: tail("package"),
+    };
+  } finally {
+    resumeContinuous();
+  }
 }
 
 async function test(extraArgs, warm, mavenProfiles, opts = {}) {
@@ -2272,70 +2426,148 @@ async function test(extraArgs, warm, mavenProfiles, opts = {}) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "test");
     return noToolResult();
   }
-  if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
-  const r = resolveRunner(warm);
-  const base = extraArgs && extraArgs.length ? extraArgs : defaultTestArgs(r.warm);
-  const args = withMavenProfiles(base, mavenProfiles);
-  lanes.test.warm = r.warm;
-  lastTestReport = null;
-  broadcast("tests", null);
-  // Seed the progress-bar estimate: persisted total if we have one, otherwise
-  // the total from any test reports already on disk (a prior run), so the
-  // bar is determinate from the first run instead of an indeterminate sweep.
-  let estimate = lastTestTotal;
-  if (!estimate) {
-    try {
-      const prev = await collectSurefireReport(0);
-      estimate = (prev.summary && prev.summary.tests) || 0;
-    } catch {
-      estimate = 0;
+  // A manual/agent test takes over from a background continuous run via the suspend
+  // gate; the continuous run itself (fromContinuous) must not suspend/pre-empt —
+  // that would stop its own process.
+  const gated = !opts.fromContinuous;
+  if (gated) await suspendContinuous();
+  try {
+    if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+    const r = resolveRunner(warm);
+    const base = extraArgs && extraArgs.length ? extraArgs : defaultTestArgs(r.warm);
+    const args = withMavenProfiles(base, mavenProfiles);
+    lanes.test.warm = r.warm;
+    lastTestReport = null;
+    broadcast("tests", null);
+    // Seed the progress-bar estimate: persisted total if we have one, otherwise
+    // the total from any test reports already on disk (a prior run), so the
+    // bar is determinate from the first run instead of an indeterminate sweep.
+    let estimate = lastTestTotal;
+    if (!estimate) {
+      try {
+        const prev = await collectSurefireReport(0);
+        estimate = (prev.summary && prev.summary.tests) || 0;
+      } catch {
+        estimate = 0;
+      }
     }
+    resetTestProgress(estimate);
+    testRunStartedAt = Date.now();
+    // Live per-class progress is parsed from Surefire's console output (Maven only);
+    // Gradle's default output isn't per-test, so its graphical view fills in from
+    // the JUnit XML report once the run finishes.
+    const onLine = buildTool === "maven" ? onTestLine : undefined;
+    const code = await spawnTool("test", args, "testing", { bin: r.bin, label: r.label, onLine });
+    if (testProgress) {
+      testProgress.running = false;
+      broadcastTestProgress();
+    }
+    const report = await collectSurefireReport(testRunStartedAt);
+    lastTestReport = report;
+    lastTest = report.summary;
+    // Persist the total only when the tool exited on its own (code is a number)
+    // and this was a full-suite run. A manual Stop kills the process (code === null),
+    // which would otherwise persist a partial total; an affected (subset) run would
+    // otherwise shrink the full-suite estimate used to size the next run's bar.
+    if (!opts.affected && code !== null && report.summary && report.summary.tests > 0) {
+      lastTestTotal = report.summary.tests;
+      persistLastTestTotal(lastTestTotal);
+    }
+    broadcast("tests", report);
+    broadcast("status", statusSnapshot());
+    return {
+      ok: code === 0,
+      exitCode: code,
+      command: lanes.test.command,
+      runner: r.label,
+      warm: r.warm,
+      report: trimReportForAgent(report),
+      tail: tail("test"),
+    };
+  } finally {
+    if (gated) resumeContinuous();
   }
-  resetTestProgress(estimate);
-  testRunStartedAt = Date.now();
-  // Live per-class progress is parsed from Surefire's console output (Maven only);
-  // Gradle's default output isn't per-test, so its graphical view fills in from
-  // the JUnit XML report once the run finishes.
-  const onLine = buildTool === "maven" ? onTestLine : undefined;
-  const code = await spawnTool("test", args, "testing", { bin: r.bin, label: r.label, onLine });
-  if (testProgress) {
-    testProgress.running = false;
-    broadcastTestProgress();
+}
+
+// Continuous mode only: recompile main + test sources before computing the
+// affected-test selection. The selection's dependency graph is built from the
+// compiled .class files (buildClassIndex), so a freshly-edited class — or worse, a
+// brand-new class or a newly-added dependency edge — is invisible to selection
+// until it has been compiled. Compiling first keeps the graph in sync with the
+// just-saved edit; the affected-test run that follows then finds everything
+// already compiled (an up-to-date no-op). Returns the tool exit code (0 = ok,
+// null = killed/pre-empted, anything else = compile failure).
+async function compileForSelection(warm, mavenProfiles) {
+  const r = resolveRunner(warm);
+  let args;
+  if (buildTool === "gradle") {
+    // Compile only the modules whose sources changed: each owns an edited file, so
+    // its :module:testClasses task is guaranteed to exist. A bare `testClasses`
+    // would build only the root project, while listing every module risks hitting a
+    // sourceless aggregator that has no such task. Unchanged modules keep their
+    // current .class references already.
+    const git = gitChangedFiles();
+    const modules = new Set();
+    if (git.ok) {
+      for (const f of git.files) {
+        const c = sourceFileToClass(f);
+        if (c) modules.add(c.module || "");
+      }
+    }
+    const tasks = (modules.size ? [...modules] : [""]).map((m) => gradleTaskPath(m, "testClasses"));
+    args = [...tasks, "--console=plain", ...gradleWarmFlags(r.warm)];
+  } else {
+    // Maven's reactor recompiles only stale modules (incremental compilation);
+    // test-compile refreshes both the main and test .class output the graph reads.
+    args = ["-ntp", "test-compile"];
   }
-  const report = await collectSurefireReport(testRunStartedAt);
-  lastTestReport = report;
-  lastTest = report.summary;
-  // Persist the total only when the tool exited on its own (code is a number)
-  // and this was a full-suite run. A manual Stop kills the process (code === null),
-  // which would otherwise persist a partial total; an affected (subset) run would
-  // otherwise shrink the full-suite estimate used to size the next run's bar.
-  if (!opts.affected && code !== null && report.summary && report.summary.tests > 0) {
-    lastTestTotal = report.summary.tests;
-    persistLastTestTotal(lastTestTotal);
-  }
-  broadcast("tests", report);
-  broadcast("status", statusSnapshot());
-  return {
-    ok: code === 0,
-    exitCode: code,
-    command: lanes.test.command,
-    runner: r.label,
-    warm: r.warm,
-    report: trimReportForAgent(report),
-    tail: tail("test"),
-  };
+  args = withMavenProfiles(args, mavenProfiles);
+  lanes.test.warm = r.warm;
+  return spawnTool("test", args, "testing", { bin: r.bin, label: r.label });
 }
 
 // Compute the affected-test selection for the current uncommitted changes, log a
 // human-readable summary to the Test console + a `tests-selection` event, and run
 // just those tests. Used by the Test tab's "Run affected" button and the
 // run_affected_tests agent action.
-async function runAffectedTests(warm, mavenProfiles) {
+async function runAffectedTests(warm, mavenProfiles, opts = {}) {
   if (!buildTool) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "test");
     return noToolResult();
   }
+  // A continuous run is already serialized by the watcher/busy flags and must not
+  // suspend itself. Manual and agent affected runs go through the suspend gate so
+  // they take priority over an in-flight continuous run (pre-empting it) instead of
+  // being rejected as "already running".
+  if (opts.fromContinuous) return runAffectedTestsCore(warm, mavenProfiles, opts);
+  await suspendContinuous();
+  try {
+    return await runAffectedTestsCore(warm, mavenProfiles, opts);
+  } finally {
+    resumeContinuous();
+  }
+}
+
+async function runAffectedTestsCore(warm, mavenProfiles, opts = {}) {
   if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
+
+  // Continuous mode compiles the changed sources first so the selection below sees
+  // the just-saved edit (new classes / new dependency edges land in the .class index
+  // the graph is built from). A compile failure surfaces in the Test console and
+  // stops the run — the tests couldn't have compiled anyway, and it re-runs on the
+  // next save. Manual / agent affected runs skip this and stay fast.
+  if (opts.fromContinuous) {
+    const code = await compileForSelection(warm, mavenProfiles);
+    if (code === null) return { ok: false, error: "Interrupted." };
+    if (code !== 0) {
+      pushConsole(
+        "[continuous] compilation failed — fix the errors above; tests re-run on the next save.",
+        "stderr",
+        "test",
+      );
+      return { ok: false, error: "Compilation failed.", compileFailed: true };
+    }
+  }
 
   const sel = computeAffectedTests();
   broadcast("tests-selection", sel);
@@ -2368,14 +2600,17 @@ async function runAffectedTests(warm, mavenProfiles) {
   }
 
   pushConsole(
-    `[coffilot] Infinitest-style selection: ${sel.tests.length} test class(es) affected by ${sel.sources.length} changed source(s)${sel.fallback ? " (name-based fallback — run Build for accurate selection)" : ""}.`,
+    `[coffilot] Affected-test selection: ${sel.tests.length} test class(es) affected by ${sel.sources.length} changed source(s)${sel.fallback ? " (name-based fallback — run Build for accurate selection)" : ""}.`,
     "stdout",
     "test",
   );
   for (const t of sel.tests) pushConsole(`  • ${t.fqcn}`, "stdout", "test");
 
   const args = withMavenProfiles(affectedTestArgs(sel.tests, warm), mavenProfiles);
-  const result = await test(args, warm, mavenProfiles, { affected: true });
+  const result = await test(args, warm, mavenProfiles, {
+    affected: true,
+    fromContinuous: opts.fromContinuous === true,
+  });
   return { ...result, selection: sel };
 }
 
@@ -2922,8 +3157,12 @@ async function restart(op, params = {}) {
   }
   // Fire-and-forget, like the /api/build|test|package handlers: progress streams
   // over SSE, so the relaunch must not block the HTTP response until it finishes.
-  const startFn = op === "build" ? build : op === "test" ? test : packageApp;
-  startFn(null, params.warm === true, params.mavenProfiles);
+  if (op === "test" && params.affected === true) {
+    runAffectedTests(params.warm === true, params.mavenProfiles);
+  } else {
+    const startFn = op === "build" ? build : op === "test" ? test : packageApp;
+    startFn(null, params.warm === true, params.mavenProfiles);
+  }
   return { ok: true, restarted: true, op };
 }
 
@@ -3994,10 +4233,19 @@ const server = createServer(async (req, res) => {
   if (req.method === "POST" && url.pathname === "/api/test") {
     const body = await readBody(req);
     // affected:true runs only the tests relevant to the current uncommitted
-    // changes (Infinitest-style); otherwise the full suite runs.
+    // changes; otherwise the full suite runs.
     if (body.affected === true) runAffectedTests(body.warm === true, body.mavenProfiles);
     else test(null, body.warm === true, body.mavenProfiles);
     sendJson(res, 200, { ok: true });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/test/continuous") {
+    const body = await readBody(req);
+    // Toggle the continuous-testing watcher: on saves it re-runs the affected
+    // tests. Always uses affected selection (the Full build toggle is disabled
+    // in the UI while this is on).
+    const result = body.enabled === true ? startContinuousTesting(body.mavenProfiles) : stopContinuousTesting();
+    sendJson(res, 200, result);
     return;
   }
   if (req.method === "POST" && url.pathname === "/api/package") {
@@ -4168,7 +4416,7 @@ function makeCanvas() {
       {
         name: "run_affected_tests",
         description:
-          "Run only the tests affected by the current uncommitted changes (git working tree vs HEAD), Infinitest-style: Coffilot builds a dependency graph from the compiled .class files and runs just the test classes that transitively depend on the changed code — much faster than the full suite. Requires a prior compile (build_app/run_tests) for dependency-accurate selection; otherwise it falls back to name-based mapping (Foo → FooTest). Returns the parsed JUnit report for the tests it ran, plus the selection details.",
+          "Run only the tests affected by the current uncommitted changes (git working tree vs HEAD): Coffilot builds a dependency graph from the compiled .class files and runs just the test classes that transitively depend on the changed code — much faster than the full suite. Requires a prior compile (build_app/run_tests) for dependency-accurate selection; otherwise it falls back to name-based mapping (Foo → FooTest). Returns the parsed JUnit report for the tests it ran, plus the selection details.",
         inputSchema: {
           type: "object",
           properties: {

--- a/public/app.js
+++ b/public/app.js
@@ -24,8 +24,10 @@ const exitEl = document.getElementById("exit");
 const metricsEl = document.getElementById("metrics");
 const testsEl = document.getElementById("tests");
 const tabBadge = document.getElementById("tab-tests-badge");
-const btnTestAffected = document.getElementById("btn-test-affected");
-const btnTestAffectedSpin = document.querySelector("#btn-test-affected .btn-spin");
+const fullbuildToggle = document.getElementById("fullbuild-toggle");
+const fullbuildInput = document.getElementById("in-fullbuild");
+const continuousToggle = document.getElementById("continuous-toggle");
+const continuousInput = document.getElementById("in-continuous");
 const testSelectionEl = document.getElementById("test-selection");
 const warmToggle = document.getElementById("warm-toggle");
 const warmInput = document.getElementById("in-warm");
@@ -115,6 +117,11 @@ let caps = {};
 // Whether a Maven/Gradle build tool is present. When false the canvas runs
 // in degraded mode: Build/Test/Package/Run stay disabled.
 let toolPresent = true;
+// Persisted "Full build" preference (env.settings.fullBuild), on by default.
+// Tracked here so renderStatus can show the toggle unchecked while continuous
+// testing overrides it, then restore the user's choice once continuous testing
+// is turned off.
+let fullBuildSetting = true;
 // Last JDTLS availability snapshot (env.jdtls), used for the toolchain pill.
 let jdtlsState = {};
 
@@ -400,34 +407,34 @@ function renderStatus(s) {
   // While a build op runs the lane is serialized, so grey out the other
   // Build/Test/Package buttons (the running one stays active — click it again
   // to restart). Everything is disabled when no build tool is present.
+  //
+  // Exception: a *continuous* (automatic) test run must not lock the toolbar.
+  // The user can still click Build/Test/Package to run it now; that pre-empts
+  // the background auto-run via the restart path. So a continuous-driven test
+  // run doesn't count as a blocking op for the sibling buttons.
+  const continuousRunning = !!(s.continuous && s.continuous.busy);
   const busyMvnOp = ["build", "test", "package"].find((op) => laneActive(s, op));
+  const blockingMvnOp = continuousRunning && busyMvnOp === "test" ? undefined : busyMvnOp;
   for (const op of ["build", "test", "package"]) {
     const btn = mvnButtons[op];
     if (!btn) continue;
     // The running op stays clickable (to restart); idle siblings are greyed out
     // until it stops, and the op itself is locked while its restart is in flight.
-    btn.disabled = !toolPresent || (!!busyMvnOp && op !== busyMvnOp) || !!restarting[op];
+    btn.disabled = !toolPresent || (!!blockingMvnOp && op !== blockingMvnOp) || !!restarting[op];
     btn.title = !toolPresent
       ? "Coffilot needs a Maven or Gradle project."
       : restarting[op]
         ? "Restarting\u2026"
-        : op === busyMvnOp
+        : op === blockingMvnOp
           ? `Restart the running ${op}`
           : btn.disabled
-            ? `Stop the running ${busyMvnOp} first`
-            : "";
+            ? `Stop the running ${blockingMvnOp} first`
+            : continuousRunning
+              ? "Continuous testing is running \u2014 click to run this now"
+              : "";
   }
-  // "Run affected" shares the serialized Maven lane; spinner follows the test lane.
-  if (btnTestAffected) {
-    const testBusy = !!(s.test && s.test.busy);
-    btnTestAffected.disabled = !toolPresent || (!!busyMvnOp && !testBusy);
-    btnTestAffected.title = !toolPresent
-      ? "Coffilot needs a Maven or Gradle project."
-      : btnTestAffected.disabled
-        ? `Stop the running ${busyMvnOp} first`
-        : "Run only the tests affected by your uncommitted changes vs HEAD (Infinitest-style)";
-    if (btnTestAffectedSpin) btnTestAffectedSpin.hidden = !testBusy;
-  }
+  // Test-view toggles reflect server state (continuous on/off) and tool presence.
+  reflectTestToggles();
   if (!toolPresent) btnRun.disabled = true;
   else btnRun.disabled = !!restarting.run;
   if (toolPresent) {
@@ -799,7 +806,7 @@ function renderTests(report, opts) {
   testsEl.innerHTML = html;
 }
 
-// Infinitest-style affected-test selection banner. `sel` is the server's
+// Affected-test selection banner. `sel` is the server's
 // computeAffectedTests() result (or an error/skip variant).
 function renderTestSelection(sel) {
   if (!testSelectionEl) return;
@@ -820,7 +827,7 @@ function renderTestSelection(sel) {
   }
   const n = (sel.tests || []).length;
   const files = sel.sources.length;
-  let txt = `Infinitest-style: ${n} test class${n === 1 ? "" : "es"} affected by ${files} changed source${files === 1 ? "" : "s"} vs HEAD`;
+  let txt = `Affected: ${n} test class${n === 1 ? "" : "es"} affected by ${files} changed source${files === 1 ? "" : "s"} vs HEAD`;
   if (sel.fallback) txt += " · name-based (run Build for dependency-accurate selection)";
   testSelectionEl.hidden = false;
   testSelectionEl.className = "test-selection" + (n ? "" : " warn");
@@ -829,6 +836,22 @@ function renderTestSelection(sel) {
 
 function hideTestSelection() {
   if (testSelectionEl) testSelectionEl.hidden = true;
+}
+
+// Sync the two Test-view toggles with server + settings state. Continuous
+// testing always uses affected selection, so while it's on the Full build
+// toggle is forced off and greyed out; turning it off restores the user's
+// persisted choice. Both are disabled when no build tool is present.
+function reflectTestToggles() {
+  if (!fullbuildToggle || !continuousToggle) return;
+  const cont = !!(statusSnap && statusSnap.continuous && statusSnap.continuous.enabled);
+  continuousInput.checked = cont;
+  continuousInput.disabled = !toolPresent;
+  continuousToggle.classList.toggle("disabled", !toolPresent);
+  const fbDisabled = !toolPresent || cont;
+  fullbuildInput.checked = cont ? false : fullBuildSetting;
+  fullbuildInput.disabled = fbDisabled;
+  fullbuildToggle.classList.toggle("disabled", fbDisabled);
 }
 
 function populateModules(modules) {
@@ -993,6 +1016,8 @@ function applySettingsState(s) {
   devtoolsInput.checked = s.devtools === true;
   randomportInput.checked = s.randomPort === true;
   openBrowserInput.checked = s.openBrowser === true;
+  fullBuildSetting = s.fullBuild === true;
+  reflectTestToggles();
   if (document.activeElement !== springInput && typeof s.springProfiles === "string") {
     springInput.value = s.springProfiles;
   }
@@ -1239,16 +1264,13 @@ document.getElementById("btn-build").onclick = () => {
 };
 document.getElementById("btn-test").onclick = () => {
   showTab("test");
-  hideTestSelection();
-  triggerLane("test", "/api/test", { warm: warm(), mavenProfiles: mvnProfiles() });
+  // Continuous testing always uses affected selection; otherwise the Full build
+  // toggle decides between the affected subset (off) and the whole suite (on).
+  const continuousOn = !!(statusSnap && statusSnap.continuous && statusSnap.continuous.enabled);
+  const affected = continuousOn || !fullbuildInput.checked;
+  if (!affected) hideTestSelection();
+  triggerLane("test", "/api/test", { affected, warm: warm(), mavenProfiles: mvnProfiles() });
 };
-if (btnTestAffected) {
-  btnTestAffected.onclick = () => {
-    if (btnTestAffected.disabled) return;
-    showTab("test");
-    post("/api/test", { affected: true, warm: warm(), mavenProfiles: mvnProfiles() });
-  };
-}
 document.getElementById("btn-package").onclick = () => {
   showTab("package");
   triggerLane("package", "/api/package", { warm: warm(), mavenProfiles: mvnProfiles() });
@@ -1321,6 +1343,7 @@ function saveSettings() {
     devtools: devtoolsInput.checked,
     randomPort: randomportInput.checked,
     openBrowser: openBrowserInput.checked,
+    fullBuild: fullbuildInput.checked,
   });
 }
 warmInput.addEventListener("change", saveSettings);
@@ -1328,6 +1351,18 @@ devtoolsInput.addEventListener("change", saveSettings);
 randomportInput.addEventListener("change", saveSettings);
 openBrowserInput.addEventListener("change", saveSettings);
 springInput.addEventListener("change", saveSettings);
+
+// "Full build" persists the affected-vs-full-suite preference for the Test button.
+fullbuildInput.addEventListener("change", () => {
+  fullBuildSetting = fullbuildInput.checked === true;
+  saveSettings();
+});
+// "Continuous testing" starts/stops the server-side watch loop. The server
+// echoes the new state via the status SSE, which reflectTestToggles() applies.
+continuousInput.addEventListener("change", () => {
+  if (continuousInput.disabled) return;
+  post("/api/test/continuous", { enabled: continuousInput.checked, mavenProfiles: mvnProfiles() });
+});
 
 btnFix.onclick = async () => {
   const kind = btnFix.dataset.kind;

--- a/public/app.js
+++ b/public/app.js
@@ -812,6 +812,21 @@ function renderTests(report, opts) {
     return;
   }
   const s = report.summary;
+  // A non-zero exit with no executed tests means the build failed before any test
+  // ran — almost always a compile error. Show that plainly instead of a misleading
+  // "0 tests / no reports" view, and point at the console + Fix button. (A Stop
+  // leaves buildExit null, so an interrupted run never shows as a build failure.)
+  if (report.buildExit != null && report.buildExit !== 0 && s.tests === 0) {
+    testsEl.innerHTML =
+      '<p class="empty bad">Build failed (exit ' +
+      report.buildExit +
+      ") before any tests ran \u2014 check the Maven console above for the error" +
+      ", or click <strong>Fix with Copilot</strong>.</p>";
+    tabBadge.hidden = false;
+    tabBadge.textContent = "!";
+    tabBadge.className = "badge bad";
+    return;
+  }
   const failed = s.failures + s.errors;
   // Tab badge
   tabBadge.hidden = false;
@@ -1423,11 +1438,20 @@ fullbuildInput.addEventListener("change", () => {
   fullBuildSetting = fullbuildInput.checked === true;
   saveSettings();
 });
-// "Continuous testing" starts/stops the server-side watch loop. The server
-// echoes the new state via the status SSE, which reflectTestToggles() applies.
-continuousInput.addEventListener("change", () => {
+// "Continuous testing" starts/stops the server-side watch loop. The endpoint
+// returns the authoritative continuous state; apply it immediately (don't wait
+// for the status SSE) so the Full build toggle re-enables and the Test button's
+// affected/full decision is correct the instant the loop stops.
+continuousInput.addEventListener("change", async () => {
   if (continuousInput.disabled) return;
-  post("/api/test/continuous", { enabled: continuousInput.checked, mavenProfiles: mvnProfiles() });
+  const res = await postJson("/api/test/continuous", {
+    enabled: continuousInput.checked,
+    mavenProfiles: mvnProfiles(),
+  });
+  if (res && res.continuous && statusSnap) {
+    statusSnap.continuous = res.continuous;
+    reflectTestToggles();
+  }
 });
 
 btnFix.onclick = async () => {

--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,9 @@ const exitEl = document.getElementById("exit");
 const metricsEl = document.getElementById("metrics");
 const testsEl = document.getElementById("tests");
 const tabBadge = document.getElementById("tab-tests-badge");
+const btnTestAffected = document.getElementById("btn-test-affected");
+const btnTestAffectedSpin = document.querySelector("#btn-test-affected .btn-spin");
+const testSelectionEl = document.getElementById("test-selection");
 const warmToggle = document.getElementById("warm-toggle");
 const warmInput = document.getElementById("in-warm");
 const warmLabel = document.getElementById("warm-label");
@@ -339,6 +342,17 @@ function renderStatus(s) {
       : btn.disabled
         ? `Stop the running ${busyMvnOp} first`
         : "";
+  }
+  // "Run affected" shares the serialized Maven lane; spinner follows the test lane.
+  if (btnTestAffected) {
+    const testBusy = !!(s.test && s.test.busy);
+    btnTestAffected.disabled = !toolPresent || (!!busyMvnOp && !testBusy);
+    btnTestAffected.title = !toolPresent
+      ? "Coffilot needs a Maven or Gradle project."
+      : btnTestAffected.disabled
+        ? `Stop the running ${busyMvnOp} first`
+        : "Run only the tests affected by your uncommitted changes vs HEAD (Infinitest-style)";
+    if (btnTestAffectedSpin) btnTestAffectedSpin.hidden = !testBusy;
   }
   if (!toolPresent) btnRun.disabled = true;
   // Header (phase / command / exit / fix) follows the active tab.
@@ -682,6 +696,38 @@ function renderTests(report, opts) {
     html += `</details>`;
   }
   testsEl.innerHTML = html;
+}
+
+// Infinitest-style affected-test selection banner. `sel` is the server's
+// computeAffectedTests() result (or an error/skip variant).
+function renderTestSelection(sel) {
+  if (!testSelectionEl) return;
+  if (!sel || !sel.ok) {
+    testSelectionEl.hidden = false;
+    testSelectionEl.className = "test-selection warn";
+    testSelectionEl.textContent = (sel && sel.message) || "Affected-test selection is unavailable.";
+    return;
+  }
+  if (!sel.sources || !sel.sources.length) {
+    testSelectionEl.hidden = false;
+    testSelectionEl.className = "test-selection warn";
+    testSelectionEl.textContent =
+      sel.changedFiles && sel.changedFiles.length
+        ? "No changed Java/Kotlin sources vs HEAD — nothing to test."
+        : "No uncommitted changes vs HEAD — nothing to test.";
+    return;
+  }
+  const n = (sel.tests || []).length;
+  const files = sel.sources.length;
+  let txt = `Infinitest-style: ${n} test class${n === 1 ? "" : "es"} affected by ${files} changed source${files === 1 ? "" : "s"} vs HEAD`;
+  if (sel.fallback) txt += " · name-based (run Build for dependency-accurate selection)";
+  testSelectionEl.hidden = false;
+  testSelectionEl.className = "test-selection" + (n ? "" : " warn");
+  testSelectionEl.textContent = txt;
+}
+
+function hideTestSelection() {
+  if (testSelectionEl) testSelectionEl.hidden = true;
 }
 
 function populateModules(modules) {
@@ -1066,8 +1112,16 @@ document.getElementById("btn-build").onclick = () => {
 };
 document.getElementById("btn-test").onclick = () => {
   showTab("test");
+  hideTestSelection();
   post("/api/test", { warm: warm(), mavenProfiles: mvnProfiles() });
 };
+if (btnTestAffected) {
+  btnTestAffected.onclick = () => {
+    if (btnTestAffected.disabled) return;
+    showTab("test");
+    post("/api/test", { affected: true, warm: warm(), mavenProfiles: mvnProfiles() });
+  };
+}
 document.getElementById("btn-package").onclick = () => {
   showTab("package");
   post("/api/package", { warm: warm(), mavenProfiles: mvnProfiles() });
@@ -1207,6 +1261,9 @@ es.addEventListener("test-progress", (e) => {
 es.addEventListener("tests", (e) => {
   const report = JSON.parse(e.data);
   renderTests(report, { runnerLabel: lastRunnerLabel });
+});
+es.addEventListener("tests-selection", (e) => {
+  renderTestSelection(JSON.parse(e.data));
 });
 es.addEventListener("reset", (e) => {
   // Clear only the console for the op that's (re)starting; the others keep

--- a/public/index.html
+++ b/public/index.html
@@ -131,13 +131,32 @@
           <div class="subtabs" role="tablist" aria-label="Test view">
             <button class="subtab active" data-tview="graphical">Graphical</button>
             <button class="subtab" data-tview="console">Console</button>
-            <button
-              id="btn-test-affected"
-              class="affected-btn"
-              title="Run only the tests affected by your uncommitted changes vs HEAD (Infinitest-style)"
-            >
-              <span class="btn-spin" hidden></span>Run affected
-            </button>
+            <div class="test-toggles">
+              <label class="switch" id="fullbuild-toggle">
+                <input type="checkbox" id="in-fullbuild" checked />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Full build</span>
+              </label>
+              <span
+                class="info"
+                id="fullbuild-info"
+                tabindex="0"
+                data-tip="On (default): the Test button runs the entire test suite. Off: run only the tests affected by your uncommitted changes (git working tree vs HEAD)."
+                >&#9432;</span
+              >
+              <label class="switch" id="continuous-toggle">
+                <input type="checkbox" id="in-continuous" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Continuous testing</span>
+              </label>
+              <span
+                class="info"
+                id="continuous-info"
+                tabindex="0"
+                data-tip="Off (default). On: automatically re-run the affected tests whenever you save a source file. While on, runs always use affected selection, so Full build is disabled."
+                >&#9432;</span
+              >
+            </div>
           </div>
           <div id="test-selection" class="test-selection" hidden></div>
           <div class="subpane-wrap">

--- a/public/index.html
+++ b/public/index.html
@@ -131,7 +131,15 @@
           <div class="subtabs" role="tablist" aria-label="Test view">
             <button class="subtab active" data-tview="graphical">Graphical</button>
             <button class="subtab" data-tview="console">Console</button>
+            <button
+              id="btn-test-affected"
+              class="affected-btn"
+              title="Run only the tests affected by your uncommitted changes vs HEAD (Infinitest-style)"
+            >
+              <span class="btn-spin" hidden></span>Run affected
+            </button>
           </div>
+          <div id="test-selection" class="test-selection" hidden></div>
           <div class="subpane-wrap">
             <div id="tests" class="tsub active">
               <p class="empty">No test run yet. Click <strong>Test</strong> to run the suite.</p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -351,6 +351,39 @@ select {
   color: var(--text-color-default, #1f2328);
   border-color: var(--true-color-blue, #0969da);
 }
+/* "Run affected" pushes to the right edge of the Test view toolbar. */
+.affected-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.15rem 0.6rem;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  border-radius: 6px;
+  color: var(--text-color-default, #1f2328);
+  background: var(--background-color-muted, #f6f8fa);
+}
+.affected-btn:hover:not(:disabled) {
+  border-color: var(--true-color-blue, #0969da);
+}
+.affected-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+/* Thin banner summarising the Infinitest-style selection for the last run. */
+.test-selection {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.75rem;
+  font-size: 12px;
+  color: var(--text-color-muted, #656d76);
+  border-bottom: 1px solid var(--border-color-muted, #d8dee4);
+  background: var(--background-color-muted, #f6f8fa);
+}
+.test-selection.warn {
+  color: var(--text-color-default, #1f2328);
+}
 .subpane-wrap {
   flex: 1 1 auto;
   min-height: 0;

--- a/public/styles.css
+++ b/public/styles.css
@@ -920,6 +920,9 @@ aside h2 {
   padding: 2rem 0;
   text-align: center;
 }
+.empty.bad {
+  color: var(--true-color-red, #cf222e);
+}
 /* Live test progress (class-by-class, while the run is in flight). */
 .suite-row {
   display: flex;

--- a/public/styles.css
+++ b/public/styles.css
@@ -432,28 +432,19 @@ select {
   color: var(--text-color-default, #1f2328);
   border-color: var(--true-color-blue, #0969da);
 }
-/* "Run affected" pushes to the right edge of the Test view toolbar. */
-.affected-btn {
+/* Test-view toolbar toggles pushed to the right edge: "Full build" (affected
+   vs full suite) and "Continuous testing". */
+.test-toggles {
   margin-left: auto;
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.15rem 0.6rem;
+  gap: 0.6rem;
+}
+.test-toggles .switch {
   font-size: 12px;
-  font-weight: 600;
-  border: 1px solid var(--border-color-default, #d0d7de);
-  border-radius: 6px;
-  color: var(--text-color-default, #1f2328);
-  background: var(--background-color-muted, #f6f8fa);
+  gap: 0.4rem;
 }
-.affected-btn:hover:not(:disabled) {
-  border-color: var(--true-color-blue, #0969da);
-}
-.affected-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-/* Thin banner summarising the Infinitest-style selection for the last run. */
+/* Thin banner summarising the affected-test selection for the last run. */
 .test-selection {
   flex: 0 0 auto;
   padding: 0.35rem 0.75rem;


### PR DESCRIPTION
## Summary

Running the whole suite on every change is slow, so this adds Infinitest-style **affected-test selection** to the Test tab plus an optional **continuous testing** mode, and hardens the result of all the edge cases that surfaced while building it.

How it fits together:

- **Affected-test selection.** Coffilot computes the tests impacted by the current uncommitted changes (vs HEAD) from a dependency graph built off the compiled `.class` files, with a name-based fallback when classes are not yet compiled. Works for both Maven (Surefire) and Gradle.
- **Two Test-tab toggles** replace the old standalone "Run affected" button:
  - *Full build* (on by default): Test runs the whole suite; off runs only the affected subset.
  - *Continuous testing* (off by default): re-runs the affected tests on every source save. It greys out Full build while active (continuous always uses affected selection). Continuous mode recompiles changed sources first so freshly edited / brand-new classes and new dependency edges are visible to selection.
- **Loads by default.** A thin `.github/extensions/coffilot/extension.mjs` wrapper imports the root module, so the Copilot CLI auto-discovers Coffilot whenever this repo is opened. No manual install step.

Most of the diff after the initial feature is robustness work for states that left the Test tab stuck or empty:

- Continuous testing is paused for the whole agent working period (suspend on `assistant.turn_start`, resume once on `session.idle`), so the agent's direct working-tree edits and reverts (including Fix with Copilot) no longer race a continuous run.
- Turning continuous off fully resets the loop and pre-empts any in-flight run, freeing the shared Maven lane so a follow-up Build/Test/Package is never rejected as "already running".
- A no-op run no longer blanks the last results; a blocked manual Test now logs why instead of silently doing nothing.
- A build/compile failure (non-zero exit, no Surefire reports) now renders a clear red "Build failed (exit N) before any tests ran" message instead of a misleading empty test view.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven project (spring-petclinic): affected selection, the two toggles, continuous testing, and the build-failure view.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

- The affected/full decision and continuous state are entangled with the shared Maven lane; the suspend gate is a reentrant depth counter, and the agent-turn pause collapses many `assistant.turn_start` events into a single suspend/resume pair balanced by `session.idle`. That area is the most worth a careful read.
- The project-scope `.github/extensions/coffilot/extension.mjs` is a thin wrapper that imports the root module for its side effects; the single source of truth stays at the repo root next to `public/`.