### PR TITLE
Add "Update to latest version" self-update button

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ wins; when neither is found the console says so and stays disabled until one is 
   project discovery done at launch (build tool, modules, Maven/Spring/Quarkus profiles
   and detected technologies), so changes to the build files show up without reloading
   the extension.
+- **Update to latest version** &mdash; when Coffilot is run from its own git checkout
+  (you cloned it, or forked and cloned it), it checks a minute after launch whether the
+  checkout is behind its remote. If newer commits exist, an **Update to latest version**
+  button appears next to **Refresh**; clicking it runs `git pull --ff-only` and then
+  prompts you to reload the extension and re-open the canvas. The button stays hidden
+  when there's nothing to pull, or when Coffilot was copied into another repository or
+  onto disk without its own `.git`.
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,
   threads, health, profiles and startup info, sourced from the richest endpoint
   available (BootUI → Actuator → Quarkus Micrometer/health → process).

--- a/extension.mjs
+++ b/extension.mjs
@@ -5553,6 +5553,239 @@ async function setLoggerLevel(name, level) {
 }
 
 // ---------------------------------------------------------------------------
+// Self-update — keep a cloned (or forked-and-cloned) Coffilot checkout current
+// ---------------------------------------------------------------------------
+//
+// One minute after launch we check whether the extension's own git checkout is
+// behind its remote and, if so, surface an "Update to latest version" button in
+// the canvas header that runs `git pull`. This only applies when Coffilot was
+// obtained as its own clone — i.e. its files sit at the repository root. When it
+// was copied into another project (e.g. <project>/.github/extensions/coffilot,
+// where the repo root is the *project*, not Coffilot) or copied onto disk
+// without a `.git`, there's nothing safe to pull, so the feature stays dormant
+// and the button never appears.
+
+const EXTENSION_DIR = __dirname;
+
+let updateState = {
+  supported: false, // the extension is a Coffilot git checkout we can update
+  available: false, // a newer commit exists on the tracked remote (behind > 0)
+  checking: false, // a status check is in flight
+  updating: false, // a `git pull` is in flight
+  behind: 0,
+  ahead: 0,
+  branch: null,
+  remoteRef: null, // the remote-tracking ref we compare against, e.g. "origin/main"
+  currentSha: null,
+  remoteSha: null,
+  checkedAt: null, // epoch ms of the last successful check
+  error: null,
+};
+
+function updatePublic() {
+  return { ...updateState };
+}
+
+// Run a git subcommand against a checkout, capturing output. Non-interactive
+// (never block on credential prompts) and time-bounded so a hung network fetch
+// can't wedge the check. Resolves rather than rejects so callers stay simple.
+function runGit(args, { cwd = EXTENSION_DIR, timeout = 25000 } = {}) {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let child;
+    const env = {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: "0", // fail instead of prompting for credentials
+      GIT_OPTIONAL_LOCKS: "0",
+      GCM_INTERACTIVE: "never",
+    };
+    try {
+      child = spawn("git", args, { cwd, env });
+    } catch (e) {
+      resolve({ ok: false, code: null, stdout: "", stderr: String(e?.message || e) });
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }, timeout);
+    timer.unref?.();
+    child.stdout?.on("data", (c) => (stdout += c));
+    child.stderr?.on("data", (c) => (stderr += c));
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      resolve({ ok: false, code: null, stdout: stdout.trim(), stderr: (stderr || String(e?.message || e)).trim() });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ ok: code === 0, code, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+  });
+}
+
+// True when EXTENSION_DIR is the root of its own git checkout (a Coffilot clone),
+// rather than a folder nested inside some other repository. Both paths are
+// realpath-normalized so a symlinked install (clone elsewhere, symlinked into the
+// Copilot extensions dir) still matches.
+async function isCoffilotCheckout() {
+  const top = await runGit(["rev-parse", "--show-toplevel"], { timeout: 8000 });
+  if (!top.ok || !top.stdout) return false;
+  try {
+    return path.resolve(realpathSync(top.stdout)) === path.resolve(realpathSync(EXTENSION_DIR));
+  } catch {
+    return false;
+  }
+}
+
+// Resolve the remote-tracking ref to compare/pull against: the branch's
+// configured upstream (`@{u}`) when set, otherwise `origin/<branch>` when that
+// remote branch exists. Returns null on a detached HEAD or when no matching
+// remote branch is found (e.g. a local-only branch), which leaves the feature
+// dormant — matching what a bare `git pull` could do.
+async function resolveTrackingRef(branch) {
+  const up = await runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], { timeout: 8000 });
+  if (up.ok && up.stdout && up.stdout !== "@{u}") return up.stdout;
+  if (branch && branch !== "HEAD") {
+    const candidate = `origin/${branch}`;
+    const verify = await runGit(["rev-parse", "--verify", "--quiet", candidate], { timeout: 8000 });
+    if (verify.ok && verify.stdout) return candidate;
+  }
+  return null;
+}
+
+// Inspect the extension's checkout and refresh `updateState`. When `doFetch` is
+// true we first `git fetch` the remote so the comparison sees commits pushed
+// after the clone/last fetch. Broadcasts the new state so an open canvas updates
+// live. Safe to call repeatedly; concurrent calls are coalesced.
+async function checkForUpdate({ doFetch = true } = {}) {
+  if (updateState.checking) return updatePublic();
+  updateState.checking = true;
+  broadcast("update", updatePublic());
+  try {
+    if (!(await isCoffilotCheckout())) {
+      updateState = { ...updateState, supported: false, available: false, checking: false, error: null };
+      return updatePublic();
+    }
+
+    const branchRes = await runGit(["rev-parse", "--abbrev-ref", "HEAD"], { timeout: 8000 });
+    const branch = branchRes.ok ? branchRes.stdout : null;
+
+    const remoteRef = await resolveTrackingRef(branch);
+    if (!remoteRef) {
+      updateState = {
+        ...updateState,
+        supported: true,
+        available: false,
+        behind: 0,
+        ahead: 0,
+        branch,
+        remoteRef: null,
+        checking: false,
+        checkedAt: Date.now(),
+        error: null,
+      };
+      return updatePublic();
+    }
+
+    const remote = remoteRef.includes("/") ? remoteRef.slice(0, remoteRef.indexOf("/")) : "origin";
+    let fetchError = null;
+    if (doFetch) {
+      const fetched = await runGit(["fetch", "--quiet", remote], { timeout: 25000 });
+      if (!fetched.ok) fetchError = fetched.stderr || "git fetch failed";
+    }
+
+    const counts = await runGit(["rev-list", "--left-right", "--count", `HEAD...${remoteRef}`], { timeout: 8000 });
+    let ahead = 0;
+    let behind = 0;
+    if (counts.ok && counts.stdout) {
+      const parts = counts.stdout.split(/\s+/);
+      ahead = parseInt(parts[0], 10) || 0;
+      behind = parseInt(parts[1], 10) || 0;
+    }
+    const cur = await runGit(["rev-parse", "--short", "HEAD"], { timeout: 8000 });
+    const rem = await runGit(["rev-parse", "--short", remoteRef], { timeout: 8000 });
+
+    updateState = {
+      ...updateState,
+      supported: true,
+      available: behind > 0,
+      behind,
+      ahead,
+      branch,
+      remoteRef,
+      currentSha: cur.ok ? cur.stdout : null,
+      remoteSha: rem.ok ? rem.stdout : null,
+      checking: false,
+      checkedAt: Date.now(),
+      error: fetchError,
+    };
+    session.log(
+      `[coffilot] update check: ${behind} commit(s) behind ${remoteRef}${fetchError ? ` (fetch: ${fetchError})` : ""}`,
+      { level: "info" },
+    );
+    return updatePublic();
+  } catch (e) {
+    updateState = { ...updateState, checking: false, error: e?.message || String(e) };
+    return updatePublic();
+  } finally {
+    updateState.checking = false;
+    broadcast("update", updatePublic());
+  }
+}
+
+// Pull the latest commit into the extension's checkout. Fast-forward only so a
+// fork that has diverged (local commits the remote doesn't have) fails cleanly
+// with a message instead of creating a merge commit in the user's working copy.
+// On success the on-disk files are newer than the still-running process, so the
+// caller surfaces a "reload the extension" hint. Re-checks status afterward.
+async function performUpdate() {
+  if (updateState.updating) return { ok: false, error: "An update is already in progress.", state: updatePublic() };
+  if (!(await isCoffilotCheckout())) {
+    return {
+      ok: false,
+      error: "Coffilot isn't running from its own git checkout, so it can't self-update.",
+      state: updatePublic(),
+    };
+  }
+  updateState.updating = true;
+  broadcast("update", updatePublic());
+  try {
+    // Pull explicitly from the ref we compared against (e.g. `origin main`) so the
+    // update works even when the branch has no configured upstream but we matched
+    // it via the `origin/<branch>` fallback; fall back to a bare pull otherwise.
+    const ref = updateState.remoteRef;
+    const slash = ref ? ref.indexOf("/") : -1;
+    const pullArgs =
+      ref && slash > 0 ? ["pull", "--ff-only", ref.slice(0, slash), ref.slice(slash + 1)] : ["pull", "--ff-only"];
+    const pull = await runGit(pullArgs, { timeout: 60000 });
+    const output = [pull.stdout, pull.stderr].filter(Boolean).join("\n").trim();
+    session.log(`[coffilot] git ${pullArgs.join(" ")} -> ${pull.ok ? "ok" : "failed"}\n${output}`, {
+      level: pull.ok ? "info" : "warn",
+    });
+    updateState.updating = false;
+    // Refresh behind/ahead from the new HEAD without another network round-trip.
+    await checkForUpdate({ doFetch: false });
+    if (!pull.ok) {
+      return {
+        ok: false,
+        error: output || "git pull failed.",
+        output,
+        state: updatePublic(),
+      };
+    }
+    return { ok: true, output: output || "Already up to date.", state: updatePublic() };
+  } catch (e) {
+    updateState.updating = false;
+    broadcast("update", updatePublic());
+    return { ok: false, error: e?.message || String(e), state: updatePublic() };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Loopback HTTP server (iframe assets + SSE + control + metrics proxy)
 // ---------------------------------------------------------------------------
 
@@ -5648,6 +5881,7 @@ async function handleRequest(req, res) {
       res.write(`event: tests\ndata: ${JSON.stringify(lastTestReport)}\n\n`);
       res.write(`event: debug\ndata: ${JSON.stringify(debugSnapshot())}\n\n`);
       res.write(`event: profile\ndata: ${JSON.stringify(profilePublic())}\n\n`);
+      res.write(`event: update\ndata: ${JSON.stringify(updatePublic())}\n\n`);
     } catch {
       drop();
     }
@@ -5671,6 +5905,7 @@ async function handleRequest(req, res) {
       debug: debugSnapshot(),
       profile: profilePublic(),
       env: envSnapshot(),
+      update: updatePublic(),
     });
     return;
   }
