### PR TITLE
Add integration tests that drive Coffilot against the sample projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
             tool: maven
           - project: quarkus-rest
             tool: maven
+          - project: failing-tests
+            tool: maven
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -74,10 +76,12 @@ jobs:
           java-version: 17
           cache: ${{ matrix.tool }}
 
-      # Drives Coffilot end-to-end: actually builds & tests the project with its
-      # own wrapper, then runs the produced JUnit reports through Coffilot's own
-      # report discovery + parser (collectSurefireReport) and asserts the results.
-      - name: Build, test & validate Coffilot parsing
+      # Drives Coffilot end-to-end: actually builds, tests and packages the
+      # project with its own wrapper using Coffilot's own lane commands, then runs
+      # the produced JUnit reports through Coffilot's own report discovery + parser
+      # (collectSurefireReport) and asserts the results. The failing-tests shard
+      # also covers the failure path (build exits non-zero, report still parses).
+      - name: Build, test, package & validate Coffilot parsing
         env:
           COFFILOT_E2E: "1"
         run: node --test --test-name-pattern "^${{ matrix.project }}:" test/e2e-projects.test.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           node -e "const m = require('./copilot-extension.json'); if (m.name !== 'coffilot' || m.version !== 1) { throw new Error('bad manifest ' + JSON.stringify(m)); }"
 
-  integration-projects:
-    name: Integration project (${{ matrix.project }})
+  e2e-projects:
+    name: E2E (${{ matrix.project }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,6 +62,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -69,12 +74,10 @@ jobs:
           java-version: 17
           cache: ${{ matrix.tool }}
 
-      - name: Build & test (Maven)
-        if: matrix.tool == 'maven'
-        working-directory: integration-tests/${{ matrix.project }}
-        run: ./mvnw -ntp -B test
-
-      - name: Build & test (Gradle)
-        if: matrix.tool == 'gradle'
-        working-directory: integration-tests/${{ matrix.project }}
-        run: ./gradlew test --no-daemon
+      # Drives Coffilot end-to-end: actually builds & tests the project with its
+      # own wrapper, then runs the produced JUnit reports through Coffilot's own
+      # report discovery + parser (collectSurefireReport) and asserts the results.
+      - name: Build, test & validate Coffilot parsing
+        env:
+          COFFILOT_E2E: "1"
+        run: node --test --test-name-pattern "^${{ matrix.project }}:" test/e2e-projects.test.mjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,10 @@ Run `npm run format` to apply formatting. The whole repo is Prettier-formatted
 ### Testing
 
 Tests live under `test/` and run on Node's built-in test runner (`node --test`,
-no extra framework) via `npm test`. CI runs the same command.
+no extra framework) via `npm test`. The `test` script lists the test files
+explicitly (rather than relying on directory discovery) so a local
+`integration-tests/**` build tree can never be mistaken for a test file — add new
+test files to that list. CI runs the same command.
 
 - **`test/parsers.test.mjs`** exercises the pure parsers / normalizers exported
   from `extension.mjs` — the JUnit/Surefire XML parser, the `.class`
@@ -120,9 +123,28 @@ no extra framework) via `npm test`. CI runs the same command.
   `renderTests`) on representative payloads to catch parse errors and obvious
   render regressions. Manual verification in a live canvas is still expected for
   UI changes.
+- **`test/integration-projects.test.mjs`** drives Coffilot's real
+  project-classification logic (build-tool detection, capability/tier
+  classification, run-mode inference, project-root resolution) against the actual
+  build files of every project under `integration-tests/`, asserting the tier each
+  scenario is meant to exercise. Deterministic — no JDK or network — so it runs as
+  part of `npm test`.
+- **`test/e2e-projects.test.mjs`** is the realistic pass: it actually builds and
+  tests each `integration-tests/` project with its own wrapper, then feeds the
+  JUnit reports the build produced through Coffilot's own report discovery +
+  parser (`collectSurefireReport`) and asserts the parsed results. It needs a
+  JDK 17 and network access, so it is **skipped unless `COFFILOT_E2E=1`**:
 
-CI additionally builds and tests each project under `integration-tests/` (Maven
-and Gradle) so the tiers Coffilot drives stay green.
+  ```bash
+  COFFILOT_E2E=1 npm test                     # all projects
+  COFFILOT_E2E=1 node --test \
+    --test-name-pattern '^hello-world:' \
+    test/e2e-projects.test.mjs                # one project
+  ```
+
+CI runs the end-to-end tests per project in a dedicated `E2E (<project>)` matrix
+job (JDK 17 + `COFFILOT_E2E=1`), so the tiers Coffilot drives stay green against
+real Maven and Gradle builds.
 
 ## Safety notes when testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,20 @@ test files to that list. CI runs the same command.
   project-classification logic (build-tool detection, capability/tier
   classification, run-mode inference, project-root resolution) against the actual
   build files of every project under `integration-tests/`, asserting the tier each
