### PR TITLE
Keep update button quiet and reload prompt persistent

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2420,27 +2420,22 @@ if (btnUpdate) {
     const labelEl = btnUpdate.querySelector(".update-btn-label");
     const prevLabel = labelEl ? labelEl.textContent : "";
     if (labelEl) labelEl.textContent = "Updating…";
-    appendLine("[canvas] updating Coffilot — running git pull…", "stdout");
     const res = await postJson("/api/update");
     btnUpdate.classList.remove("is-busy");
     if (res && res.ok) {
-      if (res.output) {
-        for (const l of String(res.output).split("\n")) if (l.trim()) appendLine(l, "stdout");
-      }
-      appendLine(
-        "[canvas] Coffilot updated. Reload extensions and re-open this canvas to run the new version.",
-        "stdout",
-      );
       updateApplied = true;
-      btnUpdate.disabled = true;
+      // Keep the button visible and enabled as a persistent "reload to finish"
+      // reminder: the pulled code only runs once the extension is reloaded, so a
+      // greyed-out (disabled) button here reads as if the action vanished.
+      btnUpdate.disabled = false;
+      btnUpdate.hidden = false;
       if (labelEl) labelEl.textContent = "Reload to finish update";
       btnUpdate.title = "Coffilot was updated on disk. Reload the Copilot extensions and re-open this canvas.";
-      btnUpdate.hidden = false;
     } else {
       const err = (res && (res.error || res.output)) || "unknown error";
-      appendLine("[canvas] update failed: " + err, "stderr");
       btnUpdate.disabled = false;
       if (labelEl) labelEl.textContent = prevLabel || "Update to latest version";
+      btnUpdate.title = "Update failed: " + err;
     }
   });
 }


### PR DESCRIPTION
## Summary

The header "Update to latest version" button had two rough edges in its post-pull behaviour. It piped the raw `git pull` output (and a couple of status lines) into the canvas console, cluttering the build/run logs with extension-maintenance noise. And once the pull finished it disabled itself, so the green button dropped to 50% opacity via the generic `button:disabled` rule — the "Reload to finish update" prompt effectively looked like it had vanished.

This change keeps the update flow self-contained in the button itself:

- Removes all `appendLine(...)` logging from the update click handler. Success and failure are now communicated through the button label and its tooltip instead of the console (failures surface as `Update failed: <error>` on hover).
- After a successful pull, the button stays visible **and** enabled as a persistent "Reload to finish update" reminder. The pulled code only runs once the extension is reloaded, so a greyed-out button there was misleading. Re-clicks remain harmless no-ops because the existing `updateApplied` guard short-circuits before re-pulling.

Scope is one file (`public/app.js`); no backend or endpoint changes.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (No doc-visible behaviour change.)
- [x] No secrets committed.

## Notes for reviewers

With logging removed, the only feedback channels left are the button label and tooltip — worth a quick look that those read clearly for both the success and failure paths.