### PR TITLE
Add Clean/Install toggles to Build and Package tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ wins; when neither is found the console says so and stays disabled until one is 
 ## Features
 
 - **Build** &mdash; Maven `./mvnw -ntp -DskipTests install` or Gradle
-  `./gradlew build -x test` (args overridable).
+  `./gradlew build -x test` (args overridable). A **Clean** toggle (off by default)
+  runs a clean first (`mvn clean install`; Gradle `clean build`).
 - **Test** &mdash; Maven `./mvnw -ntp test` or Gradle `./gradlew cleanTest test`, with
   the JUnit results parsed into a graphical, per-test view (summary chips, per-suite
   grouping, expandable failure stack traces) and a live progress bar. A console toggle
@@ -32,7 +33,10 @@ wins; when neither is found the console says so and stays disabled until one is 
   dependency-accurate selection; before the first compile it falls back to a name-based
   mapping (`Foo` → `FooTest` / `FooTests` / `FooIT`).
 - **Package** &mdash; Maven `./mvnw -ntp package` or Gradle `./gradlew assemble`,
-  streamed live like Build.
+  streamed live like Build. A **Clean** toggle (off by default) runs a clean first
+  (`mvn clean package`; Gradle `clean assemble`), and an **Install** toggle (off by
+  default) installs the artifact to the local repository (`mvn install`; Gradle
+  `publishToMavenLocal`) instead of just packaging.
 - **Run** &mdash; `spring-boot:run` (Maven) / `bootRun` (Gradle) for a Spring Boot
   module (+ Spring profiles), `quarkus:dev` (Maven) / `quarkusDev` (Gradle) for a
   Quarkus module (+ run profile), or, for a non-Spring/non-Quarkus module, the

