### PR TITLE
Add agent-driven Debug lane (JDWP launch + DAP-style attach)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,15 @@ package / run the target Java project.
 ```
 extension.mjs            The extension: SDK wiring, canvas + actions, loopback HTTP
                          server, Maven/Gradle runner, JUnit report parser, metrics/MCP
-                         proxy, and the "fix with Copilot" bridge.
-public/index.html        The iframe UI markup (toolbar, Build/Test/Package/Run tabs,
-                         live console, graphical test results, metrics + MCP panels);
-                         links public/styles.css and public/app.js.
+                         proxy, the Debug lane (JDWP injection + attach), and the
+                         "fix with Copilot" bridge.
+jdwp.mjs                 The self-contained JDWP debug engine: a loopback JDWP client
+                         and a DebugSession (breakpoints, stepping, stack, locals,
+                         evaluate, snapshots). Pure (takes a log callback); no external
+                         DAP server or language server. Drives the Debug lane.
+public/index.html        The iframe UI markup (toolbar, Build/Test/Package/Run/Debug
+                         tabs, live console, graphical test results, metrics + MCP
+                         panels); links public/styles.css and public/app.js.
 public/styles.css        The iframe styles, using the canvas theme tokens. Served
                          unauthenticated (no secrets) so the iframe can load it.
 public/app.js            The iframe client logic. Served unauthenticated (no secrets);

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,6 +26,14 @@ Shipped in the extension today:
 
 - Build / Test / Package / Run lanes with live SSE-streamed console output, a
   graphical JUnit test view with a live progress bar, and a console toggle.
+- **Debug lane** alongside Run: relaunches the app with the JDWP agent enabled
+  (loopback only) and attaches a self-contained JDWP debugger (`jdwp.mjs`, no
+  external DAP/JDTLS dependency). Breakpoints (armed on class-prepare, so they can
+  be set before launch), continue, step in/over/out, pause, paused call stack,
+  frame-local variables and a dotted-path evaluator. Per-build-tool agent injection
+  (plain Java argv, Spring Maven `-Dspring-boot.run.jvmArguments`, a generated Gradle
+  init-script for Spring/app Gradle, Quarkus `-Ddebug`). Debug and Run are mutually
+  exclusive (shared app slot); live reload is disabled while debugging.
 - **Maven and Gradle support**, auto-detected from project markers (Maven preferred
   when both are present; a clear degraded notice when neither is). The wrapper
   (`./mvnw` / `./gradlew`) is preferred over a system `mvn` / `gradle`, cross-platform.
@@ -50,7 +58,10 @@ Shipped in the extension today:
   `MAVEN_OPTS` / `GRADLE_OPTS`) and, for Maven, the app JVM to silence JDK
   native-access warnings.
 - Agent-facing actions: `build_app`, `run_tests`, `package_app`, `start_app`,
-  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`.
+  `stop_app`, `get_status`, `get_metrics`, `fix_issue`, `run_scan`, plus the debug
+  actions `start_debug`, `stop_debug`, `set_breakpoint`, `remove_breakpoint`,
+  `debug_continue`, `debug_step`, `debug_stack`, `get_variables`, `debug_evaluate`
+  and `debug_status`.
 
 ## Known limitations
 
@@ -65,6 +76,12 @@ Shipped in the extension today:
 - **No live per-test progress for Gradle.** Maven's Surefire console output drives the
   class-by-class progress bar; Gradle's graphical test view fills in from the final
   JUnit XML report instead.
+- **The debug evaluator is a field-path resolver, not a Java expression compiler.** It
+  resolves a local (or `this`) and walks dotted instance-field paths (e.g.
+  `order.customer.name`); it does not call methods or evaluate arbitrary expressions.
+  Frame-local variables also require classes compiled with debug info (`-g`, the
+  default for Maven/Gradle). The Quarkus-on-Gradle `-Ddebug` forwarding is
+  best-effort and unverified.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ wins; when neither is found the console says so and stays disabled until one is 
   Optionally opens a browser window at the app once it is up.
 - **Parallel lanes** &mdash; Build / Test / Package share one build lane while Run
   is independent, so you can keep the app running while you re-test.
+- **Debug** &mdash; launches the app exactly like Run but with the **JDWP** agent
+  enabled (`-agentlib:jdwp=…server=y,address=127.0.0.1:<port>`, loopback only) and a
+  self-contained JDWP debugger attached &mdash; no external DAP server or language
+  server required. The Debug tab drives breakpoints, continue, step in/over/out,
+  pause, the paused call stack, frame-local variables and a dotted-path evaluator.
+  Debug and Run are **mutually exclusive** (they share the single app slot), and
+  Copilot can drive the whole session through agent actions (set a breakpoint,
+  continue, inspect variables, …). Live reload is disabled while debugging so a
+  recompile can't drop the session.
 - **Stop** &mdash; terminates the running app / build process.
 - **Profiles** &mdash; the toolbar scans the project for available run profiles —
   **Spring Boot** profiles (`application-<profile>.*`) or **Quarkus** profiles
@@ -138,11 +147,16 @@ In a Copilot app session on a Maven or Gradle project, open the **Coffilot** can
 3. Once the app is up, watch the **Live JVM metrics** panel populate (badge:
    `BootUI` / `Actuator` / `Quarkus` / `process`).
 4. If something fails, click **Fix with Copilot** to hand the error to the agent.
-5. **Stop** when done.
+5. Or **Debug** instead of Run to launch under the debugger: open the **Debug** tab,
+   add a breakpoint (class binary name + line), and use Continue / Step / Pause; the
+   paused call stack, frame variables and an evaluator appear inline.
+6. **Stop** when done.
 
 The agent can drive the same flow with the `build_app`, `run_tests`,
 `package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`, `fix_issue`
-and `run_scan` actions.
+and `run_scan` actions, plus the debug actions `start_debug`, `stop_debug`,
+`set_breakpoint`, `remove_breakpoint`, `debug_continue`, `debug_step`,
+`debug_stack`, `get_variables`, `debug_evaluate` and `debug_status`.
 
 ## How it works
 
@@ -157,6 +171,12 @@ Coffilot is a Node process (the extension) that:
   proxying [BootUI](https://github.com/jdubois/boot-ui)'s sanitized `/bootui/api/**`
   DTOs when present and falling back to Spring Boot Actuator, then to Quarkus
   Micrometer/health (`/q/*`), then to coarse process metrics;
+- for **Debug**, relaunches the app with the JDWP agent enabled (injected per build
+  tool: directly into the `java` argv for plain Java, via
+  `-Dspring-boot.run.jvmArguments` for Spring Maven, a generated Gradle init-script
+  for Spring/app Gradle, or Quarkus's built-in `-Ddebug` for Quarkus) and attaches a
+  self-contained JDWP client (`jdwp.mjs`, loopback only) that the UI and agent
+  actions drive;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 
 The loopback HTTP server that backs the iframe binds to `127.0.0.1` only. See

--- a/extension.mjs
+++ b/extension.mjs
@@ -43,6 +43,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createCanvas, joinSession } from "@github/copilot-sdk/extension";
+import { DebugSession } from "./jdwp.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -1260,6 +1261,7 @@ const lanes = {
   test: newLane("test"),
   package: newLane("package"),
   run: newLane("run"),
+  debug: newLane("debug"),
 };
 
 // Run-lane application state (only meaningful while the app is up).
@@ -1283,6 +1285,15 @@ function mvnLaneBusy() {
 }
 function runLaneBusy() {
   return lanes.run.child !== null;
+}
+function debugLaneBusy() {
+  return lanes.debug.child !== null;
+}
+// The app slot (a single running JVM, tracked by the shared `app` state) is owned
+// by either the Run lane or the Debug lane — never both. Start paths guard on this
+// so Run and Debug stay mutually exclusive.
+function appBusy() {
+  return lanes.run.child !== null || lanes.debug.child !== null;
 }
 
 let testRunStartedAt = 0;
@@ -1535,6 +1546,11 @@ function fixInfo(op) {
     if (app.runMode === "quarkus") return { kind: "run-quarkus", label: "Fix Quarkus startup with Copilot" };
     return { kind: "run-spring", label: "Fix Spring Boot startup with Copilot" };
   }
+  if (op === "debug" && lane.phase === "failed") {
+    if (app.runMode === "java") return { kind: "run-java", label: "Fix startup failure with Copilot" };
+    if (app.runMode === "quarkus") return { kind: "run-quarkus", label: "Fix Quarkus startup with Copilot" };
+    return { kind: "run-spring", label: "Fix Spring Boot startup with Copilot" };
+  }
   return null;
 }
 
@@ -1558,6 +1574,14 @@ function laneStatus(op) {
     s.appPort = app.appPort;
     s.appUp = app.appUp;
   }
+  if (op === "debug") {
+    s.runMode = app.runMode;
+    s.appPort = app.appPort;
+    s.appUp = app.appUp;
+    s.paused = !!(debug.session && debug.session.paused);
+    s.attached = !!(debug.session && debug.session.active);
+    s.attaching = debug.attaching;
+  }
   if (op === "test") s.lastTest = lastTest;
   return s;
 }
@@ -1568,6 +1592,7 @@ function statusSnapshot() {
     test: laneStatus("test"),
     package: laneStatus("package"),
     run: laneStatus("run"),
+    debug: laneStatus("debug"),
     metricsTier: lastMetrics.metricsTier || null,
     reload: liveReloadStatus(),
   };
@@ -1655,6 +1680,16 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
     // spinner / button-greying off) until the process exits.
     broadcast("status", statusSnapshot());
 
+    // Debug lane: the JVM carrying the JDWP agent has just been spawned (phase
+    // "running"). Start the connect-with-retry now — not back in startDebug — so the
+    // attach budget covers JVM startup only. The pure-Java path runs a full build
+    // (phase "building") before this point, which on a cold build can exceed the
+    // attach window; deferring to the running spawn keeps the budget honest. The
+    // loop aborts promptly if this child exits (close handler flips attachCancel).
+    if (op === "debug" && phase === "running" && debug.jdwpPort) {
+      void attachDebugger(debug.jdwpPort).catch(() => {});
+    }
+
     const wire = (stream, name) => {
       let buf = "";
       stream.on("data", (chunk) => {
@@ -1697,6 +1732,15 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
         // A run that exits non-zero before the app ever served metrics is a
         // startup crash (surface a Fix button); otherwise it was a clean stop.
         lane.phase = code === 0 || app.appReachedUp ? "stopped" : "failed";
+        // The debug JVM exited: stop the connect-retry loop and clean up the
+        // generated init script. The JDWP socket dropping triggers the session's
+        // onClosed too, but a crash before attach never opens it, so do it here.
+        if (op === "debug") {
+          debug.attachCancel.aborted = true;
+          debug.attaching = false;
+          cleanupDebugInitScript();
+          broadcastDebug();
+        }
       } else {
         lane.phase = code === 0 ? "idle" : "failed";
       }
@@ -1713,8 +1757,8 @@ function tail(op = "build", n = 25) {
 // Pick the lane an agent status check most likely cares about: a failed lane
 // first, then a busy one, else build.
 function mostRelevantOp() {
-  for (const o of ["build", "test", "package", "run"]) if (lanes[o].phase === "failed") return o;
-  for (const o of ["run", "test", "package", "build"]) if (lanes[o].child) return o;
+  for (const o of ["build", "test", "package", "run", "debug"]) if (lanes[o].phase === "failed") return o;
+  for (const o of ["run", "debug", "test", "package", "build"]) if (lanes[o].child) return o;
   return "build";
 }
 
@@ -1935,13 +1979,21 @@ async function test(extraArgs, warm, mavenProfiles) {
   };
 }
 
-async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
+async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = {}) {
+  const op = dbg ? "debug" : "run";
   if (!buildTool) {
-    pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "run");
+    pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", op);
     return noToolResult();
   }
-  if (runLaneBusy()) return { ok: false, error: "The app is already running. Stop it first." };
-  lanes.run.warm = false;
+  if (appBusy()) {
+    return {
+      ok: false,
+      error: debugLaneBusy()
+        ? "A debug session is already running. Stop it first."
+        : "The app is already running. Stop it first.",
+    };
+  }
+  lanes[op].warm = false;
   app.appPort = null;
   app.appUp = false;
   app.appReachedUp = false;
@@ -1969,6 +2021,8 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
       // (SPRING_PROFILES_ACTIVE / SERVER_PORT) to avoid cross-platform --args
       // quoting pitfalls.
       const args = [gradleTaskPath(module, "bootRun"), "--console=plain"];
+      // Debug: an init script adds the JDWP agent to the forked bootRun JVM.
+      if (dbg) args.push("--init-script", gradleDebugInitScript(dbg));
       const extra = {};
       if (profiles) extra.SPRING_PROFILES_ACTIVE = profiles;
       if (settings.randomPort) {
@@ -1980,11 +2034,13 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
         }
         if (port) {
           extra.SERVER_PORT = String(port);
-          pushConsole(`[coffilot] using HTTP port ${port} via SERVER_PORT.`, "stdout", "run");
+          pushConsole(`[coffilot] using HTTP port ${port} via SERVER_PORT.`, "stdout", op);
         }
       }
-      spawnTool("run", args, "running", { bin: r.bin, label: r.label, env: toolEnv(extra), onLine: detectPort });
-      if (settings.devtools && mod && mod.devtools) {
+      spawnTool(op, args, "running", { bin: r.bin, label: r.label, env: toolEnv(extra), onLine: detectPort });
+      // Live reload would recompile and restart the JVM, dropping the debug
+      // session — keep it off while debugging.
+      if (!dbg && settings.devtools && mod && mod.devtools) {
         startLiveReload({ module: module || "", mavenProfiles, bin: r.bin, label: r.label });
       }
       return { ok: true, started: true, mode: "spring", command: `${r.label} ${args.join(" ")}` };
@@ -1996,8 +2052,10 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
     args.push("-Dmaven.test.skip=true", "spring-boot:run");
     if (profiles) args.push(`-Dspring-boot.run.profiles=${profiles}`);
     // Pass the native-access flag to the forked app JVM so its FFM-using
-    // dependencies don't print restricted-method warnings.
-    args.push(`-Dspring-boot.run.jvmArguments=${NATIVE_ACCESS_FLAG}`);
+    // dependencies don't print restricted-method warnings; in Debug mode the JDWP
+    // agent rides along on the same jvmArguments string.
+    const jvmArgs = dbg ? `${NATIVE_ACCESS_FLAG} ${jdwpAgentArg(dbg)}` : NATIVE_ACCESS_FLAG;
+    args.push(`-Dspring-boot.run.jvmArguments=${jvmArgs}`);
     // "Use a random HTTP port": run on a free port the console picks (via
     // server.port) so the app doesn't collide with whatever owns the default.
     if (settings.randomPort) {
@@ -2008,12 +2066,12 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
         /* fall back to server.port=0 (Spring picks one; detectPort reads it) */
       }
       args.push(`-Dspring-boot.run.arguments=--server.port=${port}`);
-      pushConsole(`[coffilot] using HTTP port ${port || "(random)"} via server.port.`, "stdout", "run");
+      pushConsole(`[coffilot] using HTTP port ${port || "(random)"} via server.port.`, "stdout", op);
     }
-    spawnTool("run", args, "running", { onLine: detectPort }); // fire-and-forget
+    spawnTool(op, args, "running", { onLine: detectPort }); // fire-and-forget
     // DevTools restarts in place when target/classes changes, so watch sources
-    // and recompile on save to drive that loop automatically.
-    if (settings.devtools && mod && mod.devtools) {
+    // and recompile on save to drive that loop automatically (off while debugging).
+    if (!dbg && settings.devtools && mod && mod.devtools) {
       const lr = resolveRunner(true);
       startLiveReload({ module: module || "", mavenProfiles, bin: lr.bin, label: lr.label });
     }
@@ -2023,11 +2081,14 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
   if (resolved === "quarkus") {
     // Quarkus dev mode (quarkus:dev / quarkusDev) runs the app in the foreground
     // with built-in live reload — no DevTools-style recompile loop needed. The
-    // active config profile and HTTP port flow through -D / env vars.
+    // active config profile and HTTP port flow through -D / env vars. Debug uses
+    // Quarkus's built-in JDWP support (-Ddebug=<port> -Dsuspend=<y|n>), which it
+    // binds to localhost.
     const r = resolveRunner(false);
+    const quarkusDebug = dbg ? [`-Ddebug=${dbg.jdwpPort}`, `-Dsuspend=${dbg.suspend ? "y" : "n"}`] : [];
 
     if (buildTool === "gradle") {
-      const args = [gradleTaskPath(module, "quarkusDev"), "--console=plain"];
+      const args = [gradleTaskPath(module, "quarkusDev"), "--console=plain", ...quarkusDebug];
       const extra = {};
       if (profiles) extra.QUARKUS_PROFILE = profiles;
       if (settings.randomPort) {
@@ -2039,10 +2100,10 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
         }
         if (port) {
           extra.QUARKUS_HTTP_PORT = String(port);
-          pushConsole(`[coffilot] using HTTP port ${port} via QUARKUS_HTTP_PORT.`, "stdout", "run");
+          pushConsole(`[coffilot] using HTTP port ${port} via QUARKUS_HTTP_PORT.`, "stdout", op);
         }
       }
-      spawnTool("run", args, "running", { bin: r.bin, label: r.label, env: toolEnv(extra), onLine: detectPort });
+      spawnTool(op, args, "running", { bin: r.bin, label: r.label, env: toolEnv(extra), onLine: detectPort });
       return { ok: true, started: true, mode: "quarkus", command: `${r.label} ${args.join(" ")}` };
     }
 
@@ -2050,6 +2111,7 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
     if (module) args.push("-pl", module);
     if (mavenProfiles && mavenProfiles.trim()) args.push("-P", mavenProfiles.trim());
     if (profiles) args.push(`-Dquarkus.profile=${profiles}`);
+    args.push(...quarkusDebug);
     if (settings.randomPort) {
       let port = 0;
       try {
@@ -2059,32 +2121,33 @@ async function startApp({ module, profiles, mavenProfiles, mode } = {}) {
       }
       if (port) {
         args.push(`-Dquarkus.http.port=${port}`);
-        pushConsole(`[coffilot] using HTTP port ${port} via quarkus.http.port.`, "stdout", "run");
+        pushConsole(`[coffilot] using HTTP port ${port} via quarkus.http.port.`, "stdout", op);
       }
     }
     args.push("quarkus:dev");
-    spawnTool("run", args, "running", { onLine: detectPort }); // fire-and-forget
+    spawnTool(op, args, "running", { onLine: detectPort }); // fire-and-forget
     return { ok: true, started: true, mode: "quarkus", command: `${baseRunner().label} ${args.join(" ")}` };
   }
 
   // Non-Spring: hand off to the generic runner (Gradle application run /
   // executable jar via java -jar / configured main class via java -cp).
-  runPureJava({ module, mavenProfiles });
+  runPureJava({ module, mavenProfiles, dbg });
   return { ok: true, started: true, mode: "java" };
 }
 
