### PR TITLE
Ignore Spring Boot DevTools while debugging

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -33,7 +33,8 @@ Shipped in the extension today:
   frame-local variables and a dotted-path evaluator. Per-build-tool agent injection
   (plain Java argv, Spring Maven `-Dspring-boot.run.jvmArguments`, a generated Gradle
   init-script for Spring/app Gradle, Quarkus `-Ddebug`). Debug and Run are mutually
-  exclusive (shared app slot); live reload is disabled while debugging.
+  exclusive (shared app slot); DevTools is ignored while debugging (live reload off
+  and `spring.devtools.restart.enabled=false` on the app JVM).
 - **Maven and Gradle support**, auto-detected from project markers (Maven preferred
   when both are present; a clear degraded notice when neither is). The wrapper
   (`./mvnw` / `./gradlew`) is preferred over a system `mvn` / `gradle`, cross-platform.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ wins; when neither is found the console says so and stays disabled until one is 
   pause, the paused call stack, frame-local variables and a dotted-path evaluator.
   Debug and Run are **mutually exclusive** (they share the single app slot), and
   Copilot can drive the whole session through agent actions (set a breakpoint,
-  continue, inspect variables, …). Live reload is disabled while debugging so a
-  recompile can't drop the session.
+  continue, inspect variables, …). DevTools is ignored while debugging — Coffilot's
+  live reload stays off and DevTools' own restart is disabled (via
+  `spring.devtools.restart.enabled=false`) so a recompile or restart can't drop the
+  session.
 - **Stop** &mdash; terminates the running app / build process.
 - **Profiles** &mdash; the toolbar scans the project for available run profiles —
   **Spring Boot** profiles (`application-<profile>.*`) or **Quarkus** profiles

--- a/extension.mjs
+++ b/extension.mjs
@@ -189,6 +189,15 @@ async function refineWorkspaceFromSession() {
 // Maven, the launched app JVM.
 const NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED";
 
+// Spring Boot DevTools, when on the classpath, runs the app inside a restart
+// classloader and auto-restarts the JVM whenever target/classes changes. Both
+// behaviours break a JDWP debug session (breakpoints loaded in the restart
+// classloader misbehave, and a restart silently drops the debugger). When Debug
+// launches a Spring app we therefore ignore the DevTools toggle and pass this
+// System property to the forked app JVM so DevTools stays out of the way. It is
+// a no-op when DevTools isn't present, but we only add it when it is.
+const DEVTOOLS_DISABLE_FLAG = "-Dspring.devtools.restart.enabled=false";
+
 // Maven 3.9+ (and the mvnd native client) embed JLine for their console. When
 // spawned without a TTY (as this canvas always does), JLine can't open a system
 // terminal and logs a noisy "Unable to create a system terminal, creating a dumb
@@ -2974,8 +2983,10 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
       // (SPRING_PROFILES_ACTIVE / SERVER_PORT) to avoid cross-platform --args
       // quoting pitfalls.
       const args = [gradleTaskPath(module, "bootRun"), "--console=plain"];
-      // Debug: an init script adds the JDWP agent to the forked bootRun JVM.
-      if (dbg) args.push("--init-script", gradleDebugInitScript(dbg));
+      // Debug: an init script adds the JDWP agent to the forked bootRun JVM, and
+      // (when the module carries DevTools) disables DevTools restart so it can't
+      // drop the debug session.
+      if (dbg) args.push("--init-script", gradleDebugInitScript(dbg, { devtools: !!(mod && mod.devtools) }));
       const extra = {};
       if (profiles) extra.SPRING_PROFILES_ACTIVE = profiles;
       if (settings.randomPort) {
@@ -3006,8 +3017,13 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
     if (profiles) args.push(`-Dspring-boot.run.profiles=${profiles}`);
     // Pass the native-access flag to the forked app JVM so its FFM-using
     // dependencies don't print restricted-method warnings; in Debug mode the JDWP
-    // agent rides along on the same jvmArguments string.
-    const jvmArgs = dbg ? `${NATIVE_ACCESS_FLAG} ${jdwpAgentArg(dbg)}` : NATIVE_ACCESS_FLAG;
+    // agent rides along on the same jvmArguments string. When the module carries
+    // DevTools we also disable its restart so it can't drop the debug session.
+    let jvmArgs = NATIVE_ACCESS_FLAG;
+    if (dbg) {
+      jvmArgs += ` ${jdwpAgentArg(dbg)}`;
+      if (mod && mod.devtools) jvmArgs += ` ${DEVTOOLS_DISABLE_FLAG}`;
+    }
     args.push(`-Dspring-boot.run.jvmArguments=${jvmArgs}`);
     // "Use a random HTTP port": run on a free port the console picks (via
     // server.port) so the app doesn't collide with whatever owns the default.
@@ -3360,9 +3376,12 @@ function jdwpAgentArg(dbg) {
 
 /** Write a throwaway Gradle init script that adds the JDWP agent (and the
  * native-access flag) to the forked app JVM of JavaExec-typed run tasks
- * (bootRun / run). Quarkus uses -Ddebug instead, so quarkusDev isn't matched. */
-function gradleDebugInitScript(dbg) {
+ * (bootRun / run). Quarkus uses -Ddebug instead, so quarkusDev isn't matched.
+ * When `devtools` is set (a Spring module with DevTools on the classpath), it
+ * also disables DevTools restart so it can't drop the debug session. */
+function gradleDebugInitScript(dbg, { devtools = false } = {}) {
   const flags = [NATIVE_ACCESS_FLAG, jdwpAgentArg(dbg)];
+  if (devtools) flags.push(DEVTOOLS_DISABLE_FLAG);
   const body = [
     "gradle.allprojects {",
     "  tasks.matching { it.name == 'bootRun' || it.name == 'run' }.configureEach { t ->",


### PR DESCRIPTION
## Summary

The Debug tab was being disrupted by Spring Boot DevTools. When DevTools is on the classpath it runs the app inside a restart classloader and auto-restarts the JVM on classpath changes. Both behaviors break a JDWP debug session: breakpoints loaded in the restart classloader misbehave, and a restart silently drops the debugger.

Coffilot already skipped its own live-reload watcher during Debug, but DevTools itself stayed active in the launched app. This change neutralizes DevTools for the debug launch so it stays out of the way:

- When Debug launches a Spring module that carries DevTools, pass `-Dspring.devtools.restart.enabled=false` to the forked app JVM.
  - Maven `spring-boot:run`: appended to `-Dspring-boot.run.jvmArguments` alongside the JDWP agent.
  - Gradle `bootRun`: added to the generated debug init-script's `jvmArgs` via a new `devtools` option on `gradleDebugInitScript`.

The flag is only added when the module actually has DevTools and only in Debug mode, so normal Run is unchanged and the DevTools toggle keeps working there. Quarkus and plain-Java launches are unaffected (no DevTools).

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

`spring.devtools.restart.enabled` must be a System property (read before the context starts), which is why it goes on the forked app JVM args rather than `application.properties`. It is a no-op when DevTools isn't present, but it is only added when the module reports DevTools on the classpath. Reload extensions and re-open the canvas to pick up the change when testing.