### PR TITLE
Smooth out tab-switch jitter in the canvas tab bar

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1005,6 +1005,12 @@ aside h2 {
 /* Tabs */
 .tabs {
   display: flex;
+  /* Bottom-anchor the tabs so the active tab's `margin-bottom: -1px` overhang
+     (which hides the strip's bottom border to connect the tab to its pane) just
+     overhangs instead of restretching the whole flex line. Under the default
+     `stretch`, toggling that negative margin recomputed the line height and
+     nudged every tab a subpixel — the "dancing bar" on each tab switch. */
+  align-items: flex-end;
   gap: 0.25rem;
   padding: 0.4rem 1rem 0;
   border-bottom: 1px solid var(--border-color-default, #d0d7de);
@@ -1024,7 +1030,8 @@ aside h2 {
   transition:
     color var(--dur-fast) var(--ease-out),
     background-color var(--dur-fast) var(--ease-out),
-    border-color var(--dur-fast) var(--ease-out);
+    border-color var(--dur-fast) var(--ease-out),
+    margin-bottom var(--dur-fast) var(--ease-out);
 }
 .tab svg {
   width: 15px;


### PR DESCRIPTION
## Summary

Switching top-level tabs (Build / Test / Package / Run / Debug) made the tab strip's bottom border visibly jitter, a "dancing bar" on each click.

The active tab connects to its pane via `margin-bottom: -1px`, which overhangs and hides the strip's bottom border. Under the flex container's default `align-items: stretch`, toggling that negative margin between tabs forced the flex line to recompute its height, nudging every tab and the bottom border by a subpixel on each switch.

The fix bottom-anchors the strip with `align-items: flex-end`, so the active tab's `-1px` overhang just covers the border instead of restretching the whole row (siblings and the bar stay put). It also adds `margin-bottom` to the `.tab` transition so the 1px overhang slides smoothly in sync with the existing color crossfade.

The other tab strips (`.subtabs`, `.aside-tabs`) already use a constant-width underline with no margin overlap, so they were stable and left untouched.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A - CSS polish only, no behaviour change.)
- [x] No secrets committed.

## Notes for reviewers

CSS-only change in `public/styles.css`. The reduced-motion guard at the end of the file already neutralizes the new transition, so no extra handling was needed there.