-/** Mark the Run lane failed with a console message (used by the generic runner
- * when it can't find anything launchable). */
-function failRunLane(msg) {
-  pushConsole(`[coffilot] ${msg}`, "stderr", "run");
-  lanes.run.phase = "failed";
-  lanes.run.exitCode = -1;
+/** Mark the Run/Debug lane failed with a console message (used by the generic
+ * runner when it can't find anything launchable). */
+function failRunLane(msg, op = "run") {
+  pushConsole(`[coffilot] ${msg}`, "stderr", op);
+  lanes[op].phase = "failed";
+  lanes[op].exitCode = -1;
   broadcast("status", statusSnapshot());
 }
 
 /** Two-phase pure-Java launch for non-Spring modules. Both phases run on the
- * independent Run lane so launching the app never blocks (or is blocked by) a
- * Build/Test on the shared build lane. The launch strategy degrades by capability:
+ * independent Run lane (or the Debug lane when `dbg` is set) so launching the app
+ * never blocks (or is blocked by) a Build/Test on the shared build lane. The
+ * launch strategy degrades by capability:
  *   1. Gradle `application` plugin  -> `gradle :module:run` (resolves classpath +
  *      main class and forks the app JVM — the canonical generic launcher).
  *   2. An executable jar            -> `java -jar <jar>` (fat/shaded jars, or a jar
@@ -2092,8 +2155,12 @@ function failRunLane(msg) {
  *   3. A configured main class      -> `java -cp <runtime classpath> <mainClass>`
  *      (Maven reconstructs the classpath via dependency:build-classpath; Gradle
  *      falls back to compiled classes + resources).
- * If none apply, the lane fails with actionable guidance. */
-async function runPureJava({ module, mavenProfiles }) {
+ * If none apply, the lane fails with actionable guidance. When `dbg` is set the
+ * JDWP agent is injected (Gradle `run` via an init script, plain `java` via an
+ * argv flag). */
+async function runPureJava({ module, mavenProfiles, dbg = null }) {
+  const op = dbg ? "debug" : "run";
+  const javaAgent = dbg ? [jdwpAgentArg(dbg)] : [];
   app.runMode = "java";
   const mod = listModules().find((m) => m.name === (module || "")) || null;
 
@@ -2101,8 +2168,10 @@ async function runPureJava({ module, mavenProfiles }) {
   if (buildTool === "gradle" && mod && mod.application) {
     const r = resolveRunner(false);
     const task = gradleTaskPath(module, "run");
-    pushConsole(`[coffilot] launching via the Gradle application plugin (${task}).`, "stdout", "run");
-    spawnTool("run", [task, "--console=plain"], "running", {
+    pushConsole(`[coffilot] launching via the Gradle application plugin (${task}).`, "stdout", op);
+    const args = [task, "--console=plain"];
+    if (dbg) args.push("--init-script", gradleDebugInitScript(dbg));
+    spawnTool(op, args, "running", {
       bin: r.bin,
       label: r.label,
       env: toolEnv(),
@@ -2115,21 +2184,21 @@ async function runPureJava({ module, mavenProfiles }) {
   if (buildTool === "gradle") {
     const r = resolveRunner(false);
     const buildArgs = [gradleTaskPath(module, "build"), "-x", "test", "--console=plain"];
-    const code = await spawnTool("run", buildArgs, "building", { bin: r.bin, label: r.label });
+    const code = await spawnTool(op, buildArgs, "building", { bin: r.bin, label: r.label });
     if (code !== 0) return; // run lane already 'failed' -> "fix startup" path
   } else {
     const pkg = ["-ntp", "-Dmaven.test.skip=true"];
     if (module) pkg.push("-pl", module);
     if (mavenProfiles && mavenProfiles.trim()) pkg.push("-P", mavenProfiles.trim());
     pkg.push("package");
-    const code = await spawnTool("run", pkg, "building", {});
+    const code = await spawnTool(op, pkg, "building", {});
     if (code !== 0) return; // run lane already 'failed' -> "fix startup" path
   }
 
   // 2. Prefer an executable jar (its manifest declares a Main-Class).
   const found = await findLaunchJar(module);
   if (found && found.mainClass) {
-    spawnTool("run", [NATIVE_ACCESS_FLAG, "-jar", found.jar], "running", {
+    spawnTool(op, [...javaAgent, NATIVE_ACCESS_FLAG, "-jar", found.jar], "running", {
       bin: "java",
       label: "java",
       onLine: detectPort,
@@ -2140,10 +2209,10 @@ async function runPureJava({ module, mavenProfiles }) {
   // 3. No executable jar — launch a configured main class on a runtime classpath.
   const mainClass = mod && mod.mainClass;
   if (mainClass) {
-    const cp = await runtimeClasspath(module, mavenProfiles);
+    const cp = await runtimeClasspath(module, mavenProfiles, op);
     if (cp) {
-      pushConsole(`[coffilot] launching ${mainClass} with java -cp.`, "stdout", "run");
-      spawnTool("run", [NATIVE_ACCESS_FLAG, "-cp", cp, mainClass], "running", {
+      pushConsole(`[coffilot] launching ${mainClass} with java -cp.`, "stdout", op);
+      spawnTool(op, [...javaAgent, NATIVE_ACCESS_FLAG, "-cp", cp, mainClass], "running", {
         bin: "java",
         label: "java",
         onLine: detectPort,
@@ -2160,9 +2229,9 @@ async function runPureJava({ module, mavenProfiles }) {
     pushConsole(
       "[coffilot] no executable manifest or configured main class confirmed; attempting java -jar as a fallback.",
       "stdout",
-      "run",
+      op,
     );
-    spawnTool("run", [NATIVE_ACCESS_FLAG, "-jar", found.jar], "running", {
+    spawnTool(op, [...javaAgent, NATIVE_ACCESS_FLAG, "-jar", found.jar], "running", {
       bin: "java",
       label: "java",
       onLine: detectPort,
@@ -2178,6 +2247,7 @@ async function runPureJava({ module, mavenProfiles }) {
       : "set a `<mainClass>` on the Maven Jar/Shade/Assembly plugin, or an `<exec.mainClass>` property";
   failRunLane(
     `no runnable .jar under ${dirLabel} and no main class is configured for this module — ${hint}, then Run again.`,
+    op,
   );
 }
 
@@ -2186,7 +2256,7 @@ async function runPureJava({ module, mavenProfiles }) {
  * prepends the module's compiled classes. Gradle (without the application plugin,
  * which would otherwise be used) can't resolve external dependencies cheaply, so
  * it falls back to the compiled classes + resources and warns. */
-async function runtimeClasspath(module, mavenProfiles) {
+async function runtimeClasspath(module, mavenProfiles, op = "run") {
   const moduleDir = path.join(workspacePath, module || "");
   if (buildTool === "gradle") {
     const classes = path.join(moduleDir, "build", "classes", "java", "main");
@@ -2195,7 +2265,7 @@ async function runtimeClasspath(module, mavenProfiles) {
       "[coffilot] no application plugin detected; launching with compiled classes only — external dependencies may be missing. " +
         "Apply the Gradle `application` plugin for a complete runtime classpath.",
       "stderr",
-      "run",
+      op,
     );
     return [classes, resources].filter(existsSync).join(path.delimiter) || classes;
   }
@@ -2205,7 +2275,7 @@ async function runtimeClasspath(module, mavenProfiles) {
   if (module) args.push("-pl", module);
   if (mavenProfiles && mavenProfiles.trim()) args.push("-P", mavenProfiles.trim());
   args.push("dependency:build-classpath", `-Dmdep.outputFile=${cpFile}`, "-Dmdep.includeScope=runtime");
-  const code = await spawnTool("run", args, "building", {});
+  const code = await spawnTool(op, args, "building", {});
   let deps = "";
   try {
     deps = readFileSync(cpFile, "utf8").trim();
@@ -2311,6 +2381,204 @@ function readZipEntry(zipPath, entryName) {
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Debug lane (JDWP) — launch the app with the JDWP agent enabled and drive a
+// debug session (breakpoints, stepping, stack, locals, evaluate) through the
+// self-contained engine in jdwp.mjs. Mutually exclusive with Run: both share the
+// single app slot (the shared `app` state: port, mode, live metrics), so only
+// one of them owns the running JVM at a time. The JDWP transport binds to
+// 127.0.0.1 only.
+// ---------------------------------------------------------------------------
+
+const debug = {
+  session: null, // DebugSession (created lazily; reused across VM restarts so breakpoints persist)
+  jdwpPort: null, // loopback JDWP port for the current/last launch
+  suspend: false, // suspend-on-start (pause at the very first instruction)
+  attaching: false, // true while the connect-with-retry loop runs
+  attachCancel: { aborted: false }, // flipped to stop the connect loop if the launch exits early
+  initScript: null, // generated Gradle init-script path to clean up
+};
+
+/** The JDWP agent argument injected into the app JVM. server=y means the JVM
+ * listens; we connect to it. suspend=y holds the VM at startup until we attach. */
+function jdwpAgentArg(dbg) {
+  return `-agentlib:jdwp=transport=dt_socket,server=y,suspend=${dbg.suspend ? "y" : "n"},address=127.0.0.1:${dbg.jdwpPort}`;
+}
+
+/** Write a throwaway Gradle init script that adds the JDWP agent (and the
+ * native-access flag) to the forked app JVM of JavaExec-typed run tasks
+ * (bootRun / run). Quarkus uses -Ddebug instead, so quarkusDev isn't matched. */
+function gradleDebugInitScript(dbg) {
+  const flags = [NATIVE_ACCESS_FLAG, jdwpAgentArg(dbg)];
+  const body = [
+    "gradle.allprojects {",
+    "  tasks.matching { it.name == 'bootRun' || it.name == 'run' }.configureEach { t ->",
+    "    if (t instanceof JavaExec) {",
+    `      t.jvmArgs(${JSON.stringify(flags)})`,
+    "    }",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+  const file = path.join(os.tmpdir(), `coffilot-debug-${process.pid}-${dbg.jdwpPort}.gradle`);
+  writeFileSync(file, body);
+  debug.initScript = file;
+  return file;
+}
+
+function cleanupDebugInitScript() {
+  if (!debug.initScript) return;
+  try {
+    if (existsSync(debug.initScript)) unlinkSync(debug.initScript);
+  } catch {
+    /* best-effort */
+  }
+  debug.initScript = null;
+}
+
+/** Create the DebugSession once and reuse it for the extension's lifetime so
+ * breakpoints set before/between launches survive. The engine's connect() resets
+ * per-session install state, so the same object reconnects cleanly to a new VM. */
+function ensureDebugSession() {
+  if (debug.session) return debug.session;
+  debug.session = new DebugSession({
+    log: (m) => pushConsole(`[debug] ${m}`, "stdout", "debug"),
+    onPaused: () => broadcastDebug(),
+    onResumed: () => broadcastDebug(),
+    onBreakpoints: () => broadcastDebug(),
+    onClosed: () => onDebugVmClosed(),
+  });
+  return debug.session;
+}
+
+function debugSnapshot() {
+  const s = debug.session;
+  const base = s
+    ? s.snapshot()
+    : { active: false, paused: false, stoppedReason: null, thread: null, location: null, frames: [], breakpoints: [] };
+  return {
+    laneBusy: lanes.debug.child !== null,
+    attaching: debug.attaching,
+    port: debug.jdwpPort,
+    suspend: debug.suspend,
+    ...base,
+  };
+}
+
+function broadcastDebug() {
+  broadcast("debug", debugSnapshot());
+  // The Debug lane header (running / paused) lives in the shared status too.
+  broadcast("status", statusSnapshot());
+}
+
+// The JDWP socket dropped — usually the debuggee VM exited. Keep the session
+// object (and its breakpoint specs) for the next launch; just reflect the state.
+function onDebugVmClosed() {
+  debug.attaching = false;
+  pushConsole("[debug] debug session ended (VM disconnected)", "stdout", "debug");
+  broadcastDebug();
+}
+
+/** Launch the app with JDWP enabled and attach the debugger. Mutually exclusive
+ * with Run. Returns once the JVM has been launched; the connect-with-retry runs
+ * in the background and broadcasts when attached. */
+async function startDebug({ module, profiles, mavenProfiles, mode, suspend } = {}) {
+  if (!buildTool) {
+    pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "debug");
+    return noToolResult();
+  }
+  if (appBusy()) {
+    return {
+      ok: false,
+      error: debugLaneBusy()
+        ? "A debug session is already running. Stop it first."
+        : "The app is already running. Stop it first.",
+    };
+  }
+  let jdwpPort;
+  try {
+    jdwpPort = await freePort();
+  } catch {
+    return { ok: false, error: "Could not reserve a loopback port for the debugger." };
+  }
+  debug.jdwpPort = jdwpPort;
+  debug.suspend = suspend === true;
+  debug.attaching = false;
+  debug.attachCancel = { aborted: false };
+  ensureDebugSession();
+  cleanupDebugInitScript();
+
+  pushConsole(
+    `[coffilot] starting debug session (JDWP on 127.0.0.1:${jdwpPort}, suspend=${debug.suspend ? "y" : "n"})`,
+    "stdout",
+    "debug",
+  );
+  const dbg = { jdwpPort, suspend: debug.suspend };
+  const res = await startApp({ module, profiles, mavenProfiles, mode, dbg });
+  if (!res || res.ok === false) {
+    cleanupDebugInitScript();
+    return res || { ok: false, error: "Failed to start the app for debugging." };
+  }
+  // The connect-with-retry is kicked off by spawnTool the moment the app JVM
+  // (phase "running") is spawned, so the attach budget covers JVM startup only —
+  // never a long preceding build. Nothing more to do here.
+  return { ok: true, started: true, debug: true, port: jdwpPort, suspend: debug.suspend, mode: res.mode };
+}
+
+async function attachDebugger(jdwpPort) {
+  const sess = ensureDebugSession();
+  // spawnTool fires this once per "running" spawn; guard against a re-entrant
+  // call while a connect loop is already in flight.
+  if (debug.attaching) return;
+  debug.attaching = true;
+  broadcastDebug();
+  try {
+    // Generous budget (~10 min) so even a cold compile inside the run wrapper
+    // (Spring/Quarkus build the app during the "running" phase) is covered. The
+    // loop exits early when the launch child dies: its close handler flips
+    // attachCancel.aborted, which connect() honors between attempts.
+    await sess.connect("127.0.0.1", jdwpPort, { retries: 4000, delayMs: 150, signal: debug.attachCancel });
+    debug.attaching = false;
+    pushConsole(`[debug] debugger attached on 127.0.0.1:${jdwpPort}`, "stdout", "debug");
+    broadcastDebug();
+  } catch (e) {
+    debug.attaching = false;
+    if (!debug.attachCancel.aborted) {
+      pushConsole(`[debug] could not attach the debugger: ${e.message}`, "stderr", "debug");
+    }
+    broadcastDebug();
+  }
+}
+
+/** Stop the debug session: cancel any pending attach, drop the JDWP connection,
+ * and kill the app JVM. Breakpoint specs persist for the next session. */
+function stopDebug() {
+  debug.attachCancel.aborted = true;
+  debug.attaching = false;
+  if (debug.session) {
+    try {
+      debug.session.dispose();
+    } catch {
+      /* ignore */
+    }
+  }
+  cleanupDebugInitScript();
+  const res = stopApp("debug");
+  broadcastDebug();
+  return res.stopped
+    ? { ok: true, stopped: true }
+    : { ok: true, stopped: false, note: "No debug session was running." };
+}
+
+// Guard helper for the per-action debug endpoints: there must be a live,
+// attached session to control.
+function withDebugSession(fn) {
+  if (!debug.session || !debug.session.active) {
+    return { ok: false, error: "No debug session is attached. Start Debug first." };
+  }
+  return fn(debug.session);
+}
+
 /** SIGTERM (then SIGKILL) a child process tree, cross-platform. */
 function killChild(child) {
   if (!child) return;
@@ -2410,11 +2678,11 @@ function stopApp(op) {
   let targets;
   if (op === "maven" || op === "build-group") targets = ["build", "test", "package"];
   else if (op && lanes[op]) targets = [op];
-  else targets = ["build", "test", "package", "run"];
+  else targets = ["build", "test", "package", "run", "debug"];
   let stopped = false;
   let warmBuildOp = null; // a build lane whose work is inside a daemon
   for (const o of targets) {
-    if (o === "run") {
+    if (o === "run" || o === "debug") {
       stopMetricsPolling();
       stopLiveReload();
     }
@@ -2423,7 +2691,7 @@ function stopApp(op) {
     if (child) {
       killChild(child);
       stopped = true;
-      if (o !== "run" && lane.warm) warmBuildOp = o;
+      if (o !== "run" && o !== "debug" && lane.warm) warmBuildOp = o;
     }
   }
   // Build lanes are serialized, so at most one warm daemon build is ever live.
@@ -2469,6 +2737,13 @@ async function restart(op, params = {}) {
     }
     return startApp(params);
   }
+  if (op === "debug") {
+    stopDebug();
+    if (!(await waitForLaneIdle(debugLaneBusy))) {
+      return { ok: false, error: "Timed out stopping the debug session; press Stop, then Debug." };
+    }
+    return startDebug(params);
+  }
   if (!["build", "test", "package"].includes(op)) {
     return { ok: false, error: `Cannot restart "${op}".` };
   }
@@ -2504,6 +2779,13 @@ function gracefulShutdown(signal) {
     /* host channel may already be gone */
   }
   stopApp(); // SIGTERM every lane + stop metrics polling / live reload timers
+  debug.attachCancel.aborted = true;
+  try {
+    debug.session?.dispose();
+  } catch {
+    /* ignore */
+  }
+  cleanupDebugInitScript();
   // Don't block on killChild's 5s SIGKILL escalation; exit promptly. The "exit"
   // handler below force-kills anything still alive as a last resort.
   setTimeout(() => process.exit(0), 1500).unref();
@@ -2519,7 +2801,7 @@ process.once("SIGINT", () => gracefulShutdown("SIGINT"));
 // tree is still alive, so checking it here would skip the very processes we need
 // to reap.
 process.on("exit", () => {
-  for (const o of ["build", "test", "package", "run"]) {
+  for (const o of ["build", "test", "package", "run", "debug"]) {
     const child = lanes[o].child;
     if (!child || !child.pid) continue;
     try {
@@ -2553,7 +2835,8 @@ function detectPort(line) {
     const m = line.match(re);
     if (m) {
       app.appPort = Number(m[1]);
-      pushConsole(`[coffilot] detected app port ${app.appPort}; polling for live metrics`, "stdout", "run");
+      const portOp = lanes.debug.child ? "debug" : "run";
+      pushConsole(`[coffilot] detected app port ${app.appPort}; polling for live metrics`, "stdout", portOp);
       broadcast("status", statusSnapshot());
       startMetricsPolling();
       return;
@@ -3514,6 +3797,7 @@ const server = createServer(async (req, res) => {
     res.write(`event: status\ndata: ${JSON.stringify(statusSnapshot())}\n\n`);
     res.write(`event: metrics\ndata: ${JSON.stringify(lastMetrics)}\n\n`);
     res.write(`event: tests\ndata: ${JSON.stringify(lastTestReport)}\n\n`);
+    res.write(`event: debug\ndata: ${JSON.stringify(debugSnapshot())}\n\n`);
     req.on("close", () => sseClients.get(instanceId)?.delete(res));
     return;
   }
@@ -3524,8 +3808,15 @@ const server = createServer(async (req, res) => {
       metrics: lastMetrics,
       // Concatenate all lane buffers; each entry is tagged with its op so the
       // UI replays it into the right console.
-      console: [...lanes.build.console, ...lanes.test.console, ...lanes.package.console, ...lanes.run.console],
+      console: [
+        ...lanes.build.console,
+        ...lanes.test.console,
+        ...lanes.package.console,
+        ...lanes.run.console,
+        ...lanes.debug.console,
+      ],
       tests: lastTestReport,
+      debug: debugSnapshot(),
       env: envSnapshot(),
     });
     return;
@@ -3581,6 +3872,81 @@ const server = createServer(async (req, res) => {
   if (req.method === "POST" && url.pathname === "/api/restart") {
     const body = await readBody(req);
     sendJson(res, 200, await restart(body.op, body)); // stop the lane, then relaunch it
+    return;
+  }
+
+  // --- Debug lane (JDWP) ---------------------------------------------------
+  if (req.method === "POST" && url.pathname === "/api/debug/start") {
+    const body = await readBody(req);
+    sendJson(
+      res,
+      200,
+      await startDebug({
+        module: body.module,
+        profiles: body.profiles,
+        mavenProfiles: body.mavenProfiles,
+        mode: body.mode,
+        suspend: body.suspend === true,
+      }),
+    );
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/stop") {
+    sendJson(res, 200, stopDebug());
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/debug/status") {
+    sendJson(res, 200, debugSnapshot());
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/breakpoint") {
+    const body = await readBody(req);
+    if (!body.class || !Number.isInteger(body.line)) {
+      sendJson(res, 200, { ok: false, error: "Provide a class (binary name) and an integer line." });
+      return;
+    }
+    const bp = await ensureDebugSession().addBreakpoint(String(body.class), Number(body.line));
+    sendJson(res, 200, {
+      ok: true,
+      breakpoint: { id: bp.id, class: bp.className, line: bp.line, verified: bp.verified },
+    });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/breakpoint/remove") {
+    const body = await readBody(req);
+    const removed = debug.session ? await debug.session.removeBreakpoint(Number(body.id)) : false;
+    sendJson(res, 200, { ok: true, removed });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/continue") {
+    sendJson(res, 200, await withDebugSession((s) => s.resume()));
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/step") {
+    const body = await readBody(req);
+    sendJson(res, 200, await withDebugSession((s) => s.step(body.depth)));
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/pause") {
+    sendJson(res, 200, await withDebugSession((s) => s.pause()));
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/debug/stack") {
+    sendJson(res, 200, debug.session ? await debug.session.stack() : { paused: false, frames: [] });
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/api/debug/locals") {
+    const frame = Number(url.searchParams.get("frame") || 0) || 0;
+    sendJson(res, 200, await withDebugSession((s) => s.locals(frame)));
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/debug/evaluate") {
+    const body = await readBody(req);
+    sendJson(
+      res,
+      200,
+      await withDebugSession((s) => s.evaluate(String(body.expression || ""), Number(body.frame || 0))),
+    );
     return;
   }
 
@@ -3778,17 +4144,153 @@ function makeCanvas() {
       {
         name: "stop_app",
         description:
-          "Stop a running lane. Pass op=build|test|package|run to stop one, op=maven to stop the build/test/package lane, or omit to stop all.",
+          "Stop a running lane. Pass op=build|test|package|run|debug to stop one, op=maven to stop the build/test/package lane, or omit to stop all.",
         inputSchema: {
           type: "object",
-          properties: { op: { type: "string", enum: ["build", "test", "package", "run", "maven"] } },
+          properties: { op: { type: "string", enum: ["build", "test", "package", "run", "debug", "maven"] } },
         },
         handler: async (ctx) => stopApp(ctx.input?.op),
       },
       {
+        name: "start_debug",
+        description:
+          "Launch the app under the JDWP debugger and attach (mutually exclusive with start_app/Run — stop one before starting the other). Returns immediately; output streams to the canvas and the debugger attaches in the background. Set breakpoints first (set_breakpoint) or use suspend=true to pause at startup, then drive the session with debug_continue, debug_step, debug_stack, get_variables, and debug_evaluate. Spring Boot, Quarkus and plain-Java modules are all supported.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            module: { type: "string", description: "Module to debug (Maven -pl / Gradle subproject, e.g. 'web')." },
+            profiles: {
+              type: "string",
+              description: "Config profile(s) to activate (default 'dev'): Spring profiles or the Quarkus profile.",
+            },
+            mavenProfiles: {
+              type: "string",
+              description: "Maven build profiles to activate via -P (Maven projects only; ignored for Gradle).",
+            },
+            mode: {
+              type: "string",
+              enum: ["spring", "quarkus", "java"],
+              description: "Force the run strategy; defaults to auto-detect from the module.",
+            },
+            suspend: {
+              type: "boolean",
+              description:
+                "Suspend the VM at startup until the debugger attaches (useful to debug early startup code).",
+            },
+          },
+        },
+        handler: async (ctx) =>
+          startDebug({
+            module: ctx.input?.module,
+            profiles: ctx.input?.profiles ?? "dev",
+            mavenProfiles: ctx.input?.mavenProfiles,
+            mode: ctx.input?.mode,
+            suspend: ctx.input?.suspend === true,
+          }),
+      },
+      {
+        name: "stop_debug",
+        description:
+          "Detach the debugger and stop the app JVM started for debugging. Breakpoints are kept for next time.",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => stopDebug(),
+      },
+      {
+        name: "set_breakpoint",
+        description:
+          "Add a line breakpoint at class:line (class is the binary name, e.g. 'com.example.App' or 'com.example.App$Inner'). Works before or during a debug session; it arms automatically when the class loads. Returns the breakpoint id and whether it is verified (armed).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            class: {
+              type: "string",
+              description: "Fully-qualified binary class name (e.g. com.example.OrderService).",
+            },
+            line: { type: "integer", description: "1-based source line number for the breakpoint." },
+          },
+          required: ["class", "line"],
+        },
+        handler: async (ctx) => {
+          const cls = ctx.input?.class;
+          const line = Number(ctx.input?.line);
+          if (!cls || !Number.isInteger(line)) {
+            return { ok: false, error: "Provide a class (binary name) and an integer line." };
+          }
+          const bp = await ensureDebugSession().addBreakpoint(String(cls), line);
+          return { ok: true, breakpoint: { id: bp.id, class: bp.className, line: bp.line, verified: bp.verified } };
+        },
+      },
+      {
+        name: "remove_breakpoint",
+        description: "Remove a breakpoint by its id (from set_breakpoint or debug_status).",
+        inputSchema: {
+          type: "object",
+          properties: { id: { type: "integer", description: "Breakpoint id to remove." } },
+          required: ["id"],
+        },
+        handler: async (ctx) => {
+          const removed = debug.session ? await debug.session.removeBreakpoint(Number(ctx.input?.id)) : false;
+          return { ok: true, removed };
+        },
+      },
+      {
+        name: "debug_continue",
+        description: "Resume execution from a paused breakpoint/step until the next breakpoint (or the program ends).",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => withDebugSession((s) => s.resume()),
+      },
+      {
+        name: "debug_step",
+        description:
+          "Single-step the paused thread one source line. depth=over (default) runs called methods without stepping in; into steps into the next call; out runs until the current method returns.",
+        inputSchema: {
+          type: "object",
+          properties: { depth: { type: "string", enum: ["over", "into", "out"], description: "Step granularity." } },
+        },
+        handler: async (ctx) => withDebugSession((s) => s.step(ctx.input?.depth)),
+      },
+      {
+        name: "debug_stack",
+        description: "Return the paused thread's call stack (top frame first: class, method, line).",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => (debug.session ? debug.session.stack() : { paused: false, frames: [] }),
+      },
+      {
+        name: "get_variables",
+        description:
+          "List local variables (and `this`) visible in a paused stack frame, with values. frame=0 is the top frame (default). Requires classes compiled with debug info (javac -g) for local names.",
+        inputSchema: {
+          type: "object",
+          properties: { frame: { type: "integer", description: "Stack frame index (0 = top). Defaults to 0." } },
+        },
+        handler: async (ctx) => withDebugSession((s) => s.locals(Number(ctx.input?.frame || 0))),
+      },
+      {
+        name: "debug_evaluate",
+        description:
+          "Inspect a local variable or a dotted field path (e.g. 'order.customer.name') in a paused frame. This is a field/variable inspector, not a Java expression compiler — no method calls or arithmetic.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            expression: { type: "string", description: "A local name or dotted field path (e.g. user.address.city)." },
+            frame: { type: "integer", description: "Stack frame index (0 = top). Defaults to 0." },
+          },
+          required: ["expression"],
+        },
+        handler: async (ctx) =>
+          withDebugSession((s) => s.evaluate(String(ctx.input?.expression || ""), Number(ctx.input?.frame || 0))),
+      },
+      {
+        name: "debug_status",
+        description:
+          "Return the debug session state: whether the debugger is attached, whether it is paused (and where), the current stack, and the breakpoint list.",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => debugSnapshot(),
+      },
+      {
         name: "get_status",
         description:
-          "Return per-lane status (build/test/package/run: phase, last command, exit code, suggested fix), last test summary, live metrics tier, and a recent output tail.",
+          "Return per-lane status (build/test/package/run/debug: phase, last command, exit code, suggested fix), last test summary, live metrics tier, and a recent output tail.",
         inputSchema: { type: "object", properties: {} },
         handler: async () => ({
           ...statusSnapshot(),
@@ -3840,9 +4342,17 @@ function makeCanvas() {
       // during the brief startup window.
       await serverReady;
       const inst = instanceFor(ctx.instanceId);
+      const status =
+        lanes.debug.child && debug.session && debug.session.paused
+          ? "debug: paused"
+          : lanes.debug.child
+            ? `debugging on :${app.appPort ?? "?"}`
+            : lanes.run.phase === "running"
+              ? `running on :${app.appPort ?? "?"}`
+              : lanes.run.phase;
       return {
         title: "Coffilot",
-        status: lanes.run.phase === "running" ? `running on :${app.appPort ?? "?"}` : lanes.run.phase,
+        status,
         url: `${serverUrl}/?instance=${encodeURIComponent(ctx.instanceId)}&token=${inst.token}`,
       };
     },

--- a/extension.mjs
+++ b/extension.mjs
@@ -56,6 +56,28 @@ const isMac = process.platform === "darwin";
 
 const session = await joinSession({ canvases: [makeCanvas()] });
 
+// Safety net: a background failure — a metrics poll, a port probe, a child-process
+// event, or an SSE write to a canvas that went away — must never terminate the
+// process, because that takes down the loopback control server and every later
+// canvas request then fails with "Load failed". Log and keep serving instead.
+// Never console.log here: stdout is the JSON-RPC channel.
+process.on("uncaughtException", (err) => {
+  try {
+    session.log(`[coffilot] uncaught exception (kept the server alive): ${err?.stack || err}`, { level: "error" });
+  } catch {
+    /* logging must never re-throw out of the handler */
+  }
+});
+process.on("unhandledRejection", (reason) => {
+  try {
+    session.log(`[coffilot] unhandled rejection (kept the server alive): ${reason?.stack || reason}`, {
+      level: "error",
+    });
+  } catch {
+    /* ignore */
+  }
+});
+
 // Project marker files used to locate the root and decide the build tool. Defined
 // here (before the resolution below) so findProjectRoot/detectBuildTool can read
 // them without hitting a temporal-dead-zone error during early startup.
@@ -1835,7 +1857,21 @@ function instanceFor(instanceId) {
 function broadcast(event, data) {
   const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
   for (const clients of sseClients.values()) {
-    for (const res of clients) res.write(payload);
+    for (const res of clients) {
+      // A canvas reload (its iframe port/token rotate) or a closed panel can leave
+      // a dead response in the set before its "close" handler fires. Writing to it
+      // throws, so skip ended sockets and drop any that reject the write — a failed
+      // SSE push must never take down the loopback control server.
+      if (res.writableEnded || res.destroyed) {
+        clients.delete(res);
+        continue;
+      }
+      try {
+        res.write(payload);
+      } catch {
+        clients.delete(res);
+      }
+    }
   }
 }
 
@@ -5187,12 +5223,20 @@ const server = createServer(async (req, res) => {
     });
     if (!sseClients.has(instanceId)) sseClients.set(instanceId, new Set());
     sseClients.get(instanceId).add(res);
-    res.write(`event: status\ndata: ${JSON.stringify(statusSnapshot())}\n\n`);
-    res.write(`event: metrics\ndata: ${JSON.stringify(lastMetrics)}\n\n`);
-    res.write(`event: tests\ndata: ${JSON.stringify(lastTestReport)}\n\n`);
-    res.write(`event: debug\ndata: ${JSON.stringify(debugSnapshot())}\n\n`);
-    res.write(`event: profile\ndata: ${JSON.stringify(profilePublic())}\n\n`);
-    req.on("close", () => sseClients.get(instanceId)?.delete(res));
+    // Drop this client on close OR error: a broken SSE socket emits "error"
+    // asynchronously, which would otherwise crash the process (no listener).
+    const drop = () => sseClients.get(instanceId)?.delete(res);
+    res.on("error", drop);
+    req.on("close", drop);
+    try {
+      res.write(`event: status\ndata: ${JSON.stringify(statusSnapshot())}\n\n`);
+      res.write(`event: metrics\ndata: ${JSON.stringify(lastMetrics)}\n\n`);
+      res.write(`event: tests\ndata: ${JSON.stringify(lastTestReport)}\n\n`);
+      res.write(`event: debug\ndata: ${JSON.stringify(debugSnapshot())}\n\n`);
+      res.write(`event: profile\ndata: ${JSON.stringify(profilePublic())}\n\n`);
+    } catch {
+      drop();
+    }
     return;
   }
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -206,6 +206,20 @@ function withJLineDumbFlag(args, bin) {
   return [JLINE_DUMB_FLAG, ...args];
 }
 
+/** Quote argv elements that contain whitespace for the Windows shell. spawnTool
+ * routes mvnw.cmd / gradlew.bat through cmd.exe (shell: true is required there —
+ * modern Node refuses to spawn .cmd/.bat directly), and the shell re-tokenizes the
+ * joined command line on spaces without quoting args for us. A single argv element
+ * that legitimately contains a space would therefore be split, e.g. the Spring Boot
+ * Maven debug string `-Dspring-boot.run.jvmArguments=<flag> <agent>` or a Gradle
+ * `--init-script <path>` whose temp dir has a space (C:\Users\John Doe\...). Wrap
+ * such args in double quotes. No-op on POSIX (shell: false preserves argv verbatim)
+ * and for already-quoted args. */
+function quoteWinShellArgs(args) {
+  if (!isWindows) return args;
+  return args.map((a) => (typeof a === "string" && /\s/.test(a) && !/^".*"$/.test(a) ? `"${a}"` : a));
+}
+
 /** Decide the build tool for a project root: Maven preferred, else Gradle, else null. */
 function detectBuildTool(root) {
   const has = (f) => existsSync(path.join(root, f));
@@ -1763,7 +1777,7 @@ function spawnTool(op, args, phase, { onLine, bin, label, env } = {}) {
     lane.console = [];
     session.log(`[coffilot] ${lane.command}`, { level: "info", ephemeral: true });
 
-    const child = spawn(toolBin, withJLineDumbFlag(args, toolBin), {
+    const child = spawn(toolBin, quoteWinShellArgs(withJLineDumbFlag(args, toolBin)), {
       cwd: workspacePath,
       env: env || toolEnv(),
       // mvnw.cmd / mvnd.cmd / gradlew.bat are batch scripts; modern Node refuses

--- a/extension.mjs
+++ b/extension.mjs
@@ -1479,6 +1479,17 @@ function watchTree(root, onChange) {
     } catch {
       return;
     }
+    // fs.watch emits "error" asynchronously (dir removed, EMFILE/ENOSPC, …); with
+    // no listener Node throws and crashes the process, so swallow it and drop this
+    // directory's watcher — the rest of the tree keeps working.
+    w.on("error", () => {
+      try {
+        w.close();
+      } catch {
+        /* ignore */
+      }
+      watched.delete(dir);
+    });
     watchers.push(w);
     watched.add(dir);
     let entries = [];
@@ -3528,7 +3539,9 @@ function killChild(child) {
     // shell:true means child is cmd.exe; kill the whole tree by PID so the
     // spawned Maven/Java processes don't get orphaned.
     try {
-      spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"]);
+      // .on("error") so a failed taskkill spawn (emitted asynchronously) can't
+      // crash the process; the try/catch only covers a synchronous spawn throw.
+      spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"]).on("error", () => {});
     } catch {
       /* ignore */
     }
@@ -3978,8 +3991,11 @@ async function findTestResultDirs(root, depth, acc = []) {
 
 function startMetricsPolling() {
   stopMetricsPolling();
-  metricsTimer = setInterval(refreshMetrics, 2500);
-  refreshMetrics();
+  // refreshMetrics is async; neither setInterval nor a bare call awaits it, so
+  // guard both so a failed poll can never escape as an unhandled rejection.
+  const poll = () => Promise.resolve(refreshMetrics()).catch(() => {});
+  metricsTimer = setInterval(poll, 2500);
+  poll();
 }
 
 function stopMetricsPolling() {
@@ -5192,7 +5208,7 @@ function sendJson(res, code, data) {
   res.end(JSON.stringify(data));
 }
 
-const server = createServer(async (req, res) => {
+async function handleRequest(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`);
 
   if (req.method === "GET" && STATIC_ASSETS[url.pathname]) {
@@ -5485,6 +5501,28 @@ const server = createServer(async (req, res) => {
 
   res.writeHead(404);
   res.end("Not found");
+}
+
+// Wrap the route handler so a throw in any endpoint (Build/Test/Package/Run/
+// Debug/MCP/…) can't reject an un-awaited promise — which would otherwise crash
+// the process and take the loopback server down. Log it and return a 500 so the
+// canvas stays connected.
+const server = createServer((req, res) => {
+  handleRequest(req, res).catch((err) => {
+    try {
+      session.log(`[coffilot] request handler error on ${req.method} ${req.url}: ${err?.stack || err}`, {
+        level: "error",
+      });
+    } catch {
+      /* logging must never re-throw */
+    }
+    try {
+      if (res.headersSent) res.end();
+      else sendJson(res, 500, { ok: false, error: "Internal error" });
+    } catch {
+      /* the socket is already gone */
+    }
+  });
 });
 
 let serverUrl = null;

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -98,7 +98,10 @@ Then open a Copilot session on that project, reload extensions, and open the
 
 - `hello-world` to confirm Build / Test / Package work with no Spring at all.
 - `gradle-hello-world` to confirm the same lanes drive a Gradle project.
-- `spring-mvc` for the Run lane and process-level metrics.
+- `spring-mvc` for the Run lane and process-level metrics. Also the easiest **Debug**
+  check: switch to the Debug tab, add a breakpoint at
+  `com.example.springmvc.HelloController:11`, click **Debug**, then hit `GET /` — the
+  session pauses in `hello()` with the call stack and frame variables shown.
 - `spring-mvc-actuator-devtools` for the Actuator metrics tier.
 - `spring-mvc-bootui` (run with `-Pdev`) for the full BootUI metrics + advisor scan.
 - `quarkus-rest` for the Quarkus Run lane (`quarkus:dev`) and the Quarkus metrics tier.

--- a/jdwp.mjs
+++ b/jdwp.mjs
@@ -1,0 +1,1304 @@
+// Coffilot — self-contained JDWP (Java Debug Wire Protocol) client + debug session.
+//
+// The JVM launched in the Debug lane speaks JDWP natively over a loopback socket
+// (started with `-agentlib:jdwp=...,server=y`). This module implements just enough
+// of the protocol — in plain Node, with no external debug adapter / DAP server and
+// no extra dependencies — for Copilot (or the canvas) to drive a session: set line
+// breakpoints, continue, step in/over/out, read the paused stack, inspect locals
+// and `this`, and evaluate a variable/field path.
+//
+// Two layers:
+//   * JdwpClient   — the wire protocol: handshake, request/reply correlation,
+//                    event packets, and typed wrappers for the command subset used
+//                    here. IDs are kept as BigInt (8-byte object/ref/method/frame
+//                    IDs overflow JS numbers) and surfaced to callers as strings.
+//   * DebugSession — higher-level orchestration on top of JdwpClient: a breakpoint
+//                    registry (resolved eagerly for loaded classes and lazily via
+//                    CLASS_PREPARE for not-yet-loaded ones), pause state, stack /
+//                    locals / evaluate, value formatting, and JSON snapshots.
+//
+// Everything here is pure (no @github/copilot-sdk, no canvas globals) so it can be
+// unit-tested by launching a throwaway `java -agentlib:jdwp=...` process.
+
+import { Socket } from "node:net";
+
+// ---------------------------------------------------------------------------
+// Protocol constants (subset)
+// ---------------------------------------------------------------------------
+
+const CMD = {
+  VirtualMachine: {
+    set: 1,
+    Version: 1,
+    ClassesBySignature: 2,
+    AllClasses: 3,
+    IDSizes: 7,
+    Suspend: 8,
+    Resume: 9,
+    Capabilities: 12,
+    CapabilitiesNew: 17,
+  },
+  ReferenceType: {
+    set: 2,
+    Signature: 1,
+    Fields: 4,
+    Methods: 5,
+    SourceFile: 7,
+    FieldsWithGeneric: 14,
+    MethodsWithGeneric: 15,
+  },
+  ClassType: { set: 3, Superclass: 1 },
+  Method: { set: 6, LineTable: 1, VariableTable: 2, VariableTableWithGeneric: 5 },
+  ObjectReference: { set: 9, ReferenceType: 1, GetValues: 2 },
+  StringReference: { set: 10, Value: 1 },
+  ThreadReference: { set: 11, Name: 1, Resume: 3, Status: 4, Frames: 6, FrameCount: 7 },
+  ArrayReference: { set: 13, Length: 1 },
+  EventRequest: { set: 15, Set: 1, Clear: 2 },
+  Event: { set: 64, Composite: 100 },
+};
+
+const EVENT_KIND = {
+  SINGLE_STEP: 1,
+  BREAKPOINT: 2,
+  CLASS_PREPARE: 8,
+  THREAD_START: 6,
+  THREAD_DEATH: 7,
+  VM_START: 90,
+  VM_DEATH: 99,
+};
+
+const MOD_KIND = { Count: 1, ClassMatch: 5, LocationOnly: 7, Step: 10 };
+const SUSPEND = { NONE: 0, EVENT_THREAD: 1, ALL: 2 };
+const STEP_DEPTH = { INTO: 0, OVER: 1, OUT: 2 };
+const STEP_SIZE = { MIN: 0, LINE: 1 };
+
+// JDWP value tags (first byte of a tagged value / type signature).
+const TAG = {
+  ARRAY: 91, // [
+  BYTE: 66, // B
+  CHAR: 67, // C
+  OBJECT: 76, // L
+  FLOAT: 70, // F
+  DOUBLE: 68, // D
+  INT: 73, // I
+  LONG: 74, // J
+  SHORT: 83, // S
+  VOID: 86, // V
+  BOOLEAN: 90, // Z
+  STRING: 115, // s
+  THREAD: 116, // t
+  THREAD_GROUP: 103, // g
+  CLASS_LOADER: 108, // l
+  CLASS_OBJECT: 99, // c
+};
+
+const HANDSHAKE = Buffer.from("JDWP-Handshake", "ascii");
+
+// ---------------------------------------------------------------------------
+// Buffer reader / writer (big-endian, ID-size aware)
+// ---------------------------------------------------------------------------
+
+class Writer {
+  constructor() {
+    this.parts = [];
+  }
+  u8(v) {
+    this.parts.push(Buffer.from([v & 0xff]));
+    return this;
+  }
+  u32(v) {
+    const b = Buffer.alloc(4);
+    b.writeUInt32BE(v >>> 0, 0);
+    this.parts.push(b);
+    return this;
+  }
+  id(value, size) {
+    const b = Buffer.alloc(size);
+    let v = BigInt.asUintN(size * 8, BigInt(value));
+    for (let i = size - 1; i >= 0; i--) {
+      b[i] = Number(v & 0xffn);
+      v >>= 8n;
+    }
+    this.parts.push(b);
+    return this;
+  }
+  long(value) {
+    return this.id(value, 8);
+  }
+  string(str) {
+    const s = Buffer.from(String(str), "utf8");
+    this.u32(s.length);
+    this.parts.push(s);
+    return this;
+  }
+  buffer() {
+    return Buffer.concat(this.parts);
+  }
+}
+
+class Reader {
+  constructor(buf, sizes) {
+    this.buf = buf;
+    this.off = 0;
+    this.sizes = sizes; // { field, method, object, refType, frame }
+  }
+  u8() {
+    return this.buf.readUInt8(this.off++);
+  }
+  i32() {
+    const v = this.buf.readInt32BE(this.off);
+    this.off += 4;
+    return v;
+  }
+  u32() {
+    const v = this.buf.readUInt32BE(this.off);
+    this.off += 4;
+    return v;
+  }
+  bigUint(size) {
+    let v = 0n;
+    for (let i = 0; i < size; i++) v = (v << 8n) | BigInt(this.buf[this.off++]);
+    return v;
+  }
+  bigInt(size) {
+    return BigInt.asIntN(size * 8, this.bigUint(size));
+  }
+  long() {
+    return this.bigInt(8);
+  }
+  objectId() {
+    return this.bigUint(this.sizes.object);
+  }
+  refTypeId() {
+    return this.bigUint(this.sizes.refType);
+  }
+  methodId() {
+    return this.bigUint(this.sizes.method);
+  }
+  fieldId() {
+    return this.bigUint(this.sizes.field);
+  }
+  frameId() {
+    return this.bigUint(this.sizes.frame);
+  }
+  string() {
+    const len = this.u32();
+    const s = this.buf.toString("utf8", this.off, this.off + len);
+    this.off += len;
+    return s;
+  }
+  // typeTag(1) + classId(refType) + methodId + index(8)
+  location() {
+    const tag = this.u8();
+    const classId = this.refTypeId();
+    const methodId = this.methodId();
+    const index = this.long();
+    return { tag, classId, methodId, index };
+  }
+  // A tagged value: tag byte then the value sized by its tag.
+  taggedValue() {
+    const tag = this.u8();
+    return this.untaggedValue(tag);
+  }
+  untaggedValue(tag) {
+    switch (tag) {
+      case TAG.BOOLEAN:
+        return { tag, value: this.u8() !== 0 };
+      case TAG.BYTE:
+        return { tag, value: this.buf.readInt8(this.off++) };
+      case TAG.CHAR: {
+        const v = this.buf.readUInt16BE(this.off);
+        this.off += 2;
+        return { tag, value: v };
+      }
+      case TAG.SHORT: {
+        const v = this.buf.readInt16BE(this.off);
+        this.off += 2;
+        return { tag, value: v };
+      }
+      case TAG.INT:
+        return { tag, value: this.i32() };
+      case TAG.FLOAT: {
+        const v = this.buf.readFloatBE(this.off);
+        this.off += 4;
+        return { tag, value: v };
+      }
+      case TAG.LONG:
+        return { tag, value: this.long() };
+      case TAG.DOUBLE: {
+        const v = this.buf.readDoubleBE(this.off);
+        this.off += 8;
+        return { tag, value: v };
+      }
+      case TAG.VOID:
+        return { tag, value: undefined };
+      default:
+        // All object-like tags (OBJECT/ARRAY/STRING/THREAD/...): an objectID.
+        return { tag, value: this.objectId() };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JdwpClient — the wire protocol
+// ---------------------------------------------------------------------------
+
+export class JdwpClient {
+  constructor() {
+    this.sock = null;
+    this.nextId = 1;
+    this.pending = new Map(); // id -> { resolve, reject }
+    this.rx = Buffer.alloc(0);
+    this.handshook = false;
+    this.sizes = { field: 8, method: 8, object: 8, refType: 8, frame: 8 };
+    this.onEvent = null; // (composite) => void
+    this.onClose = null; // (err?) => void
+    this._closed = false;
+  }
+
+  // A single connect attempt. Safe to retry on the same instance: per-attempt
+  // state is reset here, and a failure *before* the handshake completes only
+  // rejects the promise (it does not poison the client or emit onClose), so a
+  // caller can keep retrying while the debuggee's JDWP port comes up.
+  connect(host, port) {
+    return new Promise((resolve, reject) => {
+      const sock = new Socket();
+      this.sock = sock;
+      this.rx = Buffer.alloc(0);
+      this.handshook = false;
+      this.pending.clear();
+      let settled = false;
+      sock.setNoDelay(true);
+      sock.on("error", (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        } else if (this.handshook) {
+          this._fail(err);
+        }
+      });
+      sock.on("close", () => {
+        if (this.handshook) this._fail(null);
+      });
+      sock.on("connect", () => {
+        sock.write(HANDSHAKE);
+      });
+      sock.on("data", (chunk) => {
+        if (!this.handshook) {
+          this.rx = Buffer.concat([this.rx, chunk]);
+          if (this.rx.length < HANDSHAKE.length) return;
+          const hs = this.rx.subarray(0, HANDSHAKE.length);
+          if (!hs.equals(HANDSHAKE)) {
+            settled = true;
+            reject(new Error("JDWP handshake failed"));
+            sock.destroy();
+            return;
+          }
+          this.handshook = true;
+          this.rx = this.rx.subarray(HANDSHAKE.length);
+          settled = true;
+          resolve();
+          if (this.rx.length) this._drain();
+          return;
+        }
+        this.rx = Buffer.concat([this.rx, chunk]);
+        this._drain();
+      });
+      sock.connect(port, host);
+    });
+  }
+
+  _fail(err) {
+    if (this._closed) return;
+    this._closed = true;
+    for (const { reject } of this.pending.values()) reject(err || new Error("JDWP connection closed"));
+    this.pending.clear();
+    if (this.onClose) this.onClose(err);
+  }
+
+  _drain() {
+    // Each packet: length(4) id(4) flags(1) [errorCode(2) | set(1) cmd(1)] data...
+    while (this.rx.length >= 11) {
+      const len = this.rx.readUInt32BE(0);
+      if (this.rx.length < len) return;
+      const pkt = this.rx.subarray(0, len);
+      this.rx = this.rx.subarray(len);
+      const id = pkt.readUInt32BE(4);
+      const flags = pkt.readUInt8(8);
+      const body = pkt.subarray(11);
+      if (flags & 0x80) {
+        const errorCode = pkt.readUInt16BE(9);
+        const p = this.pending.get(id);
+        if (p) {
+          this.pending.delete(id);
+          if (errorCode !== 0) p.reject(new JdwpError(errorCode));
+          else p.resolve(new Reader(Buffer.from(body), this.sizes));
+        }
+      } else {
+        const set = pkt.readUInt8(9);
+        const cmd = pkt.readUInt8(10);
+        if (set === CMD.Event.set && cmd === CMD.Event.Composite) {
+          try {
+            const composite = this._parseComposite(new Reader(Buffer.from(body), this.sizes));
+            if (this.onEvent) this.onEvent(composite);
+          } catch {
+            /* ignore malformed event */
+          }
+        }
+      }
+    }
+  }
+
+  command(set, cmd, payload = Buffer.alloc(0)) {
+    return new Promise((resolve, reject) => {
+      if (this._closed || !this.sock) return reject(new Error("JDWP connection closed"));
+      const id = this.nextId++;
+      const len = 11 + payload.length;
+      const header = Buffer.alloc(11);
+      header.writeUInt32BE(len, 0);
+      header.writeUInt32BE(id, 4);
+      header.writeUInt8(0, 8);
+      header.writeUInt8(set, 9);
+      header.writeUInt8(cmd, 10);
+      this.pending.set(id, { resolve, reject });
+      this.sock.write(Buffer.concat([header, payload]));
+    });
+  }
+
+  close() {
+    this._closed = true;
+    try {
+      this.sock?.destroy();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  _parseComposite(r) {
+    const suspendPolicy = r.u8();
+    const count = r.i32();
+    const events = [];
+    for (let i = 0; i < count; i++) {
+      const eventKind = r.u8();
+      const ev = { eventKind };
+      switch (eventKind) {
+        case EVENT_KIND.VM_START:
+          ev.requestId = r.i32();
+          ev.thread = r.objectId();
+          break;
+        case EVENT_KIND.VM_DEATH:
+          ev.requestId = r.i32();
+          break;
+        case EVENT_KIND.BREAKPOINT:
+        case EVENT_KIND.SINGLE_STEP:
+          ev.requestId = r.i32();
+          ev.thread = r.objectId();
+          ev.location = r.location();
+          break;
+        case EVENT_KIND.CLASS_PREPARE:
+          ev.requestId = r.i32();
+          ev.thread = r.objectId();
+          ev.refTypeTag = r.u8();
+          ev.typeId = r.refTypeId();
+          ev.signature = r.string();
+          ev.status = r.i32();
+          break;
+        case EVENT_KIND.THREAD_START:
+        case EVENT_KIND.THREAD_DEATH:
+          ev.requestId = r.i32();
+          ev.thread = r.objectId();
+          break;
+        default:
+          // Unknown/unsupported kind: we can't know its size, so stop parsing
+          // the rest of this composite (only the parsed events are delivered).
+          return { suspendPolicy, events };
+      }
+      events.push(ev);
+    }
+    return { suspendPolicy, events };
+  }
+
+  // --- Typed command wrappers -------------------------------------------------
+
+  async idSizes() {
+    const r = await this.command(CMD.VirtualMachine.set, CMD.VirtualMachine.IDSizes);
+    this.sizes = {
+      field: r.i32(),
+      method: r.i32(),
+      object: r.i32(),
+      refType: r.i32(),
+      frame: r.i32(),
+    };
+    return this.sizes;
+  }
+
+  async version() {
+    const r = await this.command(CMD.VirtualMachine.set, CMD.VirtualMachine.Version);
+    const description = r.string();
+    const jdwpMajor = r.i32();
+    const jdwpMinor = r.i32();
+    const vmVersion = r.string();
+    const vmName = r.string();
+    return { description, jdwpMajor, jdwpMinor, vmVersion, vmName };
+  }
+
+  async classesBySignature(signature) {
+    const payload = new Writer().string(signature).buffer();
+    const r = await this.command(CMD.VirtualMachine.set, CMD.VirtualMachine.ClassesBySignature, payload);
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) {
+      const refTypeTag = r.u8();
+      const typeId = r.refTypeId();
+      const status = r.i32();
+      out.push({ refTypeTag, typeId, status });
+    }
+    return out;
+  }
+
+  async resumeVM() {
+    await this.command(CMD.VirtualMachine.set, CMD.VirtualMachine.Resume);
+  }
+  async suspendVM() {
+    await this.command(CMD.VirtualMachine.set, CMD.VirtualMachine.Suspend);
+  }
+
+  async signature(refTypeId) {
+    const payload = new Writer().id(refTypeId, this.sizes.refType).buffer();
+    const r = await this.command(CMD.ReferenceType.set, CMD.ReferenceType.Signature, payload);
+    return r.string();
+  }
+
+  async superclass(classId) {
+    const payload = new Writer().id(classId, this.sizes.refType).buffer();
+    const r = await this.command(CMD.ClassType.set, CMD.ClassType.Superclass, payload);
+    return r.refTypeId(); // 0 for java/lang/Object
+  }
+
+  async methods(refTypeId) {
+    const payload = new Writer().id(refTypeId, this.sizes.refType).buffer();
+    const r = await this.command(CMD.ReferenceType.set, CMD.ReferenceType.MethodsWithGeneric, payload);
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) {
+      const methodId = r.methodId();
+      const name = r.string();
+      const sig = r.string();
+      const generic = r.string();
+      const modBits = r.i32();
+      out.push({ methodId, name, sig, generic, modBits });
+    }
+    return out;
+  }
+
+  async fields(refTypeId) {
+    const payload = new Writer().id(refTypeId, this.sizes.refType).buffer();
+    const r = await this.command(CMD.ReferenceType.set, CMD.ReferenceType.FieldsWithGeneric, payload);
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) {
+      const fieldId = r.fieldId();
+      const name = r.string();
+      const sig = r.string();
+      const generic = r.string();
+      const modBits = r.i32();
+      out.push({ fieldId, name, sig, generic, modBits });
+    }
+    return out;
+  }
+
+  async lineTable(refTypeId, methodId) {
+    const payload = new Writer().id(refTypeId, this.sizes.refType).id(methodId, this.sizes.method).buffer();
+    const r = await this.command(CMD.Method.set, CMD.Method.LineTable, payload);
+    const start = r.long();
+    const end = r.long();
+    const count = r.i32();
+    const lines = [];
+    for (let i = 0; i < count; i++) {
+      const lineCodeIndex = r.long();
+      const lineNumber = r.i32();
+      lines.push({ lineCodeIndex, lineNumber });
+    }
+    return { start, end, lines };
+  }
+
+  async variableTable(refTypeId, methodId) {
+    const payload = new Writer().id(refTypeId, this.sizes.refType).id(methodId, this.sizes.method).buffer();
+    let r;
+    try {
+      r = await this.command(CMD.Method.set, CMD.Method.VariableTableWithGeneric, payload);
+    } catch {
+      return null; // no local variable table (compiled without -g)
+    }
+    const argCnt = r.i32();
+    const count = r.i32();
+    const slots = [];
+    for (let i = 0; i < count; i++) {
+      const codeIndex = r.long();
+      const name = r.string();
+      const sig = r.string();
+      const generic = r.string();
+      const length = r.i32();
+      const slot = r.i32();
+      slots.push({ codeIndex, name, sig, generic, length, slot });
+    }
+    return { argCnt, slots };
+  }
+
+  async sourceFile(refTypeId) {
+    try {
+      const payload = new Writer().id(refTypeId, this.sizes.refType).buffer();
+      const r = await this.command(CMD.ReferenceType.set, CMD.ReferenceType.SourceFile, payload);
+      return r.string();
+    } catch {
+      return null;
+    }
+  }
+
+  async threadName(threadId) {
+    const payload = new Writer().id(threadId, this.sizes.object).buffer();
+    const r = await this.command(CMD.ThreadReference.set, CMD.ThreadReference.Name, payload);
+    return r.string();
+  }
+
+  async frames(threadId, start, length) {
+    const payload = new Writer()
+      .id(threadId, this.sizes.object)
+      .u32(start)
+      .u32(length >>> 0)
+      .buffer();
+    const r = await this.command(CMD.ThreadReference.set, CMD.ThreadReference.Frames, payload);
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) {
+      const frameId = r.frameId();
+      const location = r.location();
+      out.push({ frameId, location });
+    }
+    return out;
+  }
+
+  async frameCount(threadId) {
+    const payload = new Writer().id(threadId, this.sizes.object).buffer();
+    const r = await this.command(CMD.ThreadReference.set, CMD.ThreadReference.FrameCount, payload);
+    return r.i32();
+  }
+
+  async resumeThread(threadId) {
+    const payload = new Writer().id(threadId, this.sizes.object).buffer();
+    await this.command(CMD.ThreadReference.set, CMD.ThreadReference.Resume, payload);
+  }
+
+  // StackFrame.GetValues — slots is [{ slot, tag }].
+  async getStackValues(threadId, frameId, slots) {
+    const w = new Writer().id(threadId, this.sizes.object).id(frameId, this.sizes.frame).u32(slots.length);
+    for (const s of slots) w.u32(s.slot).u8(s.tag);
+    const r = await this.command(16 /* StackFrame */, 1 /* GetValues */, w.buffer());
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) out.push(r.taggedValue());
+    return out;
+  }
+
+  async thisObject(threadId, frameId) {
+    const w = new Writer().id(threadId, this.sizes.object).id(frameId, this.sizes.frame);
+    const r = await this.command(16 /* StackFrame */, 3 /* ThisObject */, w.buffer());
+    return r.taggedValue();
+  }
+
+  async objectReferenceType(objectId) {
+    const payload = new Writer().id(objectId, this.sizes.object).buffer();
+    const r = await this.command(CMD.ObjectReference.set, CMD.ObjectReference.ReferenceType, payload);
+    const refTypeTag = r.u8();
+    const typeId = r.refTypeId();
+    return { refTypeTag, typeId };
+  }
+
+  // ObjectReference.GetValues — fieldIds is an array of BigInt field IDs.
+  async objectGetValues(objectId, fieldIds) {
+    const w = new Writer().id(objectId, this.sizes.object).u32(fieldIds.length);
+    for (const f of fieldIds) w.id(f, this.sizes.field);
+    const r = await this.command(CMD.ObjectReference.set, CMD.ObjectReference.GetValues, w.buffer());
+    const count = r.i32();
+    const out = [];
+    for (let i = 0; i < count; i++) out.push(r.taggedValue());
+    return out;
+  }
+
+  async stringValue(stringId) {
+    const payload = new Writer().id(stringId, this.sizes.object).buffer();
+    const r = await this.command(CMD.StringReference.set, CMD.StringReference.Value, payload);
+    return r.string();
+  }
+
+  async arrayLength(arrayId) {
+    const payload = new Writer().id(arrayId, this.sizes.object).buffer();
+    const r = await this.command(CMD.ArrayReference.set, CMD.ArrayReference.Length, payload);
+    return r.i32();
+  }
+
+  // EventRequest.Set for a class-prepare filter. Returns the requestId.
+  async setClassPrepare(classPattern, suspendPolicy = SUSPEND.EVENT_THREAD) {
+    const w = new Writer()
+      .u8(EVENT_KIND.CLASS_PREPARE)
+      .u8(suspendPolicy)
+      .u32(1)
+      .u8(MOD_KIND.ClassMatch)
+      .string(classPattern);
+    const r = await this.command(CMD.EventRequest.set, CMD.EventRequest.Set, w.buffer());
+    return r.i32();
+  }
+
+  // EventRequest.Set for a line breakpoint at a resolved location.
+  async setBreakpoint(location, suspendPolicy = SUSPEND.ALL) {
+    const w = new Writer()
+      .u8(EVENT_KIND.BREAKPOINT)
+      .u8(suspendPolicy)
+      .u32(1)
+      .u8(MOD_KIND.LocationOnly)
+      .u8(location.tag)
+      .id(location.classId, this.sizes.refType)
+      .id(location.methodId, this.sizes.method)
+      .long(location.index);
+    const r = await this.command(CMD.EventRequest.set, CMD.EventRequest.Set, w.buffer());
+    return r.i32();
+  }
+
+  // EventRequest.Set for a single step on one thread.
+  async setStep(threadId, depth, size = STEP_SIZE.LINE, suspendPolicy = SUSPEND.ALL) {
+    const w = new Writer()
+      .u8(EVENT_KIND.SINGLE_STEP)
+      .u8(suspendPolicy)
+      .u32(1)
+      .u8(MOD_KIND.Step)
+      .id(threadId, this.sizes.object)
+      .u32(size)
+      .u32(depth);
+    const r = await this.command(CMD.EventRequest.set, CMD.EventRequest.Set, w.buffer());
+    return r.i32();
+  }
+
+  async clearEvent(eventKind, requestId) {
+    const w = new Writer().u8(eventKind).u32(requestId >>> 0);
+    await this.command(CMD.EventRequest.set, CMD.EventRequest.Clear, w.buffer());
+  }
+}
+
+export class JdwpError extends Error {
+  constructor(code) {
+    super(`JDWP error ${code}${JDWP_ERRORS[code] ? " (" + JDWP_ERRORS[code] + ")" : ""}`);
+    this.code = code;
+  }
+}
+
+const JDWP_ERRORS = {
+  10: "INVALID_THREAD",
+  13: "THREAD_NOT_SUSPENDED",
+  20: "INVALID_OBJECT",
+  21: "INVALID_CLASS",
+  23: "INVALID_METHODID",
+  24: "INVALID_LOCATION",
+  30: "INVALID_FRAMEID",
+  31: "NO_MORE_FRAMES",
+  35: "ABSENT_INFORMATION",
+  99: "NOT_IMPLEMENTED",
+  101: "VM_DEAD",
+};
+
+// ---------------------------------------------------------------------------
+// Signature helpers
+// ---------------------------------------------------------------------------
+
+// JNI class signature ("Lcom/example/App;") <-> binary name ("com.example.App").
+function classNameToSignature(name) {
+  return "L" + String(name).replace(/\./g, "/") + ";";
+}
+function signatureToClassName(sig) {
+  const m = /^L(.+);$/.exec(sig);
+  return m ? m[1].replace(/\//g, ".") : sig;
+}
+
+// Human-readable type from a field/variable JNI signature (best-effort).
+function typeFromSignature(sig) {
+  if (!sig) return "";
+  let dims = 0;
+  let s = sig;
+  while (s[0] === "[") {
+    dims++;
+    s = s.slice(1);
+  }
+  const base =
+    {
+      B: "byte",
+      C: "char",
+      D: "double",
+      F: "float",
+      I: "int",
+      J: "long",
+      S: "short",
+      Z: "boolean",
+      V: "void",
+    }[s] || (s[0] === "L" ? signatureToClassName(s).replace(/^java\.lang\./, "") : s);
+  return base + "[]".repeat(dims);
+}
+
+// The value tag implied by a variable/field signature's first char.
+function tagFromSignature(sig) {
+  const c = sig[0];
+  if (c === "[") return TAG.ARRAY;
+  if (c === "L") return TAG.OBJECT;
+  return c.charCodeAt(0); // B C D F I J S Z map straight to their tag bytes
+}
+
+// ---------------------------------------------------------------------------
+// DebugSession — orchestration on top of JdwpClient
+// ---------------------------------------------------------------------------
+
+export class DebugSession {
+  constructor({ log, onPaused, onResumed, onClosed, onBreakpoints } = {}) {
+    this.client = new JdwpClient();
+    this.log = log || (() => {});
+    this.onPaused = onPaused || (() => {});
+    this.onResumed = onResumed || (() => {});
+    this.onClosed = onClosed || (() => {});
+    this.onBreakpoints = onBreakpoints || (() => {});
+
+    this.active = false;
+    this.paused = false;
+    this.stoppedReason = null; // "breakpoint" | "step" | "pause"
+    this.thread = null; // BigInt threadId of the stopped thread
+    this.threadNameStr = null;
+    this.frameCache = []; // resolved frames for the current stop
+    this.bpSeq = 1;
+    this.breakpoints = []; // { id, className, line, verified, error, requestId, classPrepareId, location }
+    this._sigCache = new Map(); // refTypeId(string) -> className
+    this._methodsCache = new Map(); // refTypeId(string) -> methods[]
+    this._stepRequest = null; // active step requestId
+  }
+
+  // Connect with retry: the debuggee's JDWP port only opens once the agent has
+  // initialized (early in startup), so we poll until the socket accepts us (or we
+  // run out of attempts). `signal` is an optional { aborted } flag the caller can
+  // flip to stop early (e.g. if the launch is cancelled).
+  async connect(host, port, { retries = 200, delayMs = 150, signal = null } = {}) {
+    this.client.onEvent = (c) => this._onEvent(c).catch((e) => this.log(`event error: ${e.message}`));
+    this.client.onClose = () => this._onClose();
+    // Allow reuse after a previous VM exited: clear the stale stop/close state and
+    // each breakpoint's per-session install handles so they re-arm on the new VM.
+    this._closedEmitted = false;
+    this.paused = false;
+    this.frameCache = [];
+    for (const bp of this.breakpoints) {
+      bp.requestId = null;
+      bp.classPrepareId = null;
+      bp.verified = false;
+      bp.error = null;
+    }
+    let lastErr = null;
+    for (let i = 0; i < retries; i++) {
+      if (signal && signal.aborted) throw new Error("debug attach cancelled");
+      try {
+        await this.client.connect(host, port);
+        lastErr = null;
+        break;
+      } catch (e) {
+        lastErr = e;
+        await new Promise((r) => setTimeout(r, delayMs));
+      }
+    }
+    if (lastErr) throw new Error(`could not connect to the debuggee on ${host}:${port}: ${lastErr.message}`);
+    await this.client.idSizes();
+    this.active = true;
+    const v = await this.client.version().catch(() => null);
+    if (v) this.log(`connected to ${v.vmName} ${v.vmVersion} (JDWP ${v.jdwpMajor}.${v.jdwpMinor})`);
+    // Re-resolve any breakpoints added before connect, then make sure the VM is
+    // running (a suspend=y launch starts suspended at VM_START).
+    for (const bp of this.breakpoints) await this._installBreakpoint(bp).catch(() => {});
+    await this.client.resumeVM().catch(() => {});
+    return v;
+  }
+
+  _onClose() {
+    if (!this.active && this._closedEmitted) return;
+    this.active = false;
+    this.paused = false;
+    this._closedEmitted = true;
+    this.onClosed();
+  }
+
+  dispose() {
+    try {
+      this.client.close();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // --- Events ----------------------------------------------------------------
+
+  async _onEvent(composite) {
+    for (const ev of composite.events) {
+      if (ev.eventKind === EVENT_KIND.CLASS_PREPARE) {
+        await this._onClassPrepare(ev);
+      } else if (ev.eventKind === EVENT_KIND.BREAKPOINT) {
+        await this._onStop(ev, "breakpoint");
+      } else if (ev.eventKind === EVENT_KIND.SINGLE_STEP) {
+        if (this._stepRequest != null) {
+          await this.client.clearEvent(EVENT_KIND.SINGLE_STEP, this._stepRequest).catch(() => {});
+          this._stepRequest = null;
+        }
+        await this._onStop(ev, "step");
+      } else if (ev.eventKind === EVENT_KIND.VM_DEATH) {
+        this.log("the debuggee VM exited");
+        this._onClose();
+      }
+    }
+  }
+
+  // A class we have a pending breakpoint for just loaded: resolve + arm it, then
+  // let the (briefly EVENT_THREAD-suspended) loading thread continue.
+  async _onClassPrepare(ev) {
+    const className = signatureToClassName(ev.signature);
+    let armed = false;
+    for (const bp of this.breakpoints) {
+      if (bp.verified) continue;
+      if (bp.className === className || className.startsWith(bp.className + "$")) {
+        await this._armBreakpointInClass(bp, ev.typeId).catch((e) => {
+          bp.error = e.message;
+        });
+        if (bp.verified) armed = true;
+      }
+    }
+    if (armed) this.onBreakpoints();
+    // Resume just the thread the class-prepare suspended (EVENT_THREAD policy).
+    await this.client.resumeThread(ev.thread).catch(() => {});
+  }
+
+  async _onStop(ev, reason) {
+    this.paused = true;
+    this.stoppedReason = reason;
+    this.thread = ev.thread;
+    this.threadNameStr = await this.client.threadName(ev.thread).catch(() => "thread");
+    this.frameCache = await this._resolveStack(ev.thread).catch(() => []);
+    const top = this.frameCache[0];
+    this.log(
+      `paused on ${reason}` +
+        (top ? ` at ${top.className}.${top.methodName}` + (top.line > 0 ? `:${top.line}` : "") : ""),
+    );
+    this.onPaused(this.snapshot());
+  }
+
+  // --- Breakpoints -----------------------------------------------------------
+
+  // Register a breakpoint. Resolves immediately for already-loaded classes and
+  // always installs a CLASS_PREPARE filter so a not-yet-loaded (or reloaded)
+  // class arms it on load. Returns the breakpoint record.
+  async addBreakpoint(className, line) {
+    const existing = this.breakpoints.find((b) => b.className === className && b.line === line);
+    if (existing) return existing;
+    const bp = {
+      id: this.bpSeq++,
+      className,
+      line,
+      verified: false,
+      error: null,
+      requestId: null,
+      classPrepareId: null,
+    };
+    this.breakpoints.push(bp);
+    if (this.active) await this._installBreakpoint(bp).catch((e) => (bp.error = e.message));
+    this.onBreakpoints();
+    return bp;
+  }
+
+  async _installBreakpoint(bp) {
+    // Catch the class loading in the future (covers reload + not-yet-loaded).
+    if (bp.classPrepareId == null) {
+      bp.classPrepareId = await this.client.setClassPrepare(bp.className).catch(() => null);
+      // Also watch nested types (Outer$Inner) so a breakpoint inside a lambda /
+      // inner class still arms.
+      await this.client.setClassPrepare(bp.className + "$*").catch(() => {});
+    }
+    // Arm now if the class is already loaded.
+    const loaded = await this.client.classesBySignature(classNameToSignature(bp.className)).catch(() => []);
+    for (const c of loaded) {
+      await this._armBreakpointInClass(bp, c.typeId).catch((e) => (bp.error = e.message));
+      if (bp.verified) break;
+    }
+  }
+
+  async _armBreakpointInClass(bp, refTypeId) {
+    const methods = await this._methodsOf(refTypeId);
+    for (const m of methods) {
+      const lt = await this.client.lineTable(refTypeId, m.methodId).catch(() => null);
+      if (!lt || !lt.lines.length) continue;
+      const match = lt.lines.find((l) => l.lineNumber === bp.line);
+      if (!match) continue;
+      const location = { tag: 1 /* CLASS */, classId: refTypeId, methodId: m.methodId, index: match.lineCodeIndex };
+      bp.requestId = await this.client.setBreakpoint(location);
+      bp.location = location;
+      bp.verified = true;
+      bp.error = null;
+      this.log(`breakpoint #${bp.id} armed at ${bp.className}:${bp.line}`);
+      return;
+    }
+  }
+
+  async removeBreakpoint(id) {
+    const idx = this.breakpoints.findIndex((b) => b.id === id);
+    if (idx < 0) return false;
+    const bp = this.breakpoints[idx];
+    if (this.active && bp.requestId != null) {
+      await this.client.clearEvent(EVENT_KIND.BREAKPOINT, bp.requestId).catch(() => {});
+    }
+    if (this.active && bp.classPrepareId != null) {
+      await this.client.clearEvent(EVENT_KIND.CLASS_PREPARE, bp.classPrepareId).catch(() => {});
+    }
+    this.breakpoints.splice(idx, 1);
+    this.onBreakpoints();
+    return true;
+  }
+
+  listBreakpoints() {
+    return this.breakpoints.map((b) => ({
+      id: b.id,
+      class: b.className,
+      line: b.line,
+      verified: b.verified,
+      error: b.error || null,
+    }));
+  }
+
+  // --- Execution control -----------------------------------------------------
+
+  async resume() {
+    if (!this.active) return { ok: false, error: "No debug session." };
+    this.paused = false;
+    this.frameCache = [];
+    await this.client.resumeVM();
+    this.onResumed();
+    return { ok: true };
+  }
+
+  async step(depth) {
+    if (!this.active) return { ok: false, error: "No debug session." };
+    if (!this.paused || this.thread == null) return { ok: false, error: "The app is not paused." };
+    const d = depth === "into" ? STEP_DEPTH.INTO : depth === "out" ? STEP_DEPTH.OUT : STEP_DEPTH.OVER;
+    this._stepRequest = await this.client.setStep(this.thread, d);
+    this.paused = false;
+    this.frameCache = [];
+    await this.client.resumeVM();
+    this.onResumed();
+    return { ok: true, depth: depth || "over" };
+  }
+
+  // Suspend the running VM to inspect it (the "pause" button).
+  async pause() {
+    if (!this.active) return { ok: false, error: "No debug session." };
+    if (this.paused) return { ok: true, alreadyPaused: true };
+    await this.client.suspendVM();
+    // Pick a thread with frames to present (prefer "main").
+    const ev = await this._pickSuspendedThread();
+    if (!ev) {
+      await this.client.resumeVM().catch(() => {});
+      return { ok: false, error: "Could not find a thread to inspect." };
+    }
+    await this._onStop({ thread: ev }, "pause");
+    return { ok: true };
+  }
+
+  async _pickSuspendedThread() {
+    // ThreadReference list isn't fetched here; rely on the last known thread, or
+    // fall back to scanning all threads via VM.AllThreads.
+    const r = await this.client.command(CMD.VirtualMachine.set, 4 /* AllThreads */).catch(() => null);
+    if (!r) return this.thread;
+    const count = r.i32();
+    const threads = [];
+    for (let i = 0; i < count; i++) threads.push(r.objectId());
+    let best = null;
+    for (const t of threads) {
+      const n = await this.client.threadName(t).catch(() => "");
+      const fc = await this.client.frameCount(t).catch(() => 0);
+      if (fc > 0 && (best === null || n === "main")) best = t;
+      if (n === "main" && fc > 0) return t;
+    }
+    return best || this.thread;
+  }
+
+  // --- Stack / locals / evaluate --------------------------------------------
+
+  async _resolveStack(threadId, max = 50) {
+    // Clamp to the thread's actual depth: some JVMs reject a Frames request whose
+    // length exceeds the number of frames currently on the stack.
+    const total = await this.client.frameCount(threadId).catch(() => 0);
+    const n = Math.min(max, total);
+    if (n <= 0) return [];
+    const frames = await this.client.frames(threadId, 0, n);
+    const out = [];
+    for (let i = 0; i < frames.length; i++) {
+      const f = frames[i];
+      const className = await this._classNameOf(f.location.classId);
+      const { name: methodName, line } = await this._methodAndLine(f.location);
+      out.push({
+        index: i,
+        frameId: f.frameId,
+        className,
+        methodName,
+        line,
+        location: f.location,
+        native: f.location.index === -1n,
+      });
+    }
+    return out;
+  }
+
+  async stack() {
+    if (!this.paused) return { paused: false, frames: [] };
+    return { paused: true, thread: this.threadNameStr, frames: this.frameCache.map((f) => this._publicFrame(f)) };
+  }
+
+  _publicFrame(f) {
+    return { index: f.index, class: f.className, method: f.methodName, line: f.line, native: f.native };
+  }
+
+  async locals(frameIndex = 0) {
+    if (!this.paused) return { ok: false, error: "The app is not paused." };
+    const frame = this.frameCache[frameIndex];
+    if (!frame) return { ok: false, error: `No frame at index ${frameIndex}.` };
+    const out = { ok: true, frame: this._publicFrame(frame), variables: [] };
+
+    // `this` (instance methods only).
+    const self = await this.client.thisObject(this.thread, frame.frameId).catch(() => null);
+    if (self && self.value && self.value !== 0n) {
+      out.variables.push({ name: "this", value: await this._format(self), type: await this._typeOfObject(self.value) });
+    }
+
+    const vt = await this.client.variableTable(frame.location.classId, frame.location.methodId).catch(() => null);
+    if (vt && vt.slots.length) {
+      const idx = frame.location.index;
+      const visible = vt.slots.filter((s) => idx >= s.codeIndex && idx < s.codeIndex + BigInt(s.length));
+      const slots = visible.map((s) => ({ slot: s.slot, tag: tagFromSignature(s.sig) }));
+      let values = [];
+      if (slots.length) values = await this.client.getStackValues(this.thread, frame.frameId, slots).catch(() => []);
+      for (let i = 0; i < visible.length; i++) {
+        const s = visible[i];
+        if (s.name === "this") continue;
+        out.variables.push({
+          name: s.name,
+          value: await this._format(values[i]),
+          type: typeFromSignature(s.sig),
+        });
+      }
+    } else {
+      out.note = "No local variable table (compile with -g / debug info for locals).";
+    }
+    return out;
+  }
+
+  // Evaluate a simple variable / dotted field path (e.g. "user.name") against the
+  // selected frame. Not a Java expression compiler — it resolves a local (or
+  // `this`) then walks instance fields.
+  async evaluate(expression, frameIndex = 0) {
+    if (!this.paused) return { ok: false, error: "The app is not paused." };
+    const frame = this.frameCache[frameIndex];
+    if (!frame) return { ok: false, error: `No frame at index ${frameIndex}.` };
+    const path = String(expression || "")
+      .trim()
+      .split(".")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (!path.length) return { ok: false, error: "Empty expression." };
+
+    let current = await this._resolveRoot(frame, path[0]);
+    if (!current) return { ok: false, error: `Unknown variable '${path[0]}'.` };
+    for (let i = 1; i < path.length; i++) {
+      if (!current.value || current.tag === undefined || isPrimitiveTag(current.tag)) {
+        return { ok: false, error: `'${path.slice(0, i).join(".")}' is not an object.` };
+      }
+      const next = await this._fieldValue(current.value, path[i]);
+      if (!next) return { ok: false, error: `No field '${path[i]}' on '${path.slice(0, i).join(".")}'.` };
+      current = next;
+    }
+    return {
+      ok: true,
+      expression: path.join("."),
+      value: await this._format(current),
+      type:
+        current.value && !isPrimitiveTag(current.tag)
+          ? await this._typeOfObject(current.value)
+          : typeFromTag(current.tag),
+    };
+  }
+
+  async _resolveRoot(frame, name) {
+    if (name === "this") {
+      const self = await this.client.thisObject(this.thread, frame.frameId).catch(() => null);
+      return self && self.value ? self : null;
+    }
+    const vt = await this.client.variableTable(frame.location.classId, frame.location.methodId).catch(() => null);
+    if (vt) {
+      const idx = frame.location.index;
+      const match = vt.slots.find((s) => s.name === name && idx >= s.codeIndex && idx < s.codeIndex + BigInt(s.length));
+      if (match) {
+        const values = await this.client.getStackValues(this.thread, frame.frameId, [
+          { slot: match.slot, tag: tagFromSignature(match.sig) },
+        ]);
+        return values[0];
+      }
+    }
+    // Fall back to a field on `this`.
+    const self = await this.client.thisObject(this.thread, frame.frameId).catch(() => null);
+    if (self && self.value && self.value !== 0n) return this._fieldValue(self.value, name);
+    return null;
+  }
+
+  async _fieldValue(objectId, fieldName) {
+    // Walk the type + superclasses for the named field.
+    let refTypeId = (await this.client.objectReferenceType(objectId).catch(() => null))?.typeId;
+    while (refTypeId && refTypeId !== 0n) {
+      const fields = await this.client.fields(refTypeId).catch(() => []);
+      const f = fields.find((x) => x.name === fieldName);
+      if (f) {
+        const values = await this.client.objectGetValues(objectId, [f.fieldId]).catch(() => []);
+        return values[0] || null;
+      }
+      refTypeId = await this.client.superclass(refTypeId).catch(() => 0n);
+    }
+    return null;
+  }
+
+  // --- Value formatting ------------------------------------------------------
+
+  async _format(v) {
+    if (!v) return "<unknown>";
+    const { tag, value } = v;
+    switch (tag) {
+      case TAG.BOOLEAN:
+        return String(value);
+      case TAG.BYTE:
+      case TAG.SHORT:
+      case TAG.INT:
+        return String(value);
+      case TAG.LONG:
+        return value.toString();
+      case TAG.FLOAT:
+      case TAG.DOUBLE:
+        return String(value);
+      case TAG.CHAR:
+        return `'${String.fromCharCode(Number(value))}' (${value})`;
+      case TAG.VOID:
+        return "void";
+      case TAG.STRING: {
+        if (!value || value === 0n) return "null";
+        const s = await this.client.stringValue(value).catch(() => null);
+        return s == null ? `String(id=${value})` : JSON.stringify(s);
+      }
+      case TAG.ARRAY: {
+        if (!value || value === 0n) return "null";
+        const len = await this.client.arrayLength(value).catch(() => null);
+        const t = await this._typeOfObject(value);
+        return len == null ? `${t}` : `${t.replace(/\[\]$/, "")}[${len}]`;
+      }
+      default: {
+        if (!value || value === 0n) return "null";
+        // A non-array object: show its type + a stable id. Strings sometimes come
+        // back tagged OBJECT, so special-case java.lang.String.
+        const type = await this._typeOfObject(value);
+        if (type === "String") {
+          const s = await this.client.stringValue(value).catch(() => null);
+          if (s != null) return JSON.stringify(s);
+        }
+        return `${type} (id=${value})`;
+      }
+    }
+  }
+
+  async _typeOfObject(objectId) {
+    if (!objectId || objectId === 0n) return "null";
+    const rt = await this.client.objectReferenceType(objectId).catch(() => null);
+    if (!rt) return "Object";
+    return (await this._classNameOf(rt.typeId)).replace(/^java\.lang\./, "");
+  }
+
+  // --- Caches / helpers ------------------------------------------------------
+
+  async _classNameOf(refTypeId) {
+    const key = refTypeId.toString();
+    if (this._sigCache.has(key)) return this._sigCache.get(key);
+    const sig = await this.client.signature(refTypeId).catch(() => null);
+    const name = sig ? signatureToClassName(sig) : `type#${key}`;
+    this._sigCache.set(key, name);
+    return name;
+  }
+
+  async _methodsOf(refTypeId) {
+    const key = refTypeId.toString();
+    if (this._methodsCache.has(key)) return this._methodsCache.get(key);
+    const methods = await this.client.methods(refTypeId);
+    this._methodsCache.set(key, methods);
+    return methods;
+  }
+
+  async _methodAndLine(location) {
+    if (location.index === -1n) return { name: "(native)", line: -1 };
+    const methods = await this._methodsOf(location.classId).catch(() => []);
+    const m = methods.find((x) => x.methodId === location.methodId);
+    const name = m ? m.name : "?";
+    let line = -1;
+    const lt = await this.client.lineTable(location.classId, location.methodId).catch(() => null);
+    if (lt && lt.lines.length) {
+      let best = null;
+      for (const l of lt.lines) {
+        if (l.lineCodeIndex <= location.index && (best === null || l.lineCodeIndex > best.lineCodeIndex)) best = l;
+      }
+      if (best) line = best.lineNumber;
+    }
+    return { name, line };
+  }
+
+  // --- Snapshot --------------------------------------------------------------
+
+  snapshot() {
+    const top = this.frameCache[0];
+    return {
+      active: this.active,
+      paused: this.paused,
+      stoppedReason: this.stoppedReason,
+      thread: this.threadNameStr,
+      location: top ? { class: top.className, method: top.methodName, line: top.line } : null,
+      frames: this.frameCache.map((f) => this._publicFrame(f)),
+      breakpoints: this.listBreakpoints(),
+    };
+  }
+}
+
+function isPrimitiveTag(tag) {
+  return (
+    tag === TAG.BOOLEAN ||
+    tag === TAG.BYTE ||
+    tag === TAG.CHAR ||
+    tag === TAG.SHORT ||
+    tag === TAG.INT ||
+    tag === TAG.LONG ||
+    tag === TAG.FLOAT ||
+    tag === TAG.DOUBLE ||
+    tag === TAG.VOID
+  );
+}
+
+function typeFromTag(tag) {
+  const map = {
+    [TAG.BOOLEAN]: "boolean",
+    [TAG.BYTE]: "byte",
+    [TAG.CHAR]: "char",
+    [TAG.SHORT]: "short",
+    [TAG.INT]: "int",
+    [TAG.LONG]: "long",
+    [TAG.FLOAT]: "float",
+    [TAG.DOUBLE]: "double",
+    [TAG.STRING]: "String",
+  };
+  return map[tag] || "Object";
+}
+
+export const _internals = { classNameToSignature, signatureToClassName, typeFromSignature, tagFromSignature, TAG };

--- a/public/app.js
+++ b/public/app.js
@@ -7,7 +7,14 @@ const buildConsoleEl = document.getElementById("build-console");
 const packageConsoleEl = document.getElementById("package-console");
 const testConsoleEl = document.getElementById("test-console");
 const runConsoleEl = document.getElementById("run-console");
-const consoles = { build: buildConsoleEl, package: packageConsoleEl, test: testConsoleEl, run: runConsoleEl };
+const debugConsoleEl = document.getElementById("debug-console");
+const consoles = {
+  build: buildConsoleEl,
+  package: packageConsoleEl,
+  test: testConsoleEl,
+  run: runConsoleEl,
+  debug: debugConsoleEl,
+};
 // Which main tab is active, used as the fallback target for op-less lines.
 let activeTab = "build";
 // Last full status snapshot ({ build, test, package, run, reload }). The
@@ -69,6 +76,30 @@ const btnFix = document.getElementById("btn-fix");
 const btnStopMaven = document.getElementById("btn-stop-maven");
 const btnStopRun = document.getElementById("btn-stop-run");
 const btnRun = document.getElementById("btn-run");
+const btnDebug = document.getElementById("btn-debug");
+const btnStopDebug = document.getElementById("btn-stop-debug");
+// Debug-tab controls + state.
+const dbgStateEl = document.getElementById("dbg-state");
+const dbgLocEl = document.getElementById("dbg-loc");
+const dbgSuspendInput = document.getElementById("in-dbg-suspend");
+const btnDbgContinue = document.getElementById("btn-dbg-continue");
+const btnDbgStepOver = document.getElementById("btn-dbg-stepover");
+const btnDbgStepInto = document.getElementById("btn-dbg-stepinto");
+const btnDbgStepOut = document.getElementById("btn-dbg-stepout");
+const btnDbgPause = document.getElementById("btn-dbg-pause");
+const bpClassInput = document.getElementById("in-bp-class");
+const bpLineInput = document.getElementById("in-bp-line");
+const btnBpAdd = document.getElementById("btn-bp-add");
+const bpListEl = document.getElementById("bp-list");
+const dbgStackEl = document.getElementById("dbg-stack");
+const dbgVarsEl = document.getElementById("dbg-vars");
+const dbgFrameLabel = document.getElementById("dbg-frame-label");
+const dbgEvalInput = document.getElementById("in-dbg-eval");
+const btnDbgEval = document.getElementById("btn-dbg-eval");
+const dbgEvalResult = document.getElementById("dbg-eval-result");
+const tabDebugBadge = document.getElementById("tab-debug-badge");
+let debugSnap = null;
+let dbgSelectedFrame = 0;
 // Running spinners on each trigger button and tab. The Test tab keeps its
 // badge/progress feedback too; the spinner shows only while the run is busy.
 const btnSpin = {
@@ -76,12 +107,14 @@ const btnSpin = {
   test: document.querySelector("#btn-test .btn-spin"),
   package: document.querySelector("#btn-package .btn-spin"),
   run: document.querySelector("#btn-run .btn-spin"),
+  debug: document.querySelector("#btn-debug .btn-spin"),
 };
 const tabSpin = {
   build: document.querySelector('.tab[data-tab="build"] .tab-spin'),
   test: document.querySelector('.tab[data-tab="test"] .tab-spin'),
   package: document.querySelector('.tab[data-tab="package"] .tab-spin'),
   run: document.querySelector('.tab[data-tab="run"] .tab-spin'),
+  debug: document.querySelector('.tab[data-tab="debug"] .tab-spin'),
 };
 // Build/Test/Package share one serialized Maven lane, so while one runs the
 // others are greyed out until it's stopped.
@@ -98,6 +131,7 @@ const triggerButton = {
   test: mvnButtons.test,
   package: mvnButtons.package,
   run: btnRun,
+  debug: btnDebug,
 };
 const capsEl = document.getElementById("caps");
 const metricsSrc = document.getElementById("metrics-src");
@@ -182,6 +216,7 @@ function showTab(name) {
   document.getElementById("package-console").classList.toggle("active", name === "package");
   document.getElementById("test-pane").classList.toggle("active", name === "test");
   document.getElementById("run-pane").classList.toggle("active", name === "run");
+  document.getElementById("debug-pane").classList.toggle("active", name === "debug");
   // The header (phase/command/exit/fix) follows the active tab, so
   // re-render it for the newly shown lane from the last status snapshot.
   if (statusSnap) renderLaneHeader(statusSnap[name] || {});
@@ -264,13 +299,14 @@ function appendLine(line, stream, op) {
 // spinner the moment it's clicked and clear it when the lane goes idle (or a
 // safety timeout fires, in case the process ignores the stop and the user
 // needs to retry).
-const stopping = { maven: false, run: false };
-const stopTimers = { maven: null, run: null };
+const stopping = { maven: false, run: false, debug: false };
+const stopTimers = { maven: null, run: null, debug: null };
 
 function markStopping(which, op) {
   if (stopping[which]) return;
   stopping[which] = true;
-  appendLine(`[canvas] stopping ${which === "run" ? "the app" : "the build"}\u2026`, "stdout", op);
+  const what = which === "debug" ? "the debugger" : which === "run" ? "the app" : "the build";
+  appendLine(`[canvas] stopping ${what}\u2026`, "stdout", op);
   if (statusSnap) renderStatus(statusSnap);
   clearTimeout(stopTimers[which]);
   stopTimers[which] = setTimeout(() => {
@@ -296,12 +332,13 @@ function applyStopButton(btn, which, busy) {
   if (spin) spin.hidden = !isStopping;
   const label = btn.querySelector(".btn-label");
   if (label) label.textContent = isStopping ? "Stopping\u2026" : "Stop";
+  const appLike = which !== "maven";
   if (isStopping) {
-    btn.title = which === "run" ? "Stopping the app\u2026" : "Stopping the build\u2026";
+    btn.title = appLike ? "Stopping the app\u2026" : "Stopping the build\u2026";
   } else if (busy) {
-    btn.title = which === "run" ? "Stop the running app" : "Stop the running build, test or package";
+    btn.title = appLike ? "Stop the running app" : "Stop the running build, test or package";
   } else {
-    btn.title = which === "run" ? "The app isn't running" : "No build is running";
+    btn.title = appLike ? "The app isn't running" : "No build is running";
   }
 }
 
@@ -312,8 +349,8 @@ function applyStopButton(btn, which, busy) {
 // to exit) flips to "starting" the first time the lane reports not-busy, then
 // clears once the relaunch reports busy. A safety timeout is the backstop in
 // case the restart never starts (e.g. it timed out server-side).
-const restarting = { build: false, test: false, package: false, run: false };
-const restartTimers = { build: null, test: null, package: null, run: null };
+const restarting = { build: false, test: false, package: false, run: false, debug: false };
+const restartTimers = { build: null, test: null, package: null, run: null, debug: null };
 
 function markRestarting(op) {
   if (restarting[op]) return;
@@ -339,7 +376,7 @@ function clearRestarting(op) {
 // Advance the restart state machine from the raw (server-reported) busy flags,
 // so the mask drops exactly when the relaunched process is up.
 function syncRestarting(s) {
-  for (const op of ["build", "test", "package", "run"]) {
+  for (const op of ["build", "test", "package", "run", "debug"]) {
     const busy = !!(s[op] && s[op].busy);
     if (restarting[op] === "stopping" && !busy) restarting[op] = "starting";
     else if (restarting[op] === "starting" && busy) clearRestarting(op);
@@ -382,11 +419,12 @@ function renderStatus(s) {
   const mvnBusy = laneActive(s, "build") || laneActive(s, "test") || laneActive(s, "package");
   applyStopButton(btnStopMaven, "maven", mvnBusy);
   applyStopButton(btnStopRun, "run", laneActive(s, "run"));
+  applyStopButton(btnStopDebug, "debug", laneActive(s, "debug"));
   // Per-lane spinners on the trigger buttons and tabs (global, so they reflect
   // activity regardless of which tab is showing). The `is-restarting` class
   // turns the trigger's spinner into a rotating restart glyph without touching
   // the label, so the button keeps its width.
-  for (const op of ["build", "test", "package", "run"]) {
+  for (const op of ["build", "test", "package", "run", "debug"]) {
     const active = laneActive(s, op);
     if (btnSpin[op]) btnSpin[op].hidden = !active;
     if (tabSpin[op]) tabSpin[op].hidden = !active;
@@ -414,11 +452,34 @@ function renderStatus(s) {
             ? `Stop the running ${busyMvnOp} first`
             : "";
   }
+  // Run and Debug share the single app slot, so they're mutually exclusive:
+  // each trigger restarts its own lane but is locked out while the other owns
+  // the app.
+  const runActive = laneActive(s, "run");
+  const debugActive = laneActive(s, "debug");
   if (!toolPresent) btnRun.disabled = true;
-  else btnRun.disabled = !!restarting.run;
+  else btnRun.disabled = !!restarting.run || debugActive;
   if (toolPresent) {
-    btnRun.title = restarting.run ? "Restarting\u2026" : laneActive(s, "run") ? "Restart the running app" : "";
+    btnRun.title = restarting.run
+      ? "Restarting\u2026"
+      : debugActive
+        ? "Stop the debugger first"
+        : runActive
+          ? "Restart the running app"
+          : "";
   }
+  if (!toolPresent) btnDebug.disabled = true;
+  else btnDebug.disabled = !!restarting.debug || runActive;
+  if (toolPresent) {
+    btnDebug.title = restarting.debug
+      ? "Restarting\u2026"
+      : runActive
+        ? "Stop the running app first"
+        : debugActive
+          ? "Restart the debug session"
+          : "";
+  }
+  renderDebug(debugSnap, s);
   // Header (phase / command / exit / fix) follows the active tab; while the
   // active tab's lane is restarting, show a steady "restarting" phase instead of
   // the momentary failed/idle flicker (and no stale Fix button).
@@ -470,6 +531,170 @@ function mb(bytes) {
 }
 function row(k, v) {
   return `<div class="metric"><span class="k">${k}</span><span class="v">${v}</span></div>`;
+}
+
+// --- Debug lane rendering ----------------------------------------------------
+// Class-name tail (com.example.Foo$Bar -> Foo$Bar) for compact display; the full
+// binary name is kept in the title attribute.
+function shortClass(name) {
+  if (!name) return "";
+  const i = name.lastIndexOf(".");
+  return i === -1 ? name : name.slice(i + 1);
+}
+
+// Tracks the "paused at" identity so we only refetch locals when the stop point
+// (or the selected frame) actually changes, not on every SSE debug push.
+let dbgPausedKey = null;
+
+function renderDebug(d, s) {
+  d = d || debugSnap || {};
+  const attached = !!d.active;
+  const paused = !!d.paused;
+  const laneBusy = !!(d.laneBusy || (s && s.debug && s.debug.busy));
+
+  let state = "not started";
+  let cls = "idle";
+  if (d.attaching) {
+    state = "connecting\u2026";
+    cls = "running";
+  } else if (paused) {
+    state = "paused";
+    cls = "paused";
+  } else if (attached) {
+    state = "running";
+    cls = "running";
+  } else if (laneBusy) {
+    state = "launching\u2026";
+    cls = "running";
+  }
+  dbgStateEl.textContent = state;
+  dbgStateEl.className = "pill " + cls;
+
+  const loc = d.location;
+  dbgLocEl.textContent = loc ? `${shortClass(loc.class)}.${loc.method}:${loc.line}` : "";
+  dbgLocEl.title = loc ? `${loc.class}.${loc.method}:${loc.line}` : "";
+
+  // Stepping/continue only make sense while paused; pause only while running.
+  btnDbgContinue.disabled = !paused;
+  btnDbgStepOver.disabled = !paused;
+  btnDbgStepInto.disabled = !paused;
+  btnDbgStepOut.disabled = !paused;
+  btnDbgPause.disabled = !attached || paused;
+  dbgEvalInput.disabled = !paused;
+  btnDbgEval.disabled = !paused;
+
+  renderBreakpoints(d.breakpoints || []);
+  renderStack(d.frames || [], paused);
+
+  if (paused) {
+    const key = `${loc ? loc.class : ""}:${loc ? loc.line : ""}:${dbgSelectedFrame}`;
+    if (key !== dbgPausedKey) {
+      dbgPausedKey = key;
+      refreshVars();
+    }
+  } else {
+    dbgPausedKey = null;
+    dbgSelectedFrame = 0;
+    dbgFrameLabel.textContent = "";
+    dbgVarsEl.innerHTML = `<li class="empty">Variables appear while paused at a breakpoint.</li>`;
+  }
+
+  const bpN = (d.breakpoints || []).length;
+  if (paused) {
+    tabDebugBadge.hidden = false;
+    tabDebugBadge.textContent = "\u25cf";
+    tabDebugBadge.className = "badge paused";
+    tabDebugBadge.title = "Paused at a breakpoint";
+  } else if (bpN) {
+    tabDebugBadge.hidden = false;
+    tabDebugBadge.textContent = String(bpN);
+    tabDebugBadge.className = "badge";
+    tabDebugBadge.title = `${bpN} breakpoint${bpN === 1 ? "" : "s"}`;
+  } else {
+    tabDebugBadge.hidden = true;
+  }
+}
+
+function renderBreakpoints(list) {
+  if (!list.length) {
+    bpListEl.innerHTML = `<li class="empty">No breakpoints. Add a class (binary name) and a line above.</li>`;
+    return;
+  }
+  bpListEl.innerHTML = list
+    .map((b) => {
+      const status = b.error
+        ? `<span class="bp-status error" title="${esc(b.error)}">error</span>`
+        : b.verified
+          ? `<span class="bp-status ok">armed</span>`
+          : `<span class="bp-status pending">pending</span>`;
+      return `<li class="bp-row" data-id="${b.id}">
+        <span class="bp-where" title="${esc(b.class)}:${b.line}"><span class="bp-class">${esc(shortClass(b.class))}</span><span class="bp-line">:${b.line}</span></span>
+        ${status}
+        <button class="bp-remove" data-id="${b.id}" title="Remove breakpoint">\u2715</button>
+      </li>`;
+    })
+    .join("");
+  bpListEl.querySelectorAll(".bp-remove").forEach((btn) => {
+    btn.onclick = () => post("/api/debug/breakpoint/remove", { id: Number(btn.dataset.id) });
+  });
+}
+
+function renderStack(frames, paused) {
+  if (!paused || !frames.length) {
+    dbgStackEl.innerHTML = `<li class="empty">${paused ? "No frames." : "The call stack appears while paused."}</li>`;
+    return;
+  }
+  if (dbgSelectedFrame >= frames.length) dbgSelectedFrame = 0;
+  dbgStackEl.innerHTML = frames
+    .map((f) => {
+      const where = f.native ? "(native)" : `${esc(shortClass(f.class))}.${esc(f.method)}:${f.line}`;
+      const sel = f.index === dbgSelectedFrame ? " selected" : "";
+      return `<li class="stack-frame${sel}" data-index="${f.index}" title="${esc(f.class)}.${esc(f.method)}">
+        <span class="frame-idx">${f.index}</span><span class="frame-where">${where}</span>
+      </li>`;
+    })
+    .join("");
+  dbgStackEl.querySelectorAll(".stack-frame").forEach((li) => {
+    li.onclick = () => {
+      const idx = Number(li.dataset.index);
+      if (idx === dbgSelectedFrame) return;
+      dbgSelectedFrame = idx;
+      dbgPausedKey = null; // force a locals refresh for the newly selected frame
+      if (debugSnap) renderDebug(debugSnap, statusSnap);
+    };
+  });
+}
+
+// Fetch + render locals for the selected frame (only meaningful while paused).
+async function refreshVars() {
+  dbgFrameLabel.textContent = ` \u00b7 frame ${dbgSelectedFrame}`;
+  dbgVarsEl.innerHTML = `<li class="empty">Loading variables\u2026</li>`;
+  let r;
+  try {
+    r = await (await fetch(`/api/debug/locals?frame=${dbgSelectedFrame}&${qs}`)).json();
+  } catch (e) {
+    dbgVarsEl.innerHTML = `<li class="empty">Could not read variables: ${esc(e.message)}</li>`;
+    return;
+  }
+  if (!r || r.ok === false) {
+    dbgVarsEl.innerHTML = `<li class="empty">${esc((r && r.error) || "No variables.")}</li>`;
+    return;
+  }
+  const vars = r.variables || [];
+  if (!vars.length) {
+    dbgVarsEl.innerHTML = `<li class="empty">${esc(r.note || "No variables in this frame.")}</li>`;
+    return;
+  }
+  dbgVarsEl.innerHTML = vars
+    .map(
+      (v) => `<li class="var-row">
+      <span class="var-name">${esc(v.name)}</span>
+      <span class="var-type">${esc(v.type || "")}</span>
+      <span class="var-value" title="${esc(v.value)}">${esc(v.value)}</span>
+    </li>`,
+    )
+    .join("");
+  if (r.note) dbgVarsEl.innerHTML += `<li class="empty">${esc(r.note)}</li>`;
 }
 
 // Last rendered heap-fill width (%). The metrics panel is rebuilt from scratch
@@ -1165,7 +1390,8 @@ setupCombo(mvnProfilesInput, mavenMenu, () => mavenItems);
 // restarts it (stop the current process, then relaunch with the same inputs).
 function triggerLane(op, startPath, body) {
   if (restarting[op]) return; // a restart is already in flight (either phase)
-  const busy = op === "run" ? laneBusy("run") : laneBusy("build") || laneBusy("test") || laneBusy("package");
+  const busy =
+    op === "run" || op === "debug" ? laneBusy(op) : laneBusy("build") || laneBusy("test") || laneBusy("package");
   if (busy) {
     markRestarting(op);
     if (statusSnap) renderStatus(statusSnap); // reflect "Restarting…" without waiting for the next event
@@ -1225,6 +1451,68 @@ btnStopRun.onclick = () => {
   markStopping("run", "run");
   post("/api/stop", { op: "run" });
 };
+
+// --- Debug lane controls ---------------------------------------------------
+// The Debug trigger launches the app with JDWP and attaches the debugger; it is
+// mutually exclusive with Run (the backend rejects if the app is already up).
+btnDebug.onclick = () => {
+  if (btnDebug.disabled) return;
+  showTab("debug");
+  triggerLane("debug", "/api/debug/start", {
+    module: document.getElementById("in-module").value.trim(),
+    profiles: document.getElementById("in-profiles").value.trim(),
+    mavenProfiles: mvnProfiles(),
+    suspend: dbgSuspendInput.checked,
+  });
+};
+btnStopDebug.onclick = () => {
+  if (btnStopDebug.disabled) return;
+  clearRestarting("debug");
+  markStopping("debug", "debug");
+  post("/api/debug/stop", {});
+};
+btnDbgContinue.onclick = () => post("/api/debug/continue", {});
+btnDbgStepOver.onclick = () => post("/api/debug/step", { depth: "over" });
+btnDbgStepInto.onclick = () => post("/api/debug/step", { depth: "into" });
+btnDbgStepOut.onclick = () => post("/api/debug/step", { depth: "out" });
+btnDbgPause.onclick = () => post("/api/debug/pause", {});
+
+function addBreakpoint() {
+  const klass = bpClassInput.value.trim();
+  const line = parseInt(bpLineInput.value, 10);
+  if (!klass || !Number.isInteger(line) || line <= 0) {
+    appendLine("[canvas] enter a class (binary name) and a positive line number", "stderr", "debug");
+    return;
+  }
+  post("/api/debug/breakpoint", { class: klass, line });
+  bpLineInput.value = "";
+}
+btnBpAdd.onclick = addBreakpoint;
+bpClassInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") addBreakpoint();
+});
+bpLineInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") addBreakpoint();
+});
+
+async function evalExpr() {
+  const expr = dbgEvalInput.value.trim();
+  if (!expr) return;
+  dbgEvalResult.textContent = "\u2026";
+  dbgEvalResult.className = "eval-result";
+  const r = await postJson("/api/debug/evaluate", { expression: expr, frame: dbgSelectedFrame });
+  if (!r || r.ok === false) {
+    dbgEvalResult.textContent = (r && r.error) || "Evaluation failed.";
+    dbgEvalResult.className = "eval-result error";
+  } else {
+    dbgEvalResult.textContent = `${r.value}${r.type ? `  (${r.type})` : ""}`;
+    dbgEvalResult.className = "eval-result ok";
+  }
+}
+btnDbgEval.onclick = evalExpr;
+dbgEvalInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") evalExpr();
+});
 
 // Run tab: force-open the running app in a browser.
 btnOpenBrowser.onclick = () => post("/api/open-app", {});
@@ -1303,11 +1591,11 @@ let lastRunnerLabel = null;
 // active phase (build→building, test→testing, run→running). Because each
 // lane is tracked independently, a build finishing won't yank you off the
 // Run tab, and starting a test while the app runs jumps to the Test tab.
-const laneActivePhase = { build: "building", test: "testing", package: "packaging", run: "running" };
-const laneWasActive = { build: false, test: false, package: false, run: false };
+const laneActivePhase = { build: "building", test: "testing", package: "packaging", run: "running", debug: "running" };
+const laneWasActive = { build: false, test: false, package: false, run: false, debug: false };
 function followLaneActivity(s) {
   if (!s) return;
-  for (const op of ["build", "test", "package", "run"]) {
+  for (const op of ["build", "test", "package", "run", "debug"]) {
     const lane = s[op];
     if (!lane) continue;
     const active = lane.phase === laneActivePhase[op];
@@ -1331,6 +1619,10 @@ es.addEventListener("status", (e) => {
   followLaneActivity(s);
 });
 es.addEventListener("metrics", (e) => renderMetrics(JSON.parse(e.data)));
+es.addEventListener("debug", (e) => {
+  debugSnap = JSON.parse(e.data);
+  renderDebug(debugSnap, statusSnap);
+});
 es.addEventListener("test-progress", (e) => {
   renderTestProgress(JSON.parse(e.data));
 });
@@ -1370,9 +1662,11 @@ setTimeout(hideLoading, 4000);
 fetch(`/api/state?${qs}`)
   .then((r) => r.json())
   .then((s) => {
+    debugSnap = s.debug || null;
     renderStatus(s.status);
     renderMetrics(s.metrics);
     applyEnv(s.env);
+    renderDebug(debugSnap, s.status);
     if (s.status && s.status.test) lastRunnerLabel = s.status.test.runnerLabel;
     renderTests(s.tests, { runnerLabel: lastRunnerLabel });
     for (const l of s.console || []) appendLine(l.line, l.stream, l.op);

--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,14 @@
           <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
         </button>
       </div>
+      <div class="btn-group" id="debug-group">
+        <button id="btn-debug" class="primary" title="Launch the app with the debugger attached (JDWP)">
+          <span class="btn-spin" hidden></span>Debug
+        </button>
+        <button id="btn-stop-debug" class="danger">
+          <span class="btn-spin" hidden></span><span class="btn-label">Stop</span>
+        </button>
+      </div>
       <div class="inputs">
         <label>module</label>
         <select id="in-module" title="Module to run">
@@ -119,6 +127,14 @@
         </svg>
         Run <span class="tab-spin" hidden></span>
       </button>
+      <button class="tab" data-tab="debug">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M4.5 3a2.5 2.5 0 0 1 5 0v1.05A4 4 0 0 1 12 7.5V8h2.5a.5.5 0 0 1 0 1H12v2h2.5a.5.5 0 0 1 0 1H12v.5a4 4 0 0 1-8 0V12H1.5a.5.5 0 0 1 0-1H4V9H1.5a.5.5 0 0 1 0-1H4v-.5A4 4 0 0 1 6.5 4.05V3a1.5 1.5 0 0 0-3 0 .5.5 0 0 1-1 0zm.5 5v4.5a3 3 0 0 0 6 0V8a3 3 0 0 0-6 0"
+          />
+        </svg>
+        Debug <span class="badge" id="tab-debug-badge" hidden></span> <span class="tab-spin" hidden></span>
+      </button>
     </div>
 
     <div id="workspace">
@@ -152,6 +168,76 @@
             </button>
           </div>
           <pre id="run-console" class="term" aria-label="Run output"></pre>
+        </section>
+
+        <section id="debug-pane" class="lpane col">
+          <div class="debug-bar">
+            <span id="dbg-state" class="pill idle">not attached</span>
+            <span id="dbg-loc" class="muted"></span>
+            <label
+              class="switch tiny-switch"
+              id="dbg-suspend-toggle"
+              title="Pause the VM at startup until the debugger attaches"
+            >
+              <input type="checkbox" id="in-dbg-suspend" />
+              <span class="track"><span class="thumb"></span></span>
+              <span class="switch-label">Suspend at start</span>
+            </label>
+          </div>
+          <div class="debug-controls">
+            <button id="btn-dbg-continue" class="tiny" disabled title="Resume until the next breakpoint">
+              ▶ Continue
+            </button>
+            <button id="btn-dbg-stepover" class="tiny" disabled title="Step over the current line">⤼ Step Over</button>
+            <button id="btn-dbg-stepinto" class="tiny" disabled title="Step into the next call">⤽ Step Into</button>
+            <button id="btn-dbg-stepout" class="tiny" disabled title="Run until the method returns">⤴ Step Out</button>
+            <button id="btn-dbg-pause" class="tiny" disabled title="Suspend the running VM">⏸ Pause</button>
+          </div>
+          <div class="debug-grid">
+            <section class="debug-card">
+              <h3>Breakpoints</h3>
+              <div class="bp-add">
+                <input
+                  id="in-bp-class"
+                  placeholder="com.example.App"
+                  autocomplete="off"
+                  title="Fully-qualified class (binary name)"
+                />
+                <input id="in-bp-line" type="number" min="1" placeholder="line" title="Source line number" />
+                <button id="btn-bp-add" class="tiny">Add</button>
+              </div>
+              <ul id="bp-list" class="bp-list">
+                <li class="empty">No breakpoints yet.</li>
+              </ul>
+            </section>
+            <section class="debug-card">
+              <h3>Call stack</h3>
+              <ul id="dbg-stack" class="stack-list">
+                <li class="empty">Not paused.</li>
+              </ul>
+            </section>
+            <section class="debug-card">
+              <h3>Variables<span id="dbg-frame-label" class="muted"></span></h3>
+              <ul id="dbg-vars" class="var-list">
+                <li class="empty">Not paused.</li>
+              </ul>
+            </section>
+            <section class="debug-card">
+              <h3>Evaluate</h3>
+              <div class="bp-add">
+                <input
+                  id="in-dbg-eval"
+                  placeholder="order.customer.name"
+                  autocomplete="off"
+                  title="Local variable or dotted field path"
+                  disabled
+                />
+                <button id="btn-dbg-eval" class="tiny" disabled>Inspect</button>
+              </div>
+              <div id="dbg-eval-result" class="eval-result"></div>
+            </section>
+          </div>
+          <pre id="debug-console" class="term" aria-label="Debug output"></pre>
         </section>
       </div>
       <aside>

--- a/public/styles.css
+++ b/public/styles.css
@@ -462,6 +462,223 @@ select {
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
   flex: 0 0 auto;
 }
+
+/* --- Debug lane ----------------------------------------------------------- */
+.debug-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
+}
+#dbg-loc {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+}
+.tiny-switch {
+  margin-left: auto;
+}
+.tiny-switch .switch-label {
+  font-size: 12px;
+}
+.pill.paused {
+  color: var(--true-color-yellow, #9a6700);
+  border-color: var(--true-color-yellow, #9a6700);
+}
+.tab .badge.paused {
+  background: var(--true-color-yellow, #9a6700);
+  color: var(--color-white, #fff);
+}
+.debug-controls {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color-default, #d0d7de);
+  flex: 0 0 auto;
+}
+.debug-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0.75rem;
+  overflow: auto;
+  flex: 1 1 60%;
+  min-height: 0;
+  align-content: start;
+}
+@media (max-width: 760px) {
+  .debug-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.debug-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  border-radius: 6px;
+  padding: 0.6rem 0.7rem;
+  background: var(--background-color-default, #ffffff);
+}
+.debug-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-color-muted, #656d76);
+}
+.debug-card h3 .muted {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+.bp-add {
+  display: flex;
+  gap: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+.bp-add input {
+  min-width: 0;
+}
+.bp-add #in-bp-class,
+.bp-add #in-dbg-eval {
+  flex: 1 1 auto;
+}
+.bp-add #in-bp-line {
+  flex: 0 0 auto;
+  width: 4.5rem;
+}
+.bp-list,
+.stack-list,
+.var-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  min-height: 0;
+  font-size: 12px;
+}
+.bp-list .empty,
+.stack-list .empty,
+.var-list .empty {
+  padding: 0.6rem 0;
+  font-size: 12px;
+}
+.bp-row,
+.var-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px dashed var(--border-color-muted, #d8dee4);
+}
+.bp-where,
+.frame-where,
+.var-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.bp-where {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+.bp-class {
+  font-weight: 600;
+}
+.bp-line {
+  color: var(--text-color-muted, #656d76);
+}
+.bp-status {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 600;
+}
+.bp-status.ok {
+  color: var(--true-color-green, #1a7f37);
+}
+.bp-status.pending {
+  color: var(--true-color-blue, #0969da);
+}
+.bp-status.error {
+  color: var(--true-color-red, #cf222e);
+}
+.bp-remove {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: var(--text-color-muted, #656d76);
+  padding: 0 0.2rem;
+  line-height: 1;
+  border-radius: 4px;
+}
+.bp-remove:hover {
+  color: var(--true-color-red, #cf222e);
+  background: color-mix(in srgb, var(--true-color-red, #cf222e) 12%, transparent);
+}
+.stack-frame {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.25rem 0.3rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  transition: background-color var(--dur-fast) var(--ease-out);
+}
+.stack-frame:hover {
+  background: color-mix(in srgb, var(--text-color-default, #1f2328) 5%, transparent);
+}
+.stack-frame.selected {
+  background: color-mix(in srgb, var(--true-color-blue, #0969da) 14%, transparent);
+}
+.frame-idx {
+  flex: 0 0 auto;
+  min-width: 1.2rem;
+  color: var(--text-color-muted, #656d76);
+}
+.frame-where {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.var-name {
+  flex: 0 0 auto;
+  font-weight: 600;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+.var-type {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-color-muted, #656d76);
+}
+.var-value {
+  margin-left: auto;
+  min-width: 0;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+.eval-result {
+  margin-top: 0.5rem;
+  min-height: 1.2em;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  word-break: break-word;
+}
+.eval-result.error {
+  color: var(--true-color-red, #cf222e);
+}
+.eval-result.ok {
+  color: var(--text-color-default, #1f2328);
+}
+#debug-console {
+  flex: 1 1 40%;
+  min-height: 0;
+  overflow: auto;
+  border-top: 1px solid var(--border-color-default, #d0d7de);
+}
 aside {
   border-left: 1px solid var(--border-color-default, #d0d7de);
   padding: 0.75rem 1rem;


### PR DESCRIPTION
## Summary

Adds a **Debug lane** next to Run so you can launch your Spring Boot / Quarkus / plain-Java app with the JVM debugger attached, set breakpoints, step, inspect the call stack, and evaluate expressions, all from the Coffilot side panel. Crucially, it is **agent-driven**: Copilot can start a debug session, set breakpoints, drive stepping, and read back paused state through agent actions, so you can ask it to investigate a failure interactively.

Debug and Run share the single app slot and are **mutually exclusive** (one owns the running process at a time; the inactive lane's button is disabled with a "Stop the other first" hint).

## Approach

- **JDWP engine (`jdwp.mjs`).** A dependency-free Java Debug Wire Protocol client built on `node:net` (the `dt_socket` transport). It speaks JDWP directly rather than shelling out to `jdb`, so breakpoints, stepping, stack frames, locals, and expression evaluation are handled in-process. Pure Node, no native bits, so it works the same on Linux, macOS, and Windows.
- **Launch + attach.** The lane launches the app with `-agentlib:jdwp=...` (via `spring-boot.run.jvmArguments` / `quarkus` dev props / generic Java flags, per build tool) and then attaches over loopback, retrying until the agent's listener is up. Attach kickoff lives in `spawnTool` so the timing is robust.
- **Agent actions.** `start_debug`, `stop_debug`, `set_breakpoint`, `remove_breakpoint`, `debug_continue`, `debug_step`, `debug_stack`, `debug_locals`, `debug_evaluate`, plus the matching loopback `/api/debug/*` endpoints.
- **UI integration.** A Debug tab with breakpoints, call stack, variables, and an Evaluate box, plus a "Suspend at start" toggle. This was re-integrated on top of the recent UI refactor that unified every lane behind a single toggling `lane-action` button (the button becomes a red Stop while busy).

## Notes for reviewers

This branch also merges the latest `main` twice (async-profiler flame graph, live log viewer, affected-test selection, and the unified lane-button UI refactor). The most involved part of the last merge was re-homing the Debug UI into the new single-button-per-lane model: `applyStopButton`/`btn-stop-debug` were replaced with `setLaneButton`, and Debug now flows through `laneAction`/`stopLane` like Run. I also fixed a cross-platform issue where whitespace-bearing JVM args (Spring `jvmArguments`, Gradle `--init-script` temp paths under `C:\Users\John Doe\...`) broke under the Windows `cmd.exe` shell, by quoting such args (no-op on POSIX). One benign `laneBusy` variable shadow in `renderDebug` was renamed to avoid a TDZ-class footgun.

Worth a careful look: the Run/Debug mutual-exclusion logic in `renderStatus` and the JDWP packet handling in `jdwp.mjs`.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

Additional checks: `node --check public/app.js` and `node --check jdwp.mjs` pass; manifest validates (`coffilot` v1). Verified live on macOS via a Spring + Maven end-to-end debug session (launch, breakpoint hit, step, evaluate, stop).