-  scenario is meant to exercise. Deterministic — no JDK or network — so it runs as
-  part of `npm test`.
-- **`test/e2e-projects.test.mjs`** is the realistic pass: it actually builds and
-  tests each `integration-tests/` project with its own wrapper, then feeds the
-  JUnit reports the build produced through Coffilot's own report discovery +
-  parser (`collectSurefireReport`) and asserts the parsed results. It needs a
-  JDK 17 and network access, so it is **skipped unless `COFFILOT_E2E=1`**:
+  scenario is meant to exercise. It also asserts Coffilot's lane command builders
+  (`buildArgsFor` / `testArgsFor` / `packageArgsFor` / `affectedTestArgsFor`) for
+  both Maven and Gradle, so the documented per-lane command vectors can't silently
+  drift. Deterministic — no JDK or network — so it runs as part of `npm test`.
+- **`test/e2e-projects.test.mjs`** is the realistic pass: it actually builds,
+  tests and packages each `integration-tests/` project with its own wrapper —
+  using Coffilot's own lane commands (`testArgsFor` / `buildArgsFor` /
+  `packageArgsFor`) rather than a hand-maintained copy — then feeds the JUnit
+  reports the build produced through Coffilot's own report discovery + parser
+  (`collectSurefireReport`) and asserts the parsed results. The `failing-tests`
+  project covers the failure path (build exits non-zero, report still parses with
+  the right pass/fail/error split), and two projects additionally assert the Build
+  and Package lanes each produce a jar. It needs a JDK 17 and network access, so it
+  is **skipped unless `COFFILOT_E2E=1`**:
 
   ```bash
   COFFILOT_E2E=1 npm test                     # all projects

--- a/extension.mjs
+++ b/extension.mjs
@@ -3420,7 +3420,60 @@ function computeAffectedTests() {
 
 // Build the runner args that execute only `tests` (array of { fqcn, module }).
 function affectedTestArgs(tests, warm) {
-  if (buildTool === "gradle") {
+  return affectedTestArgsFor(buildTool, tests, warm);
+}
+
+// Default argument vectors per lane, per tool. `warm` only affects Gradle (daemon
+// vs --no-daemon); Maven's warm tier swaps the binary (mvnd) instead. `clean`
+// prepends a clean goal (Build/Package "Clean" toggle); `install` (Package only)
+// installs the artifact to the local repository instead of just packaging it.
+//
+// The arg-building logic is split into pure `*For(tool, …)` helpers (exported so
+// tests — and the integration/E2E harness — drive the exact same command vectors
+// Coffilot runs) and thin module-level wrappers that bind the current buildTool.
+function defaultBuildArgs(warm, clean) {
+  return buildArgsFor(buildTool, warm, clean);
+}
+function defaultTestArgs(warm) {
+  return testArgsFor(buildTool, warm);
+}
+function defaultPackageArgs(warm, clean, install) {
+  return packageArgsFor(buildTool, warm, clean, install);
+}
+
+/** Build lane args for `tool` ("maven"|"gradle"). See defaultBuildArgs. */
+export function buildArgsFor(tool, warm = false, clean = false) {
+  if (tool === "gradle") {
+    const goals = clean ? ["clean", "build"] : ["build"];
+    return [...goals, "-x", "test", "--console=plain", ...gradleWarmFlags(warm)];
+  }
+  const goals = clean ? ["clean", "install"] : ["install"];
+  return ["-ntp", "-DskipTests", ...goals];
+}
+
+/** Test lane args for `tool`. cleanTest forces Gradle to always re-run (fresh report). */
+export function testArgsFor(tool, warm = false) {
+  if (tool === "gradle") return ["cleanTest", "test", "--console=plain", ...gradleWarmFlags(warm)];
+  return ["-ntp", "test"];
+}
+
+/** Package lane args for `tool`. `install` publishes to the local repository. */
+export function packageArgsFor(tool, warm = false, clean = false, install = false) {
+  if (tool === "gradle") {
+    // `publishToMavenLocal` is the Gradle equivalent of `mvn install` (requires
+    // the maven-publish plugin with a configured publication).
+    const goal = install ? "publishToMavenLocal" : "assemble";
+    const goals = clean ? ["clean", goal] : [goal];
+    return [...goals, "--console=plain", ...gradleWarmFlags(warm)];
+  }
+  const goal = install ? "install" : "package";
+  const goals = clean ? ["clean", goal] : [goal];
+  return ["-ntp", ...goals];
+}
+
+/** Affected-test args for `tool`: run only `tests` (array of { fqcn, module }). */
+export function affectedTestArgsFor(tool, tests, warm = false) {
+  if (tool === "gradle") {
     // List each owning module's `test` task so a global --tests filter never hits
     // a task with zero matches (which Gradle treats as an error). Every listed
     // module owns ≥1 of the patterns, so each task matches at least one test.
@@ -3435,37 +3488,6 @@ function affectedTestArgs(tests, warm) {
   // from failing the run.
   const simple = [...new Set(tests.map((t) => enclosingClass(t.fqcn).split(".").pop()))];
   return ["-ntp", `-Dtest=${simple.join(",")}`, "-Dsurefire.failIfNoSpecifiedTests=false", "test"];
-}
-
-// Default argument vectors per lane, per tool. `warm` only affects Gradle (daemon
-// vs --no-daemon); Maven's warm tier swaps the binary (mvnd) instead. `clean`
-// prepends a clean goal (Build/Package "Clean" toggle); `install` (Package only)
-// installs the artifact to the local repository instead of just packaging it.
-function defaultBuildArgs(warm, clean) {
-  if (buildTool === "gradle") {
-    const goals = clean ? ["clean", "build"] : ["build"];
-    return [...goals, "-x", "test", "--console=plain", ...gradleWarmFlags(warm)];
-  }
-  const goals = clean ? ["clean", "install"] : ["install"];
-  return ["-ntp", "-DskipTests", ...goals];
-}
-function defaultTestArgs(warm) {
-  // cleanTest forces Gradle to re-run tests even when nothing changed, so the
-  // canvas always produces a fresh report (mirroring Maven's always-run test).
-  if (buildTool === "gradle") return ["cleanTest", "test", "--console=plain", ...gradleWarmFlags(warm)];
-  return ["-ntp", "test"];
-}
-function defaultPackageArgs(warm, clean, install) {
-  if (buildTool === "gradle") {
-    // `publishToMavenLocal` is the Gradle equivalent of `mvn install` (requires
-    // the maven-publish plugin with a configured publication).
-    const goal = install ? "publishToMavenLocal" : "assemble";
-    const goals = clean ? ["clean", goal] : [goal];
-    return [...goals, "--console=plain", ...gradleWarmFlags(warm)];
-  }
-  const goal = install ? "install" : "package";
-  const goals = clean ? ["clean", goal] : [goal];
-  return ["-ntp", ...goals];
 }
 
 async function build(extraArgs, warm, mavenProfiles, clean) {

--- a/extension.mjs
+++ b/extension.mjs
@@ -293,7 +293,7 @@ function quoteWinShellArgs(args) {
 }
 
 /** Decide the build tool for a project root: Maven preferred, else Gradle, else null. */
-function detectBuildTool(root) {
+export function detectBuildTool(root) {
   const has = (f) => existsSync(path.join(root, f));
   if (MAVEN_MARKERS.some(has)) return "maven";
   if (GRADLE_MARKERS.some(has)) return "gradle";
@@ -1203,7 +1203,7 @@ async function getSessionPrimaryDir() {
   return null;
 }
 
-function findProjectRoot(primary) {
+export function findProjectRoot(primary) {
   const markers = [...MAVEN_MARKERS, ...GRADLE_MARKERS];
   const owns = (dir) => markers.some((f) => existsSync(path.join(dir, f)));
   // Walk up from `start` (max 8 hops) to the first directory that owns a Maven or
@@ -1477,7 +1477,7 @@ function pomMainClass(xml) {
 }
 
 // Per-pom capability flags, derived purely from the pom text (cheap + offline).
-function pomCaps(xml, name) {
+export function pomCaps(xml, name) {
   const quarkus = /quarkus-maven-plugin|io\.quarkus/.test(xml);
   return {
     name,
@@ -1522,7 +1522,7 @@ function gradleHasApplicationPlugin(text) {
 // Per-build-file capability flags for Gradle, derived from the build script text
 // (Groovy or Kotlin DSL). Spring Boot and Quarkus are detected from their Gradle
 // plugin ids (org.springframework.boot / io.quarkus).
-function gradleCaps(text, name) {
+export function gradleCaps(text, name) {
   const quarkus = text.includes("io.quarkus");
   return {
     name,
@@ -1537,6 +1537,16 @@ function gradleCaps(text, name) {
   };
 }
 
+// The run strategy for a module, inferred from its capability flags: Quarkus
+// (quarkus:dev / quarkusDev) and Spring Boot (spring-boot:run / bootRun) are both
+// "runnable"; anything else is launched as plain Java. Pure so the Run lane and
+// the integration tests agree on how each framework maps to a run mode.
+export function inferRunMode(mod) {
+  if (mod && mod.quarkus) return "quarkus";
+  if (mod && mod.runnable) return "spring";
+  return "java";
+}
+
 // The project's own artifactId (skip the <parent> block so we don't read the
 // parent/BOM artifactId by mistake). Used as a display label for the root module.
 function artifactIdOf(xml) {
@@ -1546,7 +1556,7 @@ function artifactIdOf(xml) {
 }
 
 /** Read a module's Gradle build script (Groovy or Kotlin DSL), or null if absent. */
-function readGradleBuildFile(dir) {
+export function readGradleBuildFile(dir) {
   for (const f of ["build.gradle", "build.gradle.kts"]) {
     try {
       return readFileSync(path.join(dir, f), "utf8");
@@ -3788,10 +3798,9 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
   broadcastProfile();
 
   // Pick the run strategy: explicit mode wins, else infer from the chosen
-  // module's framework — Quarkus (quarkus:dev / quarkusDev) and Spring Boot
-  // (spring-boot:run / bootRun) are both "runnable"; anything else is plain Java.
+  // module's framework (see inferRunMode).
   const mod = listModules().find((m) => m.name === module);
-  const inferred = mod && mod.quarkus ? "quarkus" : mod && mod.runnable ? "spring" : "java";
+  const inferred = inferRunMode(mod);
   const resolved = mode === "java" || mode === "spring" || mode === "quarkus" ? mode : inferred;
   app.runMode = resolved;
   app.module = module || "";
@@ -4847,12 +4856,12 @@ function xmlAttr(tag, name) {
  * {@code sinceMs} filters out stale reports left by earlier builds of other
  * modules so only the freshly-run module's results are reported.
  */
-async function collectSurefireReport(sinceMs) {
+export async function collectSurefireReport(sinceMs, root = workspacePath) {
   const report = {
     summary: { tests: 0, passed: 0, failures: 0, errors: 0, skipped: 0, timeSec: 0, files: 0 },
     suites: [],
   };
-  const dirs = await findTestResultDirs(workspacePath, 0);
+  const dirs = await findTestResultDirs(root, 0);
   for (const dir of dirs) {
     let files;
     try {
@@ -4976,7 +4985,7 @@ const SKIP_DIRS = new Set(["node_modules", ".git", ".m2", ".gradle", "src", "fro
 // Collect every directory that may hold JUnit TEST-*.xml: Maven's
 // target/surefire-reports + failsafe-reports, and Gradle's
 // build/test-results/<task> subfolders.
-async function findTestResultDirs(root, depth, acc = []) {
+export async function findTestResultDirs(root, depth, acc = []) {
   if (depth > 4) return acc;
   let entries;
   try {

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,7 +1,7 @@
 # Coffilot integration-test projects
 
-Six **independent** projects used to exercise Coffilot against every capability
-tier it supports. Five are Maven and one is Gradle, so both build tools get real
+Seven **independent** projects used to exercise Coffilot against every capability
+tier it supports. Six are Maven and one is Gradle, so both build tools get real
 coverage. Each folder is a self-contained project with its own wrapper (`./mvnw`
 or `./gradlew`) — none of them depend on each other or on this repo's Node tooling.
 
@@ -16,6 +16,7 @@ rung of that ladder:
 | [`spring-mvc-actuator-devtools`](spring-mvc-actuator-devtools) | Same app + Actuator + DevTools | **Actuator** — richer live metrics via `/actuator` |
 | [`spring-mvc-bootui`](spring-mvc-bootui) | Same app with BootUI in a `dev` Maven profile | **BootUI** — richest metrics + advisor scan |
 | [`quarkus-rest`](quarkus-rest) | Quarkus REST app with SmallRye Health + Micrometer/Prometheus | **Quarkus** — Run via `quarkus:dev` + live metrics from `/q/metrics` & `/q/health` |
+| [`failing-tests`](failing-tests) | Plain Maven project whose JUnit suite has a pass, a failure and an error | **Failure path** — Test lane parses a real report with failures/errors |
 
 The three Spring projects were generated with
 [start.spring.io](https://start.spring.io) (Maven, Java 17, Spring Boot 4.1) and
@@ -105,6 +106,8 @@ Then open a Copilot session on that project, reload extensions, and open the
 - `spring-mvc-actuator-devtools` for the Actuator metrics tier.
 - `spring-mvc-bootui` (run with `-Pdev`) for the full BootUI metrics + advisor scan.
 - `quarkus-rest` for the Quarkus Run lane (`quarkus:dev`) and the Quarkus metrics tier.
+- `failing-tests` to see the Test lane surface a failing + erroring suite (and to drive
+  "Fix with Copilot" from a real failure).
 
 ## Automated tests against these projects
 
@@ -114,13 +117,17 @@ Coffilot's own test suite drives these projects on two levels (see `test/`):
   `npm test`. They point Coffilot's real build-tool detection, capability/tier
   classification, run-mode inference and project-root resolution at each project's
   actual build files and assert the tier each scenario in the table above is meant
-  to exercise. They are deterministic and need no JDK or network.
+  to exercise. The same file also asserts Coffilot's lane command builders
+  (Build / Test / Package / affected-test args) for both Maven and Gradle. They are
+  deterministic and need no JDK or network.
 
-- **End-to-end tests** (`test/e2e-projects.test.mjs`) actually build and test each
-  project with its own wrapper, then feed the JUnit reports the build produced
-  through Coffilot's own report discovery + parser and assert the parsed results.
-  They need a JDK 17 and network access, so they are **skipped unless
-  `COFFILOT_E2E=1`** is set:
+- **End-to-end tests** (`test/e2e-projects.test.mjs`) actually build, test and
+  package each project with its own wrapper — using Coffilot's own lane commands —
+  then feed the JUnit reports the build produced through Coffilot's own report
+  discovery + parser and assert the parsed results. `failing-tests` additionally
+  covers the failure path: the build exits non-zero, yet the report still parses
+  with the right pass/fail/error split. They need a JDK 17 and network access, so
+  they are **skipped unless `COFFILOT_E2E=1`** is set:
 
   ```bash
   COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -105,3 +105,26 @@ Then open a Copilot session on that project, reload extensions, and open the
 - `spring-mvc-actuator-devtools` for the Actuator metrics tier.
 - `spring-mvc-bootui` (run with `-Pdev`) for the full BootUI metrics + advisor scan.
 - `quarkus-rest` for the Quarkus Run lane (`quarkus:dev`) and the Quarkus metrics tier.
