### PR TITLE
Declutter Coffilot top UI and unify lane headers

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -67,8 +67,6 @@ const openBrowserInput = document.getElementById("in-openbrowser");
 const autoProfileInput = document.getElementById("in-autoprofile");
 const btnOpenBrowser = document.getElementById("btn-open-browser");
 const btnFix = document.getElementById("btn-fix");
-const btnStopMaven = document.getElementById("btn-stop-maven");
-const btnStopRun = document.getElementById("btn-stop-run");
 const btnRun = document.getElementById("btn-run");
 // Run-tab flame graph (async-profiler) controls.
 const flameEvent = document.getElementById("flame-event");
@@ -213,8 +211,8 @@ function showTab(name) {
   if (!consoles[name]) return;
   activeTab = name;
   document.querySelectorAll(".tab").forEach((t) => t.classList.toggle("active", t.dataset.tab === name));
-  document.getElementById("build-console").classList.toggle("active", name === "build");
-  document.getElementById("package-console").classList.toggle("active", name === "package");
+  document.getElementById("build-pane").classList.toggle("active", name === "build");
+  document.getElementById("package-pane").classList.toggle("active", name === "package");
   document.getElementById("test-pane").classList.toggle("active", name === "test");
   document.getElementById("run-pane").classList.toggle("active", name === "run");
   // The header (phase/command/exit/fix) follows the active tab, so
@@ -308,7 +306,8 @@ document.addEventListener("keydown", (e) => {
 asideDrawer.addEventListener("change", () => setAsideOpen(!asideDrawer.matches));
 // Initial state: open on a wide canvas, collapsed on a narrow one. No loggers
 // sync here (it would touch state declared later in this module) — polling is
-// driven by tab activation and the metrics tab is the default.
+// driven by tab activation and the Settings tab is the default, so loggers
+// polling stays off until that tab is opened.
 workspaceEl.classList.toggle("aside-open", !asideDrawer.matches);
 syncAsideMode();
 
@@ -461,23 +460,19 @@ function clearStopping(which) {
   stopTimers[which] = null;
 }
 
-function applyStopButton(btn, which, busy) {
-  // The process has actually stopped: drop the optimistic state.
-  if (stopping[which] && !busy) clearStopping(which);
-  const isStopping = stopping[which];
-  btn.disabled = !busy || isStopping;
-  btn.classList.toggle("is-stopping", isStopping);
-  const spin = btn.querySelector(".btn-spin");
-  if (spin) spin.hidden = !isStopping;
-  const label = btn.querySelector(".btn-label");
-  if (label) label.textContent = isStopping ? "Stopping\u2026" : "Stop";
-  if (isStopping) {
-    btn.title = which === "run" ? "Stopping the app\u2026" : "Stopping the build\u2026";
-  } else if (busy) {
-    btn.title = which === "run" ? "Stop the running app" : "Stop the running build, test or package";
-  } else {
-    btn.title = which === "run" ? "The app isn't running" : "No build is running";
-  }
+// Each lane's primary button doubles as Build/Test/Package/Run (idle) and Stop
+// (while that lane is busy), so there's exactly one action per lane.
+const laneLabel = { build: "Build", test: "Run tests", package: "Package", run: "Run" };
+function setLaneButton(op, { label, danger, disabled, busyState, title }) {
+  const btn = triggerButton[op];
+  if (!btn) return;
+  const lbl = btn.querySelector(".btn-label");
+  if (lbl) lbl.textContent = label;
+  btn.classList.toggle("danger", !!danger);
+  btn.classList.toggle("primary", !danger);
+  btn.classList.toggle("is-stopping", busyState === "stopping");
+  btn.disabled = !!disabled;
+  btn.title = title || "";
 }
 
 // Optimistic "restarting" state for the trigger buttons. Clicking a trigger
@@ -556,11 +551,10 @@ function renderStatus(s) {
   // app actually running (the run lane busy).
   runActive = !!(run.busy || run.appPort);
   updateProfileButton();
-  // The two grouped Stop buttons are global, not tied to the active tab:
-  // the Maven Stop covers build/test/package; the Run Stop covers run.
+  // Drop the optimistic "stopping" state once the process has actually exited.
   const mvnBusy = laneActive(s, "build") || laneActive(s, "test") || laneActive(s, "package");
-  applyStopButton(btnStopMaven, "maven", mvnBusy);
-  applyStopButton(btnStopRun, "run", laneActive(s, "run"));
+  if (stopping.run && !laneActive(s, "run")) clearStopping("run");
+  if (stopping.maven && !mvnBusy) clearStopping("maven");
   // Per-lane spinners on the trigger buttons and tabs (global, so they reflect
   // activity regardless of which tab is showing). The `is-restarting` class
   // turns the trigger's spinner into a rotating restart glyph without touching
@@ -573,30 +567,41 @@ function renderStatus(s) {
       triggerButton[op].classList.toggle("is-restarting", !!restarting[op]);
     }
   }
-  // While a build op runs the lane is serialized, so grey out the other
-  // Build/Test/Package buttons (the running one stays active — click it again
-  // to restart). Everything is disabled when no build tool is present.
+  // Each lane's primary button: it triggers the lane when idle and becomes a red
+  // Stop while that lane is busy. Build/Test/Package share one serialized Maven
+  // lane, so while one runs its siblings are greyed out until it stops.
   const busyMvnOp = ["build", "test", "package"].find((op) => laneActive(s, op));
   for (const op of ["build", "test", "package"]) {
-    const btn = mvnButtons[op];
-    if (!btn) continue;
-    // The running op stays clickable (to restart); idle siblings are greyed out
-    // until it stops, and the op itself is locked while its restart is in flight.
-    btn.disabled = !toolPresent || (!!busyMvnOp && op !== busyMvnOp) || !!restarting[op];
-    btn.title = !toolPresent
-      ? "Coffilot needs a Maven or Gradle project."
-      : restarting[op]
-        ? "Restarting\u2026"
-        : op === busyMvnOp
-          ? `Restart the running ${op}`
-          : btn.disabled
-            ? `Stop the running ${busyMvnOp} first`
-            : "";
+    if (!toolPresent) {
+      setLaneButton(op, { label: laneLabel[op], disabled: true, title: "Coffilot needs a Maven or Gradle project." });
+    } else if (op === busyMvnOp) {
+      const isStopping = stopping.maven;
+      setLaneButton(op, {
+        label: isStopping ? "Stopping\u2026" : "Stop",
+        danger: true,
+        disabled: isStopping,
+        busyState: isStopping ? "stopping" : "stop",
+        title: isStopping ? "Stopping the build\u2026" : `Stop the running ${op}`,
+      });
+    } else if (busyMvnOp) {
+      setLaneButton(op, { label: laneLabel[op], disabled: true, title: `Stop the running ${busyMvnOp} first` });
+    } else {
+      setLaneButton(op, { label: laneLabel[op], disabled: !!restarting[op] });
+    }
   }
-  if (!toolPresent) btnRun.disabled = true;
-  else btnRun.disabled = !!restarting.run;
-  if (toolPresent) {
-    btnRun.title = restarting.run ? "Restarting\u2026" : laneActive(s, "run") ? "Restart the running app" : "";
+  if (!toolPresent) {
+    setLaneButton("run", { label: laneLabel.run, disabled: true, title: "Coffilot needs a Maven or Gradle project." });
+  } else if (laneActive(s, "run")) {
+    const isStopping = stopping.run;
+    setLaneButton("run", {
+      label: isStopping ? "Stopping\u2026" : "Stop",
+      danger: true,
+      disabled: isStopping,
+      busyState: isStopping ? "stopping" : "stop",
+      title: isStopping ? "Stopping the app\u2026" : "Stop the running app",
+    });
+  } else {
+    setLaneButton("run", { label: laneLabel.run, disabled: !!restarting.run });
   }
   // Header (phase / command / exit / fix) follows the active tab; while the
   // active tab's lane is restarting, show a steady "restarting" phase instead of
@@ -1304,6 +1309,8 @@ function applyEnv(env) {
 
   // Maven profiles are Maven-only; hide the control for Gradle / no tool.
   const profilesSupported = !!(env && env.profilesSupported);
+  const setMvnProfiles = document.getElementById("set-mvn-profiles");
+  if (setMvnProfiles) setMvnProfiles.hidden = !profilesSupported;
   if (mvnProfilesLabel) mvnProfilesLabel.hidden = !profilesSupported;
   if (mvnProfilesCombo) mvnProfilesCombo.hidden = !profilesSupported;
 
@@ -1513,44 +1520,48 @@ async function restartLane(op, body) {
   }
 }
 
-document.getElementById("btn-build").onclick = () => {
-  showTab("build");
-  triggerLane("build", "/api/build", { warm: warm(), mavenProfiles: mvnProfiles() });
-};
-document.getElementById("btn-test").onclick = () => {
-  showTab("test");
-  triggerLane("test", "/api/test", { warm: warm(), mavenProfiles: mvnProfiles() });
-};
-document.getElementById("btn-package").onclick = () => {
-  showTab("package");
-  triggerLane("package", "/api/package", { warm: warm(), mavenProfiles: mvnProfiles() });
-};
-document.getElementById("btn-run").onclick = () => {
-  showTab("run");
-  triggerLane("run", "/api/run", {
-    module: document.getElementById("in-module").value.trim(),
-    profiles: document.getElementById("in-profiles").value.trim(),
-    mavenProfiles: mvnProfiles(),
-  });
-};
-// Two grouped Stop buttons: the Maven Stop kills the shared build/test/
-// package lane; the Run Stop kills the independent app. They are global,
-// so you can stop a build without killing the running app, or vice versa.
-btnStopMaven.onclick = () => {
-  if (btnStopMaven.disabled) return;
+// Stop a lane. `which` is the lane group: "run" (the app) or "maven" (the shared
+// build/test/package lane). `op` is the specific Maven op that's running.
+function stopLane(which, op) {
+  if (stopping[which]) return;
+  if (which === "run") {
+    clearRestarting("run");
+    markStopping("run", "run");
+    post("/api/stop", { op: "run" });
+    return;
+  }
   const s = statusSnap || {};
-  const op = ["build", "test", "package"].find((o) => s[o] && s[o].busy) || activeTab;
+  const target = op || ["build", "test", "package"].find((o) => s[o] && s[o].busy) || activeTab;
   // A Stop wins over any in-flight restart of the build group.
   ["build", "test", "package"].forEach(clearRestarting);
-  markStopping("maven", op);
+  markStopping("maven", target);
   post("/api/stop", { op: "maven" });
-};
-btnStopRun.onclick = () => {
-  if (btnStopRun.disabled) return;
-  clearRestarting("run");
-  markStopping("run", "run");
-  post("/api/stop", { op: "run" });
-};
+}
+
+// One button per lane: it starts the lane when idle, or stops it while busy.
+function laneAction(op) {
+  if (op === "run") {
+    if (laneBusy("run")) return stopLane("run");
+    showTab("run");
+    triggerLane("run", "/api/run", {
+      module: document.getElementById("in-module").value.trim(),
+      profiles: document.getElementById("in-profiles").value.trim(),
+      mavenProfiles: mvnProfiles(),
+    });
+    return;
+  }
+  // build / test / package share the serialized Maven lane.
+  const busyOp = ["build", "test", "package"].find(laneBusy);
+  if (busyOp === op) return stopLane("maven", op); // this lane is running → stop it
+  if (busyOp) return; // a sibling is running (the button is disabled anyway)
+  showTab(op);
+  triggerLane(op, "/api/" + op, { warm: warm(), mavenProfiles: mvnProfiles() });
+}
+
+document.getElementById("btn-build").onclick = () => laneAction("build");
+document.getElementById("btn-test").onclick = () => laneAction("test");
+document.getElementById("btn-package").onclick = () => laneAction("package");
+document.getElementById("btn-run").onclick = () => laneAction("run");
 
 // Run tab: force-open the running app in a browser.
 btnOpenBrowser.onclick = () => post("/api/open-app", {});

--- a/public/index.html
+++ b/public/index.html
@@ -110,10 +110,15 @@
         </section>
 
         <section id="test-pane" class="lpane col">
-          <div class="subtabs" role="tablist" aria-label="Test view">
-            <button class="subtab active" data-tview="graphical">Graphical</button>
-            <button class="subtab" data-tview="console">Console</button>
-            <div class="test-toggles">
+          <div class="lane-bar">
+            <button id="btn-test" class="primary lane-action">
+              <span class="btn-spin" hidden></span><span class="btn-label">Run tests</span>
+            </button>
+            <div class="subtabs" role="tablist" aria-label="Test view">
+              <button class="subtab active" data-tview="graphical">Graphical</button>
+              <button class="subtab" data-tview="console">Console</button>
+            </div>
+            <div class="lane-controls">
               <label class="switch" id="fullbuild-toggle">
                 <input type="checkbox" id="in-fullbuild" checked />
                 <span class="track"><span class="thumb"></span></span>
@@ -139,9 +144,6 @@
                 >&#9432;</span
               >
             </div>
-            <button id="btn-test" class="primary lane-action">
-              <span class="btn-spin" hidden></span><span class="btn-label">Run tests</span>
-            </button>
           </div>
           <div id="test-selection" class="test-selection" hidden></div>
           <div class="subpane-wrap">
@@ -153,22 +155,31 @@
         </section>
 
         <section id="run-pane" class="lpane col">
-          <div class="run-bar">
+          <div class="lane-bar">
             <button id="btn-run" class="primary lane-action">
               <span class="btn-spin" hidden></span><span class="btn-label">Run</span>
             </button>
-            <label class="switch" id="openbrowser-toggle">
-              <input type="checkbox" id="in-openbrowser" />
-              <span class="track"><span class="thumb"></span></span>
-              <span class="switch-label">Open browser when the app starts</span>
-            </label>
-            <button id="btn-open-browser" class="tiny" disabled title="Open the running app in your browser">
-              Open in browser
-            </button>
-          </div>
-          <div class="subtabs" role="tablist" aria-label="Run view">
-            <button class="subtab active" data-rview="console">Console</button>
-            <button class="subtab" data-rview="flame">Flame graph</button>
+            <div class="subtabs" role="tablist" aria-label="Run view">
+              <button class="subtab active" data-rview="console">Console</button>
+              <button class="subtab" data-rview="flame">Flame graph</button>
+            </div>
+            <div class="lane-controls">
+              <label class="switch" id="openbrowser-toggle">
+                <input type="checkbox" id="in-openbrowser" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Auto open browser</span>
+              </label>
+              <span
+                class="info"
+                id="openbrowser-info"
+                tabindex="0"
+                data-tip="When the app starts, automatically open it in your browser."
+                >&#9432;</span
+              >
+              <button id="btn-open-browser" class="tiny" disabled title="Open the running app in your browser">
+                Open in browser
+              </button>
+            </div>
           </div>
           <div class="subpane-wrap">
             <section id="run-console-view" class="tsub active" aria-label="Run output">

--- a/public/index.html
+++ b/public/index.html
@@ -16,36 +16,14 @@
     </div>
     <header>
       <h1>Coffilot</h1>
-      <div class="btn-group" id="maven-group">
-        <button id="btn-build"><span class="btn-spin" hidden></span>Build</button>
-        <button id="btn-test"><span class="btn-spin" hidden></span>Test</button>
-        <button id="btn-package"><span class="btn-spin" hidden></span>Package</button>
-        <button id="btn-stop-maven" class="danger">
-          <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
-        </button>
-      </div>
-      <div class="btn-group" id="run-group">
-        <button id="btn-run" class="primary"><span class="btn-spin" hidden></span>Run</button>
-        <button id="btn-stop-run" class="danger">
-          <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
-        </button>
-      </div>
-      <div class="inputs">
-        <label>module</label>
-        <select id="in-module" title="Module to run">
-          <option value="" disabled selected>Scanning modules…</option>
-        </select>
-        <label id="lbl-mvn-profiles">Maven profiles</label>
-        <span class="combo" id="mvn-profiles-combo">
-          <input
-            id="in-mvn-profiles"
-            size="8"
-            placeholder="(none)"
-            autocomplete="off"
-            title="Maven build profiles to activate with -P for Build / Test / Run."
-          />
-          <div class="combo-menu" id="maven-menu" hidden></div>
-        </span>
+      <div id="status">
+        <span id="phase" class="pill idle">idle</span>
+        <span id="cmd" class="muted">No command run yet.</span>
+        <span id="cmd-copied" class="copied" hidden>copied</span>
+        <span id="exit"></span>
+        <span id="reload-pill" class="pill" hidden>live reload</span>
+        <span id="caps"></span>
+        <button id="btn-fix" class="fix" hidden></button>
       </div>
       <button
         id="btn-refresh"
@@ -68,16 +46,6 @@
         disabled until one is present.</span
       >
       <button id="btn-recheck" class="fix tiny">Check again</button>
-    </div>
-
-    <div id="status">
-      <span id="phase" class="pill idle">idle</span>
-      <span id="cmd" class="muted">No command run yet.</span>
-      <span id="cmd-copied" class="copied" hidden>copied</span>
-      <span id="exit"></span>
-      <span id="reload-pill" class="pill" hidden>live reload</span>
-      <span id="caps"></span>
-      <button id="btn-fix" class="fix" hidden style="margin-left: auto"></button>
     </div>
 
     <div class="tabs">
@@ -123,14 +91,31 @@
 
     <div id="workspace" class="aside-rail">
       <div id="left">
-        <pre id="build-console" class="lpane term active" aria-label="Build output"></pre>
+        <section id="build-pane" class="lpane col active">
+          <div class="lane-bar">
+            <button id="btn-build" class="primary lane-action">
+              <span class="btn-spin" hidden></span><span class="btn-label">Build</span>
+            </button>
+          </div>
+          <pre id="build-console" class="term" aria-label="Build output"></pre>
+        </section>
 
-        <pre id="package-console" class="lpane term" aria-label="Package output"></pre>
+        <section id="package-pane" class="lpane col">
+          <div class="lane-bar">
+            <button id="btn-package" class="primary lane-action">
+              <span class="btn-spin" hidden></span><span class="btn-label">Package</span>
+            </button>
+          </div>
+          <pre id="package-console" class="term" aria-label="Package output"></pre>
+        </section>
 
         <section id="test-pane" class="lpane col">
           <div class="subtabs" role="tablist" aria-label="Test view">
             <button class="subtab active" data-tview="graphical">Graphical</button>
             <button class="subtab" data-tview="console">Console</button>
+            <button id="btn-test" class="primary lane-action lane-action-end">
+              <span class="btn-spin" hidden></span><span class="btn-label">Run tests</span>
+            </button>
           </div>
           <div class="subpane-wrap">
             <div id="tests" class="tsub active">
@@ -142,6 +127,15 @@
 
         <section id="run-pane" class="lpane col">
           <div class="run-bar">
+            <button id="btn-run" class="primary lane-action">
+              <span class="btn-spin" hidden></span><span class="btn-label">Run</span>
+            </button>
+            <label class="lane-field">
+              <span class="lane-field-label">module</span>
+              <select id="in-module" title="Module to run">
+                <option value="" disabled selected>Scanning modules…</option>
+              </select>
+            </label>
             <label class="switch" id="openbrowser-toggle">
               <input type="checkbox" id="in-openbrowser" />
               <span class="track"><span class="thumb"></span></span>
@@ -237,7 +231,7 @@
       </div>
       <aside id="aside">
         <div class="aside-tabs">
-          <button class="atab active" data-atab="metrics">
+          <button class="atab" data-atab="metrics">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
                 d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4M3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707M2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10m9.5 0a.5.5 0 0 1 .5-.5H14a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5m.754-4.246a.39.39 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.39.39 0 0 0-.029-.518z"
@@ -257,7 +251,7 @@
             </svg>
             <span class="atab-label">Loggers</span>
           </button>
-          <button class="atab" data-atab="settings">
+          <button class="atab active" data-atab="settings">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
                 d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492M5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0"
@@ -278,7 +272,7 @@
         </div>
 
         <div class="aside-body">
-          <div id="atab-metrics" class="apane active">
+          <div id="atab-metrics" class="apane">
             <h2>Live JVM metrics<span id="metrics-src" class="src" hidden></span></h2>
             <div id="metrics">
               <p class="muted">Application isn&rsquo;t running or doesn&rsquo;t expose metrics.</p>
@@ -304,7 +298,7 @@
             </div>
           </div>
 
-          <div id="atab-settings" class="apane">
+          <div id="atab-settings" class="apane active">
             <!-- Java language server (JDTLS): powers Copilot's Java code
                intelligence (go-to-definition, find references, hover). Not part
                of this extension — the CLI launches it — so we report whether
@@ -330,6 +324,21 @@
                 <span id="jdtls-copied" class="copied" hidden>copied</span>
                 <a id="jdtls-docs" href="#" target="_blank" rel="noopener">docs</a>
               </div>
+            </div>
+
+            <!-- Maven build profiles (-P), applied to Build / Test / Run -->
+            <div class="set-row" id="set-mvn-profiles">
+              <label class="cap-label" id="lbl-mvn-profiles">Maven profiles</label>
+              <span class="combo" id="mvn-profiles-combo">
+                <input
+                  id="in-mvn-profiles"
+                  size="14"
+                  placeholder="(none)"
+                  autocomplete="off"
+                  title="Maven build profiles to activate with -P for Build / Test / Run."
+                />
+                <div class="combo-menu" id="maven-menu" hidden></div>
+              </span>
             </div>
 
             <!-- Run config profile (Spring Boot / Quarkus only) -->

--- a/public/index.html
+++ b/public/index.html
@@ -130,12 +130,6 @@
             <button id="btn-run" class="primary lane-action">
               <span class="btn-spin" hidden></span><span class="btn-label">Run</span>
             </button>
-            <label class="lane-field">
-              <span class="lane-field-label">module</span>
-              <select id="in-module" title="Module to run">
-                <option value="" disabled selected>Scanning modules…</option>
-              </select>
-            </label>
             <label class="switch" id="openbrowser-toggle">
               <input type="checkbox" id="in-openbrowser" />
               <span class="track"><span class="thumb"></span></span>
@@ -299,31 +293,15 @@
           </div>
 
           <div id="atab-settings" class="apane active">
-            <!-- Java language server (JDTLS): powers Copilot's Java code
-               intelligence (go-to-definition, find references, hover). Not part
-               of this extension — the CLI launches it — so we report whether
-               it's actually available and offer to set it up if not. Kept at the
-               top so its status is the first thing visible in Settings. -->
-            <div class="set-row jdtls-row" id="set-jdtls" hidden>
-              <div class="switch-row">
-                <span class="jdtls-dot" id="jdtls-dot"></span>
-                <span class="switch-label">Java IntelliSense (JDTLS)</span>
-                <span id="jdtls-state" class="mcp-state"></span>
-                <span
-                  class="info"
-                  id="jdtls-info"
-                  tabindex="0"
-                  data-tip="JDTLS gives Copilot Java go-to-definition, find references and hover. Checking availability…"
-                  >&#9432;</span
-                >
-              </div>
-              <button id="btn-setup-jdtls" class="fix tiny" hidden>Set up JDTLS</button>
-              <div id="jdtls-banner" class="banner setting-banner" hidden>
-                <span id="jdtls-msg"></span>
-                <code id="jdtls-cmd" title="Click to copy" hidden></code>
-                <span id="jdtls-copied" class="copied" hidden>copied</span>
-                <a id="jdtls-docs" href="#" target="_blank" rel="noopener">docs</a>
-              </div>
+            <!-- Maven module selector: which module Run targets, and which the
+               per-module proposals below (BootUI / DevTools, framework profile
+               rows) apply to. Kept first so it's the obvious context picker for
+               multi-module reactors. -->
+            <div class="set-row" id="set-module">
+              <label class="cap-label" for="in-module">Module</label>
+              <select id="in-module" title="Module to run and configure">
+                <option value="" disabled selected>Scanning modules…</option>
+              </select>
             </div>
 
             <!-- Maven build profiles (-P), applied to Build / Test / Run -->
@@ -354,6 +332,32 @@
                 />
                 <div class="combo-menu" id="spring-menu" hidden></div>
               </span>
+            </div>
+
+            <!-- Java language server (JDTLS): powers Copilot's Java code
+               intelligence (go-to-definition, find references, hover). Not part
+               of this extension — the CLI launches it — so we report whether
+               it's actually available and offer to set it up if not. -->
+            <div class="set-row jdtls-row" id="set-jdtls" hidden>
+              <div class="switch-row">
+                <span class="jdtls-dot" id="jdtls-dot"></span>
+                <span class="switch-label">Java IntelliSense (JDTLS)</span>
+                <span id="jdtls-state" class="mcp-state"></span>
+                <span
+                  class="info"
+                  id="jdtls-info"
+                  tabindex="0"
+                  data-tip="JDTLS gives Copilot Java go-to-definition, find references and hover. Checking availability…"
+                  >&#9432;</span
+                >
+              </div>
+              <button id="btn-setup-jdtls" class="fix tiny" hidden>Set up JDTLS</button>
+              <div id="jdtls-banner" class="banner setting-banner" hidden>
+                <span id="jdtls-msg"></span>
+                <code id="jdtls-cmd" title="Click to copy" hidden></code>
+                <span id="jdtls-copied" class="copied" hidden>copied</span>
+                <a id="jdtls-docs" href="#" target="_blank" rel="noopener">docs</a>
+              </div>
             </div>
 
             <!-- Keep JVM warm -->

--- a/public/styles.css
+++ b/public/styles.css
@@ -228,11 +228,6 @@ select {
   min-width: 84px;
   text-align: center;
 }
-/* In the Test subtab bar, the Run tests button follows the right-aligned
-   Full build / Continuous testing toggles; give it a little breathing room. */
-.subtabs #btn-test {
-  margin-left: 0.4rem;
-}
 
 /* Module picker in Settings: a full-width, prominent context selector. */
 #set-module select {
@@ -396,14 +391,12 @@ select {
   min-height: 0;
 }
 
-/* Test tab: Graphical / Console sub-toggle */
+/* Sub-view toggles shown inline in a lane bar (Test: Graphical/Console;
+   Run: Console/Flame graph). */
 .subtabs {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--border-color-default, #d0d7de);
-  flex: 0 0 auto;
 }
 .subtab {
   padding: 0.15rem 0.6rem;
@@ -419,15 +412,15 @@ select {
   color: var(--text-color-default, #1f2328);
   border-color: var(--true-color-blue, #0969da);
 }
-/* Test-view toolbar toggles pushed to the right edge: "Full build" (affected
-   vs full suite) and "Continuous testing". */
-.test-toggles {
+/* Right-aligned lane controls grouped at the right edge of a lane bar:
+   the Test toggles (Full build / Continuous) and the Run browser controls. */
+.lane-controls {
   margin-left: auto;
   display: flex;
   align-items: center;
   gap: 0.6rem;
 }
-.test-toggles .switch {
+.lane-controls .switch {
   font-size: 12px;
   gap: 0.4rem;
 }
@@ -464,16 +457,6 @@ select {
   overflow: hidden;
 }
 
-/* Run tab: browser controls bar */
-.run-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--border-color-default, #d0d7de);
-  flex: 0 0 auto;
-}
 /* Run tab: live log filter bar (severity + text search) */
 .log-bar {
   display: flex;

--- a/public/styles.css
+++ b/public/styles.css
@@ -231,14 +231,11 @@ select {
 .lane-action-end {
   margin-left: auto;
 }
-.lane-field {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-.lane-field-label {
-  color: var(--text-color-muted, #656d76);
-  font-size: 12px;
+
+/* Module picker in Settings: a full-width, prominent context selector. */
+#set-module select {
+  width: 100%;
+  max-width: 280px;
 }
 
 /* Custom combobox (replaces native <datalist>, whose popup mis-positions

--- a/public/styles.css
+++ b/public/styles.css
@@ -22,6 +22,10 @@
 }
 body {
   margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   background: var(--background-color-default, #ffffff);
   color: var(--text-color-default, #1f2328);
   font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
@@ -31,33 +35,23 @@ body {
   text-rendering: optimizeLegibility;
 }
 header {
-  padding: 0.75rem 3rem 0.75rem 1rem;
+  padding: 0.5rem 1rem;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.6rem;
   align-items: center;
-  position: relative;
-  /* Height of the toolbar's first row, set by the Build/Test/Run button groups
-     (group border + padding wrapping a button's border + padding + line-box).
-     Used to vertically center the absolutely-positioned refresh button on that
-     same row. */
-  --toolbar-row-h: calc(4px + 1.1rem + var(--leading-body-medium, 20px));
+  flex: 0 0 auto;
 }
 h1 {
   font-size: var(--text-title-medium, 16px);
   font-weight: var(--font-weight-semibold, 600);
-  margin: 0 0.5rem 0 0;
+  margin: 0;
+  flex: 0 0 auto;
 }
-/* Pinned to the header's top-right corner. Re-runs project discovery (build
-   tool, modules, Maven/Spring/Quarkus profiles, detected technologies). The
-   header reserves right padding so wrapping controls never slide under it. */
+/* Re-runs project discovery (build tool, modules, Maven/Spring/Quarkus profiles,
+   detected technologies). Sits at the end of the header bar. */
 .icon-btn {
-  position: absolute;
-  /* Center on the toolbar's first row instead of pinning to the very top, so
-     the icon lines up with the Build/Test/Run controls. */
-  top: calc(0.75rem + (var(--toolbar-row-h) - 30px) / 2);
-  right: 1rem;
+  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -89,15 +83,6 @@ h1 {
 }
 .icon-btn.is-busy svg {
   animation: cof-spin 0.7s linear infinite;
-}
-.btn-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.4rem;
-  border: 1px solid var(--border-color-default, #d0d7de);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--text-color-default, #1f2328) 4%, transparent);
 }
 button {
   font: inherit;
@@ -192,15 +177,13 @@ button.tiny {
    the :hover rules so a press always wins the tie and reads as a real click. */
 button.primary:not(:disabled):hover,
 button.danger:not(.is-stopping):not(.is-restarting):not(:disabled):hover,
-button.fix:not(:disabled):hover,
-.btn-group button:not(:disabled):not(.is-stopping):not(.is-restarting):hover {
+button.fix:not(:disabled):hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
 button.primary:not(:disabled):active,
 button.danger:not(:disabled):active,
-button.fix:not(:disabled):active,
-.btn-group button:not(:disabled):active {
+button.fix:not(:disabled):active {
   transform: translateY(0) scale(0.96);
   box-shadow: var(--shadow-sm);
 }
@@ -230,14 +213,30 @@ select {
   cursor: pointer;
   max-width: 220px;
 }
-.inputs {
+/* Lane toolbars: a thin bar inside each pane holding that lane's primary
+   action (Build / Run tests / Package / Run) and any lane-scoped controls. */
+.lane-bar {
   display: flex;
-  gap: 0.4rem;
   align-items: center;
-  margin-left: auto;
+  gap: 0.6rem;
   flex-wrap: wrap;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
 }
-.inputs label {
+.lane-action {
+  min-width: 84px;
+  text-align: center;
+}
+.lane-action-end {
+  margin-left: auto;
+}
+.lane-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.lane-field-label {
   color: var(--text-color-muted, #656d76);
   font-size: 12px;
 }
@@ -282,12 +281,16 @@ select {
   color: var(--text-color-muted, #656d76);
 }
 #status {
-  padding: 0.4rem 1rem;
-  border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
   align-items: center;
+}
+#status #btn-fix {
+  margin-left: auto;
+  flex: 0 0 auto;
 }
 .pill {
   border-radius: 999px;
@@ -339,7 +342,8 @@ select {
   display: grid;
   grid-template-columns: 1fr 320px;
   gap: 0;
-  height: calc(100vh - 130px);
+  flex: 1 1 auto;
+  min-height: 0;
   position: relative;
 }
 @media (max-width: 819px) {
@@ -386,7 +390,9 @@ select {
 .term .err {
   color: var(--true-color-red, #cf222e);
 }
-#run-console {
+#run-console,
+#build-console,
+#package-console {
   flex: 1 1 auto;
   min-height: 0;
 }
@@ -394,6 +400,7 @@ select {
 /* Test tab: Graphical / Console sub-toggle */
 .subtabs {
   display: flex;
+  align-items: center;
   gap: 0.25rem;
   padding: 0.5rem 0.75rem;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
@@ -679,6 +686,7 @@ aside h2 {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex: 0 0 auto;
   padding: 0.55rem 1rem;
   font-size: 12.5px;
   line-height: 1.5;
@@ -708,6 +716,7 @@ aside h2 {
   gap: 0.25rem;
   padding: 0.4rem 1rem 0;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
 }
 .tab {
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary

The Coffilot canvas felt cluttered at the top: each lane carried its own header row, build actions lived in a separate toolbar, and the Maven module / profile pickers were scattered. This PR makes the console cleaner and more consistent so common actions are easier to find.

Key changes:
- **Actions merged into the tabs.** Build / Test / Package / Run each expose a single primary action button in a shared `.lane-bar` header instead of a separate global toolbar, with per-lane Start/Stop handled by one toggle button.
- **Settings is the default panel tab**, so the Maven profile (and module) controls are visible immediately.
- **Module + profiles grouped in Settings.** The Maven module is now a prominent dropdown at the top of Settings (works for multi-module projects), followed by Maven profiles, then Spring profiles, then JDTLS.
- **Unified Test and Run headers.** The Test button now sits on the left like the other lanes, the Run tab's Console / Flame-graph subtabs moved up onto the same line as the Run button, and both headers share one layout: primary button, inline `.subtabs`, then right-aligned `.lane-controls`.
- The run toggle was renamed to **"Auto open browser"** with an explanatory tooltip.

This also folds in the affected-test selection / continuous-testing work from `main` (merge of #38), keeping the single-button-per-lane toggle model: during a continuous test run, sibling actions are greyed and Test shows Stop.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

This is UI/markup/CSS only (`public/index.html`, `public/styles.css`, `public/app.js`); no changes to `extension.mjs` or backend behaviour. CSS cleanup: `.test-toggles` was replaced by a shared `.lane-controls`, `.subtabs` is now an inline group, and the now-unused `.run-bar` rule was removed. One open design question: whether a continuous test run should pre-empt a sibling action rather than just greying it out (kept as grey-out for now for consistency).