### PR TITLE
Keep "Fix with Copilot" buttons prominent, install buttons quiet

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1184,7 +1184,7 @@ async function runScan(tool) {
   mcpResultEl.innerHTML =
     `<div style="display:flex;align-items:center;gap:0.5rem;justify-content:space-between">` +
     `<strong>${esc(tool)}</strong>` +
-    `<button class="fix tiny" id="mcp-send">Fix findings with Copilot</button></div>` +
+    `<button class="fix fix-copilot tiny" id="mcp-send">Fix findings with Copilot</button></div>` +
     `<pre>${esc(text)}</pre>`;
   const send = document.getElementById("mcp-send");
   if (send)

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
         <span id="exit"></span>
         <span id="reload-pill" class="pill" hidden>live reload</span>
         <span id="caps"></span>
-        <button id="btn-fix" class="fix" hidden></button>
+        <button id="btn-fix" class="fix fix-copilot" hidden></button>
       </div>
       <button
         id="btn-refresh"
@@ -309,7 +309,7 @@
                   autocomplete="off"
                 />
                 <button id="btn-flame-reset" class="tiny" hidden title="Reset zoom">Reset zoom</button>
-                <button id="btn-flame-fix" class="fix tiny" hidden style="margin-left: auto">
+                <button id="btn-flame-fix" class="fix fix-copilot tiny" hidden style="margin-left: auto">
                   Analyze hotspots with Copilot
                 </button>
               </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -212,6 +212,17 @@ button.fix:hover {
   background: color-mix(in srgb, var(--text-color-default, #1f2328) 6%, var(--background-color-muted, #f6f8fa));
   border-color: var(--text-color-muted, #8c959f);
 }
+/* Genuine "Fix/Analyze … with Copilot" CTAs stay prominent (bright orange) so
+   they stand out from the quiet, neutral install/setup .fix buttons. */
+button.fix.fix-copilot {
+  border-color: var(--true-color-orange, #bc4c00);
+  color: var(--color-white, #fff);
+  background: var(--true-color-orange, #bc4c00);
+}
+button.fix.fix-copilot:hover {
+  background: color-mix(in srgb, #000 14%, var(--true-color-orange, #bc4c00));
+  border-color: color-mix(in srgb, #000 14%, var(--true-color-orange, #bc4c00));
+}
 button.tiny {
   padding: 0.15rem 0.5rem;
   font-size: 12px;


### PR DESCRIPTION
## Summary

A previous change (#47) softened every `.fix` button to a neutral grey so the secondary install/setup actions would recede. That also dimmed the genuine "Fix with Copilot" call-to-action buttons, which are meant to stand out.

This restores the distinction by adding a `fix-copilot` modifier that brings back the bright orange fill (and hover) for the three real Copilot CTAs, while leaving the quiet neutral `.fix` style as the baseline for everything else.

- **Prominent (orange):** Fix with Copilot (`btn-fix`), Analyze hotspots with Copilot (`btn-flame-fix`), Fix findings with Copilot (`mcp-send`).
- **Quiet (neutral):** Add BootUI, Add DevTools, Set up JDTLS, Check again, Register MCP.

The CTAs keep the `fix` class, so the existing pop-in animation and hover-lift behaviour still apply unchanged.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

## Notes for reviewers

`button.primary` was already in use (green), so the new modifier is scoped as `button.fix.fix-copilot` rather than reusing a generic `primary` name.