+
+## Automated tests against these projects
+
+Coffilot's own test suite drives these projects on two levels (see `test/`):
+
+- **Detection tests** (`test/integration-projects.test.mjs`) run as part of
+  `npm test`. They point Coffilot's real build-tool detection, capability/tier
+  classification, run-mode inference and project-root resolution at each project's
+  actual build files and assert the tier each scenario in the table above is meant
+  to exercise. They are deterministic and need no JDK or network.
+
+- **End-to-end tests** (`test/e2e-projects.test.mjs`) actually build and test each
+  project with its own wrapper, then feed the JUnit reports the build produced
+  through Coffilot's own report discovery + parser and assert the parsed results.
+  They need a JDK 17 and network access, so they are **skipped unless
+  `COFFILOT_E2E=1`** is set:
+
+  ```bash
+  COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs
+  ```
+
+  CI runs them per project in the `E2E (<project>)` matrix job.
+

--- a/integration-tests/failing-tests/.gitignore
+++ b/integration-tests/failing-tests/.gitignore
@@ -1,0 +1,19 @@
+target/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### VS Code ###
+.vscode/

--- a/integration-tests/failing-tests/.mvn/wrapper/maven-wrapper.properties
+++ b/integration-tests/failing-tests/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/integration-tests/failing-tests/mvnw
+++ b/integration-tests/failing-tests/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/integration-tests/failing-tests/mvnw.cmd
+++ b/integration-tests/failing-tests/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/integration-tests/failing-tests/pom.xml
+++ b/integration-tests/failing-tests/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>failing-tests</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>failing-tests</name>
+    <description>Plain Maven project whose JUnit 5 suite has a passing test, an assertion failure and an error, so Coffilot's failure parsing is exercised against a real Surefire report</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+        <junit.version>5.11.4</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>failing-tests</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.example.failing.Calculator</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/failing-tests/src/main/java/com/example/failing/Calculator.java
+++ b/integration-tests/failing-tests/src/main/java/com/example/failing/Calculator.java
@@ -1,0 +1,16 @@
+package com.example.failing;
+
+public class Calculator {
+
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    public int divide(int a, int b) {
+        return a / b;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("2 + 3 = " + new Calculator().add(2, 3));
+    }
+}