@@ -5897,6 +6132,19 @@ async function handleRequest(req, res) {
     return;
   }
 
+  if (req.method === "GET" && url.pathname === "/api/update/status") {
+    sendJson(res, 200, updatePublic());
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/update/check") {
+    sendJson(res, 200, await checkForUpdate({ doFetch: true }));
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/update") {
+    sendJson(res, 200, await performUpdate());
+    return;
+  }
+
   res.writeHead(404);
   res.end("Not found");
 }
@@ -5938,6 +6186,14 @@ await serverReady;
 // session surfaces the canvas immediately; the UI self-heals via the broadcast
 // env (and its focus refresh / "Check again").
 void refineWorkspaceFromSession();
+
+// One minute after launch, check whether this Coffilot checkout is behind its
+// remote and, if so, light up the header's "Update to latest version" button.
+// Delayed so it never competes with startup work, fetches the network off the
+// hot path, and .unref()'d so the pending timer alone won't keep the process up.
+setTimeout(() => {
+  void checkForUpdate({ doFetch: true });
+}, 60000).unref();
 
 // ---------------------------------------------------------------------------
 // Canvas declaration

--- a/public/app.js
+++ b/public/app.js
@@ -64,6 +64,7 @@ const mvnProfilesCombo = document.getElementById("mvn-profiles-combo");
 const noToolBanner = document.getElementById("no-tool-banner");
 const btnRecheck = document.getElementById("btn-recheck");
 const btnRefresh = document.getElementById("btn-refresh");
