### PR TITLE
Rename update button labels for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ wins; when neither is found the console says so and stays disabled until one is 
   project discovery done at launch (build tool, modules, Maven/Spring/Quarkus profiles
   and detected technologies), so changes to the build files show up without reloading
   the extension.
-- **Update to latest version** &mdash; when Coffilot is run from its own git checkout
+- **New version available** &mdash; when Coffilot is run from its own git checkout
   (you cloned it, or forked and cloned it), it checks a minute after launch whether the
-  checkout is behind its remote. If newer commits exist, an **Update to latest version**
+  checkout is behind its remote. If newer commits exist, a **New version available**
   button appears next to **Refresh**; clicking it runs `git pull --ff-only` and then
-  prompts you to reload the extension and re-open the canvas. The button stays hidden
+  prompts you to restart the extension and re-open the canvas. The button stays hidden
   when there's nothing to pull, or when Coffilot was copied into another repository or
   onto disk without its own `.git`.
 - **Live JVM metrics** &mdash; once the app is up, the panel shows heap / non-heap,

--- a/public/app.js
+++ b/public/app.js
@@ -2429,12 +2429,12 @@ if (btnUpdate) {
       // greyed-out (disabled) button here reads as if the action vanished.
       btnUpdate.disabled = false;
       btnUpdate.hidden = false;
-      if (labelEl) labelEl.textContent = "Reload to finish update";
+      if (labelEl) labelEl.textContent = "Restart to finish update";
       btnUpdate.title = "Coffilot was updated on disk. Reload the Copilot extensions and re-open this canvas.";
     } else {
       const err = (res && (res.error || res.output)) || "unknown error";
       btnUpdate.disabled = false;
-      if (labelEl) labelEl.textContent = prevLabel || "Update to latest version";
+      if (labelEl) labelEl.textContent = prevLabel || "New version available";
       btnUpdate.title = "Update failed: " + err;
     }
   });

--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
             d="M7.47 1.47a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1-1.06 1.06L8.75 3.81v6.44a.75.75 0 0 1-1.5 0V3.81L4.78 6.28a.75.75 0 0 1-1.06-1.06l3.75-3.75ZM2.75 12.5a.75.75 0 0 0 0 1.5h10.5a.75.75 0 0 0 0-1.5H2.75Z"
           />
         </svg>
-        <span class="update-btn-label">Update to latest version</span>
+        <span class="update-btn-label">New version available</span>
       </button>
     </header>
 


### PR DESCRIPTION
## Summary

The auto-update affordance used phrasing that read more like an action label than a status. This renames the labels so the available-update state reads as a notification and the follow-up step reads as a restart:

- Header button "Update to latest version" -> "New version available"
- Post-update prompt "Reload to finish update" -> "Restart to finish update"

The fallback label shown when an update fails was updated to match the new default, and the README feature description was aligned with the new wording. No behavior changes; these are text-only edits to `public/index.html`, `public/app.js`, and `README.md`.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

The iframe assets changed, so reload the Copilot extensions and re-open the canvas to see the new labels. The post-update tooltip still uses "Reload the Copilot extensions" wording; left as-is since the request was scoped to the button labels.