--- a/integration-tests/failing-tests/src/test/java/com/example/failing/CalculatorTest.java
+++ b/integration-tests/failing-tests/src/test/java/com/example/failing/CalculatorTest.java
@@ -1,0 +1,29 @@
+package com.example.failing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+// Deliberately mixed suite: one passing test, one assertion FAILURE and one
+// ERROR (uncaught exception). It exists so Coffilot's report discovery + parser
+// (collectSurefireReport / parseSurefireSuiteXml) is exercised against a real
+// Surefire report that contains failures and errors, not just green runs.
+class CalculatorTest {
+
+    @Test
+    void addsTwoNumbers() {
+        assertEquals(5, new Calculator().add(2, 3));
+    }
+
+    @Test
+    void failsOnPurpose() {
+        // Wrong expectation on purpose -> recorded as a <failure> in the report.
+        assertEquals(42, new Calculator().add(2, 3), "add should equal 42 (intentionally wrong)");
+    }
+
+    @Test
+    void errorsOnPurpose() {
+        // Division by zero throws -> recorded as an <error> in the report.
+        new Calculator().divide(1, 0);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "check": "node --check extension.mjs",
-    "test": "node --test",
+    "test": "node --test test/parsers.test.mjs test/ui-smoke.test.mjs test/integration-projects.test.mjs test/e2e-projects.test.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/test/e2e-projects.test.mjs
+++ b/test/e2e-projects.test.mjs
@@ -1,24 +1,27 @@
-// End-to-end integration tests: actually build and test each sample project in
-// integration-tests/ with its own wrapper (./mvnw / ./gradlew), then feed the
-// real JUnit reports the build produced through Coffilot's own report-discovery +
-// parsing pipeline (collectSurefireReport) and assert the parsed results.
+// End-to-end integration tests: actually build, test and package each sample
+// project in integration-tests/ with its own wrapper (./mvnw / ./gradlew), then
+// feed the real JUnit reports the build produced through Coffilot's own
+// report-discovery + parsing pipeline (collectSurefireReport) and assert the
+// parsed results. The command vectors come from Coffilot's own lane arg builders
+// (testArgsFor / buildArgsFor / packageArgsFor), so the harness runs exactly what
+// the Test / Build / Package lanes run — not a hand-maintained copy.
 //
 // This is the "realistic" pass — it needs a JDK 17 and network access (the
 // wrappers download Maven/Gradle and dependencies), so it is SKIPPED unless
-// COFFILOT_E2E=1 is set. The fast, deterministic detection tests live in
-// integration-projects.test.mjs and always run.
+// COFFILOT_E2E=1 is set. The fast, deterministic detection + arg-builder tests
+// live in integration-projects.test.mjs and always run.
 //
 //   COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 process.env.COFFILOT_TEST = "1";
 
-const { collectSurefireReport } = await import("../extension.mjs");
+const { collectSurefireReport, testArgsFor, buildArgsFor, packageArgsFor } = await import("../extension.mjs");
 
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const projectsDir = path.join(repoRoot, "integration-tests");
@@ -27,28 +30,19 @@ const E2E = !!process.env.COFFILOT_E2E;
 const SKIP = E2E ? false : "set COFFILOT_E2E=1 (needs JDK 17 + network) to run end-to-end builds";
 const isWindows = process.platform === "win32";
 
-// Per-tool wrapper + test goal. These mirror what Coffilot's Test lane runs
-// (defaultTestArgs): `mvn test` for Maven, `cleanTest test` for Gradle (which
-// forces a re-run so a fresh report is always produced). -B / --console=plain
-// keep the output non-interactive in CI.
-function testCommand(tool) {
-  if (tool === "gradle") {
-    return {
-      wrapper: isWindows ? "gradlew.bat" : "gradlew",
-      args: ["cleanTest", "test", "--console=plain", "--no-daemon"],
-    };
-  }
-  return { wrapper: isWindows ? "mvnw.cmd" : "mvnw", args: ["-ntp", "-B", "test"] };
+// The build wrapper filename for a tool. Args come from Coffilot's lane builders.
+function wrapperFor(tool) {
+  if (tool === "gradle") return isWindows ? "gradlew.bat" : "gradlew";
+  return isWindows ? "mvnw.cmd" : "mvnw";
 }
 
-// Run a build wrapper in a project directory, resolving with its exit code. The
-// child's output is captured and only surfaced (via the rejection / assertion
-// message) when the build fails, to keep passing runs quiet.
-function runBuild(dir, tool) {
-  const { wrapper, args } = testCommand(tool);
-  // Use the wrapper's absolute path: a relative executable is resolved against
-  // the parent process cwd (not the spawn `cwd`), so join it onto the project dir.
-  const bin = path.join(dir, wrapper);
+// Run a project's wrapper with the given args, resolving { code, out }. The
+// child's output is captured and only surfaced (via the assertion message) when
+// the build fails, to keep passing runs quiet. A relative executable is resolved
+// against the parent process cwd (not the spawn `cwd`), so join the wrapper onto
+// the project dir to get an absolute path.
+function runWrapper(dir, tool, args) {
+  const bin = path.join(dir, wrapperFor(tool));
   return new Promise((resolve, reject) => {
     const child = spawn(bin, args, { cwd: dir, env: process.env });
     let out = "";
@@ -63,9 +57,20 @@ function runBuild(dir, tool) {
   });
 }
 
+// Where each tool drops its packaged artifact (relative to the project dir).
+function artifactDir(tool) {
+  return tool === "gradle" ? path.join("build", "libs") : "target";
+}
+function hasJar(dir, tool) {
+  const d = path.join(dir, artifactDir(tool));
+  return existsSync(d) && readdirSync(d).some((f) => f.endsWith(".jar"));
+}
+
 // Expected real-build outcome per project. tests/files are exact for these
 // controlled fixtures (see integration-tests/README.md); suites lists class-name
-// suffixes that must appear in the parsed report.
+// suffixes that must appear in the parsed report. By default a project's tests
+// all pass and the build exits 0; failing-tests overrides those to exercise the
+// failure path. `cases` pins specific test-method -> status pairs.
 const SCENARIOS = [
   { project: "hello-world", tool: "maven", tests: 1, files: 1, suites: ["AppTest"] },
   { project: "gradle-hello-world", tool: "gradle", tests: 1, files: 1, suites: ["AppTest"] },
@@ -97,6 +102,29 @@ const SCENARIOS = [
     files: 2,
     suites: ["GreetingResourceTest", "GreetingResourceUnitTest"],
   },
+  {
+    // The failure path: the build exits non-zero, but Surefire still writes a
+    // report that Coffilot must discover and parse with the right pass/fail/error
+    // split (this is what drives the graphical test view + "Fix with Copilot").
+    project: "failing-tests",
+    tool: "maven",
+    tests: 3,
+    files: 1,
+    suites: ["CalculatorTest"],
+    failures: 1,
+    errors: 1,
+    passed: 1,
+    buildShouldFail: true,
+    cases: { addsTwoNumbers: "passed", failsOnPurpose: "failed", errorsOnPurpose: "error" },
+  },
+];
+
+// Build/Package lane coverage: for one Maven and one Gradle project, drive the
+// real Build and Package lane commands and assert each produces a jar artifact.
+// Kept to the two tiny plain projects so CI stays fast.
+const LIFECYCLE = [
+  { project: "hello-world", tool: "maven" },
+  { project: "gradle-hello-world", tool: "gradle" },
 ];
 
 // Builds pull the toolchain + dependencies over the network on a cold cache, so
@@ -105,15 +133,23 @@ const BUILD_TIMEOUT_MS = 15 * 60 * 1000;
 
 for (const s of SCENARIOS) {
   const dir = path.join(projectsDir, s.project);
+  const failures = s.failures ?? 0;
+  const errors = s.errors ?? 0;
+  const passed = s.passed ?? s.tests;
 
   test(
-    `${s.project}: builds, tests and Coffilot parses the real report`,
+    `${s.project}: Test lane builds and Coffilot parses the real report`,
     { skip: SKIP, timeout: BUILD_TIMEOUT_MS },
     async () => {
       assert.ok(existsSync(dir), `missing integration project: ${dir}`);
 
-      const { code, out } = await runBuild(dir, s.tool);
-      assert.equal(code, 0, `${s.project} build/test failed (exit ${code}):\n${out.slice(-4000)}`);
+      // Run exactly what Coffilot's Test lane runs (cold: no Gradle daemon).
+      const { code, out } = await runWrapper(dir, s.tool, testArgsFor(s.tool));
+      if (s.buildShouldFail) {
+        assert.notEqual(code, 0, `${s.project}: expected the test build to fail, but it exited 0`);
+      } else {
+        assert.equal(code, 0, `${s.project} build/test failed (exit ${code}):\n${out.slice(-4000)}`);
+      }
 
       // Drive Coffilot's actual discovery + parsing over the freshly produced
       // surefire-reports / build/test-results.
@@ -121,9 +157,9 @@ for (const s of SCENARIOS) {
 
       assert.equal(report.summary.files, s.files, `${s.project}: report files`);
       assert.equal(report.summary.tests, s.tests, `${s.project}: total tests`);
-      assert.equal(report.summary.failures, 0, `${s.project}: failures`);
-      assert.equal(report.summary.errors, 0, `${s.project}: errors`);
-      assert.equal(report.summary.passed, s.tests, `${s.project}: passed`);
+      assert.equal(report.summary.failures, failures, `${s.project}: failures`);
+      assert.equal(report.summary.errors, errors, `${s.project}: errors`);
+      assert.equal(report.summary.passed, passed, `${s.project}: passed`);
 
       for (const suffix of s.suites) {
         assert.ok(
@@ -133,14 +169,44 @@ for (const s of SCENARIOS) {
       }
 
       // Every parsed case must carry a concrete pass/fail status (not the default).
+      const byName = new Map();
       for (const suite of report.suites) {
         for (const c of suite.cases) {
+          byName.set(c.name, c.status);
           assert.ok(
             ["passed", "failed", "error", "skipped"].includes(c.status),
             `bad status ${c.status} for ${c.name}`,
           );
         }
       }
+
+      // Pin specific method -> status pairs where the scenario declares them.
+      for (const [name, status] of Object.entries(s.cases ?? {})) {
+        assert.equal(byName.get(name), status, `${s.project}: ${name} should be ${status}`);
+      }
+    },
+  );
+}
+
+for (const l of LIFECYCLE) {
+  const dir = path.join(projectsDir, l.project);
+
+  test(
+    `${l.project}: Build and Package lanes each produce a jar`,
+    { skip: SKIP, timeout: BUILD_TIMEOUT_MS },
+    async () => {
+      assert.ok(existsSync(dir), `missing integration project: ${dir}`);
+
+      // Build lane: compile + assemble without running tests.
+      const build = await runWrapper(dir, l.tool, buildArgsFor(l.tool));
+      assert.equal(build.code, 0, `${l.project} build lane failed (exit ${build.code}):\n${build.out.slice(-4000)}`);
+      assert.ok(hasJar(dir, l.tool), `${l.project}: Build lane produced no jar in ${artifactDir(l.tool)}/`);
+
+      // Package lane with the "Clean" toggle, so it must rebuild the artifact from
+      // scratch — proving the Package lane works independently of the Build lane.
+      const pkg = await runWrapper(dir, l.tool, packageArgsFor(l.tool, false, true, false));
+      assert.equal(pkg.code, 0, `${l.project} package lane failed (exit ${pkg.code}):\n${pkg.out.slice(-4000)}`);
+      assert.ok(hasJar(dir, l.tool), `${l.project}: Package lane produced no jar in ${artifactDir(l.tool)}/`);
     },
   );
 }

--- a/test/e2e-projects.test.mjs
+++ b/test/e2e-projects.test.mjs
@@ -1,0 +1,146 @@
+// End-to-end integration tests: actually build and test each sample project in
+// integration-tests/ with its own wrapper (./mvnw / ./gradlew), then feed the
+// real JUnit reports the build produced through Coffilot's own report-discovery +
+// parsing pipeline (collectSurefireReport) and assert the parsed results.
+//
+// This is the "realistic" pass — it needs a JDK 17 and network access (the
+// wrappers download Maven/Gradle and dependencies), so it is SKIPPED unless
+// COFFILOT_E2E=1 is set. The fast, deterministic detection tests live in
+// integration-projects.test.mjs and always run.
+//
+//   COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+process.env.COFFILOT_TEST = "1";
+
+const { collectSurefireReport } = await import("../extension.mjs");
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const projectsDir = path.join(repoRoot, "integration-tests");
+
+const E2E = !!process.env.COFFILOT_E2E;
+const SKIP = E2E ? false : "set COFFILOT_E2E=1 (needs JDK 17 + network) to run end-to-end builds";
+const isWindows = process.platform === "win32";
+
+// Per-tool wrapper + test goal. These mirror what Coffilot's Test lane runs
+// (defaultTestArgs): `mvn test` for Maven, `cleanTest test` for Gradle (which
+// forces a re-run so a fresh report is always produced). -B / --console=plain
+// keep the output non-interactive in CI.
+function testCommand(tool) {
+  if (tool === "gradle") {
+    return {
+      wrapper: isWindows ? "gradlew.bat" : "gradlew",
+      args: ["cleanTest", "test", "--console=plain", "--no-daemon"],
+    };
+  }
+  return { wrapper: isWindows ? "mvnw.cmd" : "mvnw", args: ["-ntp", "-B", "test"] };
+}
+
+// Run a build wrapper in a project directory, resolving with its exit code. The
+// child's output is captured and only surfaced (via the rejection / assertion
+// message) when the build fails, to keep passing runs quiet.
+function runBuild(dir, tool) {
+  const { wrapper, args } = testCommand(tool);
+  // Use the wrapper's absolute path: a relative executable is resolved against
+  // the parent process cwd (not the spawn `cwd`), so join it onto the project dir.
+  const bin = path.join(dir, wrapper);
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { cwd: dir, env: process.env });
+    let out = "";
+    const capture = (chunk) => {
+      out += chunk;
+      if (out.length > 200000) out = out.slice(-200000); // bound memory on chatty builds
+    };
+    child.stdout.on("data", capture);
+    child.stderr.on("data", capture);
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, out }));
+  });
+}
+
+// Expected real-build outcome per project. tests/files are exact for these
+// controlled fixtures (see integration-tests/README.md); suites lists class-name
+// suffixes that must appear in the parsed report.
+const SCENARIOS = [
+  { project: "hello-world", tool: "maven", tests: 1, files: 1, suites: ["AppTest"] },
+  { project: "gradle-hello-world", tool: "gradle", tests: 1, files: 1, suites: ["AppTest"] },
+  {
+    project: "spring-mvc",
+    tool: "maven",
+    tests: 2,
+    files: 2,
+    suites: ["HelloControllerTest", "SpringMvcApplicationTests"],
+  },
+  {
+    project: "spring-mvc-actuator-devtools",
+    tool: "maven",
+    tests: 2,
+    files: 2,
+    suites: ["HelloControllerTest", "SpringMvcActuatorDevtoolsApplicationTests"],
+  },
+  {
+    project: "spring-mvc-bootui",
+    tool: "maven",
+    tests: 2,
+    files: 2,
+    suites: ["HelloControllerTest", "SpringMvcBootuiApplicationTests"],
+  },
+  {
+    project: "quarkus-rest",
+    tool: "maven",
+    tests: 2,
+    files: 2,
+    suites: ["GreetingResourceTest", "GreetingResourceUnitTest"],
+  },
+];
+
+// Builds pull the toolchain + dependencies over the network on a cold cache, so
+// allow a generous per-project budget.
+const BUILD_TIMEOUT_MS = 15 * 60 * 1000;
+
+for (const s of SCENARIOS) {
+  const dir = path.join(projectsDir, s.project);
+
+  test(
+    `${s.project}: builds, tests and Coffilot parses the real report`,
+    { skip: SKIP, timeout: BUILD_TIMEOUT_MS },
+    async () => {
+      assert.ok(existsSync(dir), `missing integration project: ${dir}`);
+
+      const { code, out } = await runBuild(dir, s.tool);
+      assert.equal(code, 0, `${s.project} build/test failed (exit ${code}):\n${out.slice(-4000)}`);
+
+      // Drive Coffilot's actual discovery + parsing over the freshly produced
+      // surefire-reports / build/test-results.
+      const report = await collectSurefireReport(0, dir);
+
+      assert.equal(report.summary.files, s.files, `${s.project}: report files`);
+      assert.equal(report.summary.tests, s.tests, `${s.project}: total tests`);
+      assert.equal(report.summary.failures, 0, `${s.project}: failures`);
+      assert.equal(report.summary.errors, 0, `${s.project}: errors`);
+      assert.equal(report.summary.passed, s.tests, `${s.project}: passed`);
+
+      for (const suffix of s.suites) {
+        assert.ok(
+          report.suites.some((suite) => suite.name.endsWith(suffix)),
+          `${s.project}: expected a parsed suite ending in ${suffix}, got ${report.suites.map((x) => x.name).join(", ")}`,
+        );
+      }
+
+      // Every parsed case must carry a concrete pass/fail status (not the default).
+      for (const suite of report.suites) {
+        for (const c of suite.cases) {
+          assert.ok(
+            ["passed", "failed", "error", "skipped"].includes(c.status),
+            `bad status ${c.status} for ${c.name}`,
+          );
+        }
+      }
+    },
+  );
+}

--- a/test/integration-projects.test.mjs
+++ b/test/integration-projects.test.mjs
@@ -1,0 +1,162 @@
+// Integration tests that drive Coffilot's real project-classification logic
+// against the sample projects in integration-tests/. Each project targets a
+// distinct capability tier (see integration-tests/README.md); these tests assert
+// that Coffilot detects the build tool, per-module capabilities, run mode and
+// metrics tier each scenario is meant to exercise — using the actual build files,
+// not synthetic fixtures. They are deterministic and need no JDK/network, so they
+// run as part of `npm test`. The heavier "actually build it" pass lives in
+// e2e-projects.test.mjs (gated behind COFFILOT_E2E=1).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Skip the side-effectful bootstrap so we can import the pure detectors. See
+// extension.mjs / parsers.test.mjs.
+process.env.COFFILOT_TEST = "1";
+
+const { detectBuildTool, pomCaps, gradleCaps, readGradleBuildFile, findProjectRoot, inferRunMode } =
+  await import("../extension.mjs");
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const projectsDir = path.join(repoRoot, "integration-tests");
+
+// Compute a module's capability flags the way the runtime does: read the
+// project's own build file and run the matching capability extractor. Returns the
+// detected tool alongside the caps so each scenario can assert both.
+function classify(dir) {
+  const pom = path.join(dir, "pom.xml");
+  if (existsSync(pom)) return { tool: "maven", caps: pomCaps(readFileSync(pom, "utf8"), "") };
+  const gradle = readGradleBuildFile(dir);
+  if (gradle != null) return { tool: "gradle", caps: gradleCaps(gradle, "") };
+  throw new Error(`no Maven or Gradle build file in ${dir}`);
+}
+
+// The metrics/Run tier each scenario should resolve to, derived purely from the
+// static capabilities. Mirrors Coffilot's graceful-degradation ladder (richest
+// first): BootUI > Actuator > Spring (process metrics) > plain Java, with Quarkus
+// as its own runnable tier.
+function tierOf(c) {
+  if (c.bootui) return "bootui";
+  if (c.quarkus) return "quarkus";
+  if (c.actuator) return "actuator";
+  if (c.runnable) return "spring";
+  return "java";
+}
+
+// The documented scenario matrix (kept in lockstep with integration-tests/README.md).
+const SCENARIOS = [
+  {
+    project: "hello-world",
+    tool: "maven",
+    runMode: "java",
+    tier: "java",
+    caps: {
+      runnable: false,
+      springBoot: false,
+      quarkus: false,
+      actuator: false,
+      devtools: false,
+      bootui: false,
+      mainClass: "com.example.helloworld.App",
+    },
+  },
+  {
+    project: "gradle-hello-world",
+    tool: "gradle",
+    runMode: "java",
+    tier: "java",
+    caps: {
+      runnable: false,
+      springBoot: false,
+      quarkus: false,
+      actuator: false,
+      devtools: false,
+      bootui: false,
+      application: true,
+      mainClass: "com.example.helloworld.App",
+    },
+  },
+  {
+    project: "spring-mvc",
+    tool: "maven",
+    runMode: "spring",
+    tier: "spring",
+    caps: { runnable: true, springBoot: true, quarkus: false, actuator: false, devtools: false, bootui: false },
+  },
+  {
+    project: "spring-mvc-actuator-devtools",
+    tool: "maven",
+    runMode: "spring",
+    tier: "actuator",
+    caps: { runnable: true, springBoot: true, quarkus: false, actuator: true, devtools: true, bootui: false },
+  },
+  {
+    project: "spring-mvc-bootui",
+    tool: "maven",
+    runMode: "spring",
+    tier: "bootui",
+    // BootUI lives in a `dev` Maven profile; pomCaps reads the whole pom, so the
+    // starter is still detected statically (the dev Spring profile is what
+    // actually wakes it at runtime).
+    caps: { runnable: true, springBoot: true, quarkus: false, actuator: true, devtools: true, bootui: true },
+  },
+  {
+    project: "quarkus-rest",
+    tool: "maven",
+    runMode: "quarkus",
+    tier: "quarkus",
+    caps: { runnable: true, springBoot: false, quarkus: true, actuator: false, devtools: false, bootui: false },
+  },
+];
+
+for (const s of SCENARIOS) {
+  const dir = path.join(projectsDir, s.project);
+
+  test(`${s.project}: detects ${s.tool} as the build tool`, () => {
+    assert.ok(existsSync(dir), `missing integration project: ${dir}`);
+    assert.equal(detectBuildTool(dir), s.tool);
+  });
+
+  test(`${s.project}: classifies capabilities for the ${s.tier} tier`, () => {
+    const { tool, caps } = classify(dir);
+    assert.equal(tool, s.tool, "build tool");
+    for (const [key, expected] of Object.entries(s.caps)) {
+      assert.equal(caps[key], expected, `${s.project}.${key}`);
+    }
+  });
+
+  test(`${s.project}: infers the ${s.runMode} run mode`, () => {
+    assert.equal(inferRunMode(classify(dir).caps), s.runMode);
+  });
+
+  test(`${s.project}: resolves to the ${s.tier} capability tier`, () => {
+    assert.equal(tierOf(classify(dir).caps), s.tier);
+  });
+
+  test(`${s.project}: project root is resolved from a nested source dir`, () => {
+    // Coffilot walks up from the opened path to the directory that owns the build
+    // marker; a file deep under src/ must still resolve to the project root.
+    const nested = path.join(dir, "src", "main");
+    assert.equal(findProjectRoot(nested), dir);
+  });
+}
+
+test("Maven wins when both Maven and Gradle markers are present", () => {
+  // Coffilot's documented "prefer Maven" rule: a directory owning both a pom.xml
+  // and a build.gradle is treated as Maven.
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "coffilot-detect-"));
+  try {
+    writeFileSync(path.join(tmp, "pom.xml"), "<project/>");
+    writeFileSync(path.join(tmp, "build.gradle"), "");
+    assert.equal(detectBuildTool(tmp), "maven");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("a directory with no build markers detects no tool", () => {
+  assert.equal(detectBuildTool(repoRoot), null);
+});

--- a/test/integration-projects.test.mjs
+++ b/test/integration-projects.test.mjs
@@ -6,7 +6,7 @@
 // not synthetic fixtures. They are deterministic and need no JDK/network, so they
 // run as part of `npm test`. The heavier "actually build it" pass lives in
 // e2e-projects.test.mjs (gated behind COFFILOT_E2E=1).
-import { test } from "node:test";
+import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
@@ -17,9 +17,18 @@ import { fileURLToPath } from "node:url";
 // extension.mjs / parsers.test.mjs.
 process.env.COFFILOT_TEST = "1";
 
-const { detectBuildTool, pomCaps, gradleCaps, readGradleBuildFile, findProjectRoot, inferRunMode } =
-  await import("../extension.mjs");
-
+const {
+  detectBuildTool,
+  pomCaps,
+  gradleCaps,
+  readGradleBuildFile,
+  findProjectRoot,
+  inferRunMode,
+  buildArgsFor,
+  testArgsFor,
+  packageArgsFor,
+  affectedTestArgsFor,
+} = await import("../extension.mjs");
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const projectsDir = path.join(repoRoot, "integration-tests");
 
@@ -110,6 +119,23 @@ const SCENARIOS = [
     tier: "quarkus",
     caps: { runnable: true, springBoot: false, quarkus: true, actuator: false, devtools: false, bootui: false },
   },
+  {
+    project: "failing-tests",
+    tool: "maven",
+    runMode: "java",
+    tier: "java",
+    // Plain Maven project; its JUnit suite intentionally fails/errors so the E2E
+    // pass can exercise failure parsing. Statically it classifies like hello-world.
+    caps: {
+      runnable: false,
+      springBoot: false,
+      quarkus: false,
+      actuator: false,
+      devtools: false,
+      bootui: false,
+      mainClass: "com.example.failing.Calculator",
+    },
+  },
 ];
 
 for (const s of SCENARIOS) {
@@ -159,4 +185,63 @@ test("Maven wins when both Maven and Gradle markers are present", () => {
 
 test("a directory with no build markers detects no tool", () => {
   assert.equal(detectBuildTool(repoRoot), null);
+});
+
+// Lane command builders: the same pure helpers the Build/Test/Package/affected
+// lanes use to assemble their runner arguments. Asserting them here keeps the
+// documented per-tool command vectors from drifting, and the E2E pass drives the
+// very same builders against the real wrappers.
+describe("lane command builders", () => {
+  test("Maven build/test/package vectors match the documented goals", () => {
+    assert.deepEqual(buildArgsFor("maven"), ["-ntp", "-DskipTests", "install"]);
+    assert.deepEqual(buildArgsFor("maven", false, true), ["-ntp", "-DskipTests", "clean", "install"]);
+    assert.deepEqual(testArgsFor("maven"), ["-ntp", "test"]);
+    assert.deepEqual(packageArgsFor("maven"), ["-ntp", "package"]);
+    assert.deepEqual(packageArgsFor("maven", false, true, true), ["-ntp", "clean", "install"]);
+  });
+
+  test("Gradle build/test/package vectors swap goals and honor the warm daemon", () => {
+    // Cold (warm=false) appends --no-daemon; warm drops it.
+    assert.deepEqual(buildArgsFor("gradle"), ["build", "-x", "test", "--console=plain", "--no-daemon"]);
+    assert.deepEqual(buildArgsFor("gradle", true), ["build", "-x", "test", "--console=plain"]);
+    assert.deepEqual(testArgsFor("gradle"), ["cleanTest", "test", "--console=plain", "--no-daemon"]);
+    assert.deepEqual(packageArgsFor("gradle"), ["assemble", "--console=plain", "--no-daemon"]);
+    assert.deepEqual(packageArgsFor("gradle", false, true, true), [
+      "clean",
+      "publishToMavenLocal",
+      "--console=plain",
+      "--no-daemon",
+    ]);
+  });
+
+  test("affected-test args target only the changed classes (Maven by simple name)", () => {
+    const tests = [
+      { fqcn: "com.example.FooTest", module: "" },
+      { fqcn: "com.example.BarTest$Inner", module: "" },
+    ];
+    // Inner classes collapse to their enclosing class; Surefire matches by simple name.
+    assert.deepEqual(affectedTestArgsFor("maven", tests), [
+      "-ntp",
+      "-Dtest=FooTest,BarTest",
+      "-Dsurefire.failIfNoSpecifiedTests=false",
+      "test",
+    ]);
+  });
+
+  test("affected-test args target only the owning modules (Gradle by FQCN)", () => {
+    const tests = [
+      { fqcn: "com.example.FooTest", module: "web" },
+      { fqcn: "com.example.BarTest", module: "" },
+    ];
+    assert.deepEqual(affectedTestArgsFor("gradle", tests), [
+      ":web:test",
+      "test",
+      "--console=plain",
+      "--no-daemon",
+      "--tests",
+      "com.example.FooTest",
+      "--tests",
+      "com.example.BarTest",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

CI already built and ran each `integration-tests/*` project's own Java tests, but nothing exercised **Coffilot's** logic against those projects. This adds two layers of integration tests so the tiers Coffilot drives stay verified against real-world build files and real builds.

- **`test/integration-projects.test.mjs`** (fast, deterministic, no JDK/network, runs in `npm test`): drives Coffilot's real build-tool detection, capability/tier classification, run-mode inference and project-root resolution against each project's actual `pom.xml` / `build.gradle`, and asserts the documented tier matrix (plain Java for Maven and Gradle, Spring Boot, Actuator, BootUI, Quarkus) plus the "Maven wins" precedence rule.
- **`test/e2e-projects.test.mjs`** (the realistic pass, gated behind `COFFILOT_E2E=1`): actually builds and tests each project with its own wrapper, then feeds the JUnit reports the build produced through Coffilot's own report discovery + parser (`collectSurefireReport`) and asserts the parsed results. Verified locally against the Maven (`surefire-reports`) and Gradle (`build/test-results`) output layouts.

Supporting changes are behavior-preserving:

- `extension.mjs`: exported the pure detectors used above, extracted a tiny shared `inferRunMode(mod)` helper (now used by both the Run lane and the tests), and let `collectSurefireReport(sinceMs, root)` target an arbitrary project root.
- `.github/workflows/ci.yml`: the per-project matrix job now runs the E2E test (build + Coffilot parsing validation) instead of a build-only `./mvnw test` step, so CI validates Coffilot rather than just the raw build.
- `package.json`: the `test` script now lists the test files explicitly.
- Documented both layers in `CONTRIBUTING.md` and `integration-tests/README.md`.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project. (N/A: test-only change; validated via `npm test` and real E2E builds of hello-world, gradle-hello-world, spring-mvc, quarkus-rest.)
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (Updated `integration-tests/README.md` and `CONTRIBUTING.md`.)
- [x] No secrets committed.

`npm test` reports 78 tests: 72 pass, 6 E2E skipped (gated), 0 fail.

## Notes for reviewers

- The `test` npm script now lists files explicitly (`node --test test/parsers.test.mjs ...`) rather than relying on directory discovery. This is deliberate: Node 20 (CI) lacks `--test` glob support and Node 26 does not auto-expand a directory arg, and explicit files also prevent a local `integration-tests/**` build tree from being mistaken for a test file. Heads-up: new test files must be added to that list.
- The E2E CI job intentionally has no `npm install` step; `extension.mjs` imports only Node builtins plus `./jdwp.mjs` under `COFFILOT_TEST=1`, so the deps-free job can import it fine.
- Exact test counts/suite names in the E2E assertions are pinned to these controlled fixtures and kept in lockstep with the README tier table.