+const btnUpdate = document.getElementById("btn-update");
 const warmBanner = document.getElementById("warm-banner");
 const warmMsg = document.getElementById("warm-msg");
 const warmCmd = document.getElementById("warm-cmd");
@@ -2276,6 +2277,11 @@ es.addEventListener("env", (e) => {
   // the refreshed env so the build tool, modules, and banners update live.
   applyEnv(JSON.parse(e.data));
 });
+es.addEventListener("update", (e) => {
+  // Self-update availability is checked ~1 min after launch and after a pull;
+  // reflect it live so the "Update to latest version" button appears/hides.
+  applyUpdateState(JSON.parse(e.data));
+});
 es.addEventListener("reset", (e) => {
   // Clear only the console for the op that's (re)starting; the others keep
   // their last output.
@@ -2313,6 +2319,7 @@ fetch(`/api/state?${qs}`)
     applyEnv(s.env);
     renderDebug(debugSnap, s.status);
     if (s.profile) renderProfileState(s.profile);
+    if (s.update) applyUpdateState(s.update);
     if (s.status && s.status.test) lastRunnerLabel = s.status.test.runnerLabel;
     renderTests(s.tests, { runnerLabel: lastRunnerLabel });
     for (const l of s.console || []) appendLine(l.line, l.stream, l.op);
@@ -2374,6 +2381,67 @@ if (btnRefresh) {
     }
     btnRefresh.classList.remove("is-busy");
     btnRefresh.disabled = false;
+  });
+}
+
+// "Update to latest version": shown only when the extension is its own Coffilot
+// git checkout that's behind its remote. Reflects the backend's update state —
+// available, in-progress, or freshly updated (which needs a reload to take hold).
+let updateApplied = false;
+function applyUpdateState(u) {
+  if (!btnUpdate) return;
+  u = u || {};
+  // Once a pull has succeeded this session, keep the "reload" prompt visible:
+  // the new code only runs after the user reloads the extension, so don't revert
+  // to a plain hidden/available state from a later background check.
+  if (updateApplied) {
+    btnUpdate.hidden = false;
+    return;
+  }
+  if (btnUpdate.classList.contains("is-busy")) return; // mid-pull; leave the button as-is
+  const show = !!u.available;
+  btnUpdate.hidden = !show;
+  if (show) {
+    const n = u.behind || 0;
+    const where = u.remoteRef ? ` on ${u.remoteRef}` : "";
+    btnUpdate.title =
+      n > 0
+        ? `${n} new commit${n === 1 ? "" : "s"} available${where} — click to run "git pull"`
+        : 'A newer version of Coffilot is available — click to run "git pull"';
+  }
+}
+
+if (btnUpdate) {
+  btnUpdate.addEventListener("click", async () => {
+    if (updateApplied) return; // already pulled; waiting for a reload
+    if (btnUpdate.classList.contains("is-busy")) return;
+    btnUpdate.classList.add("is-busy");
+    btnUpdate.disabled = true;
+    const labelEl = btnUpdate.querySelector(".update-btn-label");
+    const prevLabel = labelEl ? labelEl.textContent : "";
+    if (labelEl) labelEl.textContent = "Updating…";
+    appendLine("[canvas] updating Coffilot — running git pull…", "stdout");
+    const res = await postJson("/api/update");
+    btnUpdate.classList.remove("is-busy");
+    if (res && res.ok) {
+      if (res.output) {
+        for (const l of String(res.output).split("\n")) if (l.trim()) appendLine(l, "stdout");
+      }
+      appendLine(
+        "[canvas] Coffilot updated. Reload extensions and re-open this canvas to run the new version.",
+        "stdout",
+      );
+      updateApplied = true;
+      btnUpdate.disabled = true;
+      if (labelEl) labelEl.textContent = "Reload to finish update";
+      btnUpdate.title = "Coffilot was updated on disk. Reload the Copilot extensions and re-open this canvas.";
+      btnUpdate.hidden = false;
+    } else {
+      const err = (res && (res.error || res.output)) || "unknown error";
+      appendLine("[canvas] update failed: " + err, "stderr");
+      btnUpdate.disabled = false;
+      if (labelEl) labelEl.textContent = prevLabel || "Update to latest version";
+    }
   });
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,14 @@
           />
         </svg>
       </button>
+      <button id="btn-update" class="update-btn" hidden title="A newer version of Coffilot is available — pull it now">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path
+            d="M7.47 1.47a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1-1.06 1.06L8.75 3.81v6.44a.75.75 0 0 1-1.5 0V3.81L4.78 6.28a.75.75 0 0 1-1.06-1.06l3.75-3.75ZM2.75 12.5a.75.75 0 0 0 0 1.5h10.5a.75.75 0 0 0 0-1.5H2.75Z"
+          />
+        </svg>
+        <span class="update-btn-label">Update to latest version</span>
+      </button>
     </header>
 
     <div id="no-tool-banner" hidden>

--- a/public/styles.css
+++ b/public/styles.css
@@ -84,6 +84,51 @@ h1 {
 .icon-btn.is-busy svg {
   animation: cof-spin 0.7s linear infinite;
 }
+/* "Update to latest version": appears (to the right of Refresh) only when the
+   extension is a Coffilot git checkout that's behind its remote. Green to read as
+   a safe "go/update" action; collapses to just its icon on a narrow header. */
+.update-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.28rem 0.6rem;
+  font-size: 12px;
+  font-weight: 600;
+  border-color: var(--true-color-green, #1a7f37);
+  color: var(--color-white, #fff);
+  background: var(--true-color-green, #1a7f37);
+}
+.update-btn svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+}
+.update-btn:not(:disabled):hover {
+  background: color-mix(in srgb, #000 14%, var(--true-color-green, #1a7f37));
+  border-color: color-mix(in srgb, #000 14%, var(--true-color-green, #1a7f37));
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+.update-btn:not(:disabled):active {
+  transform: translateY(0) scale(0.96);
+  box-shadow: var(--shadow-sm);
+}
+.update-btn.is-busy,
+.update-btn.is-busy:hover {
+  opacity: 0.9;
+  cursor: progress;
+  transform: none;
+  box-shadow: none;
+}
+.update-btn.is-busy svg {
+  animation: cof-spin 0.7s linear infinite;
+}
+@media (max-width: 560px) {
+  .update-btn-label {
+    display: none;
+  }
+}
 button {
   font: inherit;
   cursor: pointer;


### PR DESCRIPTION
## Summary

Makes it easy to keep a cloned (or forked-and-cloned) Coffilot current without manual git work. One minute after launch, Coffilot checks whether its own checkout is behind its remote (`git fetch` + `git rev-list --left-right --count`). When it is, an **"Update to latest version"** button appears in the canvas header, to the right of **Refresh**. Clicking it runs `git pull --ff-only`, streams the output to the console, and prompts the user to reload the extension and re-open the canvas (the running process keeps the old code until reload).

The feature is intentionally scoped to checkouts it can safely update:

- **Cloned / forked-and-cloned** -> supported. The extension's files sit at the repo root, so `git rev-parse --show-toplevel` (realpath-normalized) equals the extension dir.
- **Copied into another repo** (e.g. `.github/extensions/coffilot`) -> dormant. The repo root is the host project, not Coffilot, so it never tries to pull the user's project.
- **Copied on disk without `.git`** -> dormant. `git` fails, the button never shows.

It pulls explicitly from the resolved remote ref (e.g. `origin main`), using the branch's configured upstream when set and falling back to `origin/<branch>` otherwise, so it works even without tracking info. Forks that diverged (local commits the remote lacks) fail fast on `--ff-only` with a clear message instead of creating a merge commit in the user's working copy.

Backend (`extension.mjs`): a self-update module (`runGit`, `isCoffilotCheckout`, `resolveTrackingRef`, `checkForUpdate`, `performUpdate`), routes `GET /api/update/status`, `POST /api/update/check`, `POST /api/update`, an `update` block in `/api/state` plus the SSE initial replay, and a 60s `.unref()`'d timer. The git runner is non-interactive (`GIT_TERMINAL_PROMPT=0`) and time-bounded so a hung fetch can't wedge the check. Frontend wires the button, live state over SSE, and the click handler.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

Additional automated checks run during development (not committed): a harness against real temp git repos covered clone detect/pull, upstream-advance detection, embedded/loose unsupported cases, fork `--ff-only` refusal, and the no-upstream `origin/<branch>` fallback; a stubbed-SDK boot test exercised the new routes, token gating, and the `/api/state` shape.

## Notes for reviewers

- This dev branch itself won't show the button (it has no upstream and isn't behind), which is the expected dormant behavior. To see it live, reload extensions and re-open the canvas from a `main` checkout that is behind `origin/main`.
- After a successful pull the on-disk files are newer than the still-running Node process, so the button switches to a "Reload to finish update" prompt rather than hot-swapping code.