--- a/extension.mjs
+++ b/extension.mjs
@@ -892,6 +892,9 @@ const SETTINGS_KEYS = [
   "randomPort",
   "openBrowser",
   "fullBuild",
+  "buildClean",
+  "packageClean",
+  "packageInstall",
   "autoProfile",
   "autoProfileEvent",
   "autoProfileDuration",
@@ -914,6 +917,13 @@ function defaultSettings() {
     // On by default: the Test button runs the whole suite. Off runs only the
     // tests affected by the current uncommitted changes.
     fullBuild: true,
+    // Build/Package "Clean" toggles (off by default): prepend a clean goal so a
+    // build runs `clean install` instead of `install` (Gradle `clean build`).
+    buildClean: false,
+    packageClean: false,
+    // Package "Install" toggle (off by default): install the artifact to the
+    // local repository (`mvn install`; Gradle `publishToMavenLocal`).
+    packageInstall: false,
     autoProfile: false,
     autoProfileEvent: "cpu",
     autoProfileDuration: 30,
@@ -1837,6 +1847,9 @@ function applySettings(body) {
   if (typeof body.randomPort === "boolean") settings.randomPort = body.randomPort;
   if (typeof body.openBrowser === "boolean") settings.openBrowser = body.openBrowser;
   if (typeof body.fullBuild === "boolean") settings.fullBuild = body.fullBuild;
+  if (typeof body.buildClean === "boolean") settings.buildClean = body.buildClean;
+  if (typeof body.packageClean === "boolean") settings.packageClean = body.packageClean;
+  if (typeof body.packageInstall === "boolean") settings.packageInstall = body.packageInstall;
   if (typeof body.autoProfile === "boolean") settings.autoProfile = body.autoProfile;
   if (["cpu", "alloc", "wall", "lock"].includes(body.autoProfileEvent)) {
     settings.autoProfileEvent = body.autoProfileEvent;
@@ -2685,10 +2698,16 @@ function affectedTestArgs(tests, warm) {
 }
 
 // Default argument vectors per lane, per tool. `warm` only affects Gradle (daemon
-// vs --no-daemon); Maven's warm tier swaps the binary (mvnd) instead.
-function defaultBuildArgs(warm) {
-  if (buildTool === "gradle") return ["build", "-x", "test", "--console=plain", ...gradleWarmFlags(warm)];
-  return ["-ntp", "-DskipTests", "install"];
+// vs --no-daemon); Maven's warm tier swaps the binary (mvnd) instead. `clean`
+// prepends a clean goal (Build/Package "Clean" toggle); `install` (Package only)
+// installs the artifact to the local repository instead of just packaging it.
+function defaultBuildArgs(warm, clean) {
+  if (buildTool === "gradle") {
+    const goals = clean ? ["clean", "build"] : ["build"];
+    return [...goals, "-x", "test", "--console=plain", ...gradleWarmFlags(warm)];
+  }
+  const goals = clean ? ["clean", "install"] : ["install"];
+  return ["-ntp", "-DskipTests", ...goals];
 }
 function defaultTestArgs(warm) {
   // cleanTest forces Gradle to re-run tests even when nothing changed, so the
@@ -2696,12 +2715,20 @@ function defaultTestArgs(warm) {
   if (buildTool === "gradle") return ["cleanTest", "test", "--console=plain", ...gradleWarmFlags(warm)];
   return ["-ntp", "test"];
 }
-function defaultPackageArgs(warm) {
-  if (buildTool === "gradle") return ["assemble", "--console=plain", ...gradleWarmFlags(warm)];
-  return ["-ntp", "package"];
+function defaultPackageArgs(warm, clean, install) {
+  if (buildTool === "gradle") {
+    // `publishToMavenLocal` is the Gradle equivalent of `mvn install` (requires
+    // the maven-publish plugin with a configured publication).
+    const goal = install ? "publishToMavenLocal" : "assemble";
+    const goals = clean ? ["clean", goal] : [goal];
+    return [...goals, "--console=plain", ...gradleWarmFlags(warm)];
+  }
+  const goal = install ? "install" : "package";
+  const goals = clean ? ["clean", goal] : [goal];
+  return ["-ntp", ...goals];
 }
 
-async function build(extraArgs, warm, mavenProfiles) {
+async function build(extraArgs, warm, mavenProfiles, clean) {
   if (!buildTool) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "build");
     return noToolResult();
@@ -2710,7 +2737,7 @@ async function build(extraArgs, warm, mavenProfiles) {
   try {
     if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
     const r = resolveRunner(warm);
-    const base = extraArgs && extraArgs.length ? extraArgs : defaultBuildArgs(r.warm);
+    const base = extraArgs && extraArgs.length ? extraArgs : defaultBuildArgs(r.warm, clean === true);
     const args = withMavenProfiles(base, mavenProfiles);
     lanes.build.warm = r.warm;
     const code = await spawnTool("build", args, "building", { bin: r.bin, label: r.label });
@@ -2727,7 +2754,7 @@ async function build(extraArgs, warm, mavenProfiles) {
   }
 }
 
-async function packageApp(extraArgs, warm, mavenProfiles) {
+async function packageApp(extraArgs, warm, mavenProfiles, clean, install) {
   if (!buildTool) {
     pushConsole("[coffilot] No Maven or Gradle project detected.", "stderr", "package");
     return noToolResult();
@@ -2736,7 +2763,8 @@ async function packageApp(extraArgs, warm, mavenProfiles) {
   try {
     if (mvnLaneBusy()) return { ok: false, error: "A build, test or package is already running. Stop it first." };
     const r = resolveRunner(warm);
-    const base = extraArgs && extraArgs.length ? extraArgs : defaultPackageArgs(r.warm);
+    const base =
+      extraArgs && extraArgs.length ? extraArgs : defaultPackageArgs(r.warm, clean === true, install === true);
     const args = withMavenProfiles(base, mavenProfiles);
     lanes.package.warm = r.warm;
     const code = await spawnTool("package", args, "packaging", { bin: r.bin, label: r.label });
@@ -3794,9 +3822,12 @@ async function restart(op, params = {}) {
   // over SSE, so the relaunch must not block the HTTP response until it finishes.
   if (op === "test" && params.affected === true) {
     runAffectedTests(params.warm === true, params.mavenProfiles);
+  } else if (op === "build") {
+    build(null, params.warm === true, params.mavenProfiles, params.clean === true);
+  } else if (op === "package") {
+    packageApp(null, params.warm === true, params.mavenProfiles, params.clean === true, params.install === true);
   } else {
-    const startFn = op === "build" ? build : op === "test" ? test : packageApp;
-    startFn(null, params.warm === true, params.mavenProfiles);
+    test(null, params.warm === true, params.mavenProfiles);
   }
   return { ok: true, restarted: true, op };
 }
@@ -5376,7 +5407,7 @@ async function handleRequest(req, res) {
 
   if (req.method === "POST" && url.pathname === "/api/build") {
     const body = await readBody(req);
-    build(null, body.warm === true, body.mavenProfiles); // fire-and-forget; progress streams over SSE
+    build(null, body.warm === true, body.mavenProfiles, body.clean === true); // fire-and-forget; progress streams over SSE
     sendJson(res, 200, { ok: true });
     return;
   }
@@ -5401,7 +5432,7 @@ async function handleRequest(req, res) {
   }
   if (req.method === "POST" && url.pathname === "/api/package") {
     const body = await readBody(req);
-    packageApp(null, body.warm === true, body.mavenProfiles); // fire-and-forget; streams over SSE
+    packageApp(null, body.warm === true, body.mavenProfiles, body.clean === true, body.install === true); // fire-and-forget; streams over SSE
     sendJson(res, 200, { ok: true });
     return;
   }
@@ -5666,9 +5697,20 @@ function makeCanvas() {
               description:
                 "Keep the JVM warm between runs (Maven Daemon mvnd when available, or the Gradle daemon) for faster startup.",
             },
+            clean: {
+              type: "boolean",
+              description:
+                "Run a clean before building, so the build runs `clean install` instead of `install` (Gradle `clean build`). Ignored when `args` is given.",
+            },
           },
         },
-        handler: async (ctx) => build(splitArgs(ctx.input?.args), ctx.input?.warm === true, ctx.input?.mavenProfiles),
+        handler: async (ctx) =>
+          build(
+            splitArgs(ctx.input?.args),
+            ctx.input?.warm === true,
+            ctx.input?.mavenProfiles,
+            ctx.input?.clean === true,
+          ),
       },
       {
         name: "run_tests",
@@ -5734,10 +5776,26 @@ function makeCanvas() {
               description:
                 "Keep the JVM warm between runs (Maven Daemon mvnd when available, or the Gradle daemon) for faster startup.",
             },
+            clean: {
+              type: "boolean",
+              description:
+                "Run a clean before packaging (`mvn clean package`; Gradle `clean assemble`). Ignored when `args` is given.",
+            },
+            install: {
+              type: "boolean",
+              description:
+                "Install the artifact to the local repository (`mvn install`; Gradle `publishToMavenLocal`) instead of just packaging. Ignored when `args` is given.",
+            },
           },
         },
         handler: async (ctx) =>
-          packageApp(splitArgs(ctx.input?.args), ctx.input?.warm === true, ctx.input?.mavenProfiles),
+          packageApp(
+            splitArgs(ctx.input?.args),
+            ctx.input?.warm === true,
+            ctx.input?.mavenProfiles,
+            ctx.input?.clean === true,
+            ctx.input?.install === true,
+          ),
       },
       {
         name: "start_app",

--- a/public/app.js
+++ b/public/app.js
@@ -36,6 +36,9 @@ const tabRunBadge = document.getElementById("tab-run-badge");
 const tabPackageBadge = document.getElementById("tab-package-badge");
 const fullbuildToggle = document.getElementById("fullbuild-toggle");
 const fullbuildInput = document.getElementById("in-fullbuild");
+const buildCleanInput = document.getElementById("in-build-clean");
+const packageCleanInput = document.getElementById("in-package-clean");
+const packageInstallInput = document.getElementById("in-package-install");
 const continuousToggle = document.getElementById("continuous-toggle");
 const continuousInput = document.getElementById("in-continuous");
 const testSelectionEl = document.getElementById("test-selection");
@@ -1623,6 +1626,9 @@ function applySettingsState(s) {
   randomportInput.checked = s.randomPort === true;
   openBrowserInput.checked = s.openBrowser === true;
   fullBuildSetting = s.fullBuild === true;
+  buildCleanInput.checked = s.buildClean === true;
+  packageCleanInput.checked = s.packageClean === true;
+  packageInstallInput.checked = s.packageInstall === true;
   reflectTestToggles();
   if (autoProfileInput) autoProfileInput.checked = s.autoProfile === true;
   if (flameEvent && typeof s.autoProfileEvent === "string" && document.activeElement !== flameEvent) {
@@ -1938,7 +1944,13 @@ function laneAction(op) {
     triggerLane("test", "/api/test", { affected, warm: warm(), mavenProfiles: mvnProfiles() });
     return;
   }
-  triggerLane(op, "/api/" + op, { warm: warm(), mavenProfiles: mvnProfiles() });
+  const body = { warm: warm(), mavenProfiles: mvnProfiles() };
+  if (op === "build") body.clean = buildCleanInput.checked === true;
+  if (op === "package") {
+    body.clean = packageCleanInput.checked === true;
+    body.install = packageInstallInput.checked === true;
+  }
+  triggerLane(op, "/api/" + op, body);
 }
 
 document.getElementById("btn-build").onclick = () => laneAction("build");
@@ -2036,6 +2048,9 @@ function saveSettings() {
     randomPort: randomportInput.checked,
     openBrowser: openBrowserInput.checked,
     fullBuild: fullbuildInput.checked,
+    buildClean: buildCleanInput.checked,
+    packageClean: packageCleanInput.checked,
+    packageInstall: packageInstallInput.checked,
     autoProfile: autoProfileInput ? autoProfileInput.checked : false,
     autoProfileEvent: flameEvent ? flameEvent.value : "cpu",
     autoProfileDuration: flameDuration ? Number(flameDuration.value) : 30,
@@ -2046,6 +2061,9 @@ devtoolsInput.addEventListener("change", saveSettings);
 randomportInput.addEventListener("change", saveSettings);
 openBrowserInput.addEventListener("change", saveSettings);
 springInput.addEventListener("change", saveSettings);
+buildCleanInput.addEventListener("change", saveSettings);
+packageCleanInput.addEventListener("change", saveSettings);
+packageInstallInput.addEventListener("change", saveSettings);
 if (autoProfileInput) autoProfileInput.addEventListener("change", saveSettings);
 if (flameEvent) flameEvent.addEventListener("change", saveSettings);
 if (flameDuration) flameDuration.addEventListener("change", saveSettings);

--- a/public/index.html
+++ b/public/index.html
@@ -104,6 +104,20 @@
             <button id="btn-build" class="primary lane-action">
               <span class="btn-spin" hidden></span><span class="btn-label">Build</span>
             </button>
+            <div class="lane-controls">
+              <label class="switch" id="build-clean-toggle">
+                <input type="checkbox" id="in-build-clean" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Clean</span>
+              </label>
+              <span
+                class="info"
+                id="build-clean-info"
+                tabindex="0"
+                data-tip="Off (default). On: run a clean first, so the build runs `mvn clean install` instead of `mvn install` (Gradle `clean build`)."
+                >&#9432;</span
+              >
+            </div>
           </div>
           <pre id="build-console" class="term" aria-label="Build output"></pre>
         </section>
@@ -113,6 +127,32 @@
             <button id="btn-package" class="primary lane-action">
               <span class="btn-spin" hidden></span><span class="btn-label">Package</span>
             </button>
+            <div class="lane-controls">
+              <label class="switch" id="package-clean-toggle">
+                <input type="checkbox" id="in-package-clean" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Clean</span>
+              </label>
+              <span
+                class="info"
+                id="package-clean-info"
+                tabindex="0"
+                data-tip="Off (default). On: run a clean first (`mvn clean package`; Gradle `clean assemble`)."
+                >&#9432;</span
+              >
+              <label class="switch" id="package-install-toggle">
+                <input type="checkbox" id="in-package-install" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Install</span>
+              </label>
+              <span
+                class="info"
+                id="package-install-info"
+                tabindex="0"
+                data-tip="Off (default). On: install the artifact to the local repository (`mvn install`; Gradle `publishToMavenLocal`) instead of just packaging."
+                >&#9432;</span
+              >
+            </div>
           </div>
           <pre id="package-console" class="term" aria-label="Package output"></pre>
         </section>


### PR DESCRIPTION
## Summary

Lets you control clean and install behavior per run without dropping to the args override or the agent. The Build and Package lanes only exposed their fixed default goals, so a clean rebuild or installing the artifact to the local repo meant manually overriding the build-tool args.

- **Build tab** gains a `Clean` toggle (off by default). When on, it prepends a clean goal so the build runs `mvn clean install` instead of `mvn install` (Gradle `clean build`).
- **Package tab** gains a matching `Clean` toggle (`mvn clean package`; Gradle `clean assemble`) plus, to its right, an `Install` toggle (off by default) that installs the artifact to the local repository (`mvn install`; Gradle `publishToMavenLocal`) instead of just packaging. Combined, they produce `mvn clean install` / Gradle `clean publishToMavenLocal`.

All three toggles persist like the existing `Full build` setting and are threaded end to end: the `defaultBuildArgs` / `defaultPackageArgs` builders, the `build()` / `packageApp()` lane functions, the `/api/build` and `/api/package` endpoints, the restart path, and the `build_app` / `package_app` agent actions (so the agent can pass `clean` / `install` too). The off/off defaults are byte-for-byte unchanged, so existing behavior is preserved.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Reloaded the extension (clean load, no runtime errors) and exercised every toggle combination against the extracted arg-builders, confirming each emits the expected Maven/Gradle command for both tools.
- [x] Updated `README.md` (Build/Package feature descriptions).
- [x] No secrets committed.

## Notes for reviewers

The Gradle `Install` path maps to `publishToMavenLocal`, the canonical equivalent of `mvn install`. That task requires the `maven-publish` plugin with a configured publication; projects without it will see Gradle report the task as not found. This matches the requested "Gradle equivalent" semantics and is called out in the toggle tooltip.