### PR TITLE
Show BootUI MCP panel in Settings only for Spring Boot modules

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -92,6 +92,7 @@ const devtoolsToggle = document.getElementById("devtools-toggle");
 const devtoolsInput = document.getElementById("in-devtools");
 const setRandomport = document.getElementById("set-randomport");
 const randomportInput = document.getElementById("in-randomport");
+const setMcp = document.getElementById("mcp");
 const maskSecretsInput = document.getElementById("in-masksecrets");
 const metricsPollInput = document.getElementById("in-metricspoll");
 const openBrowserInput = document.getElementById("in-openbrowser");
@@ -1097,9 +1098,11 @@ function showMcpRegister(show) {
 }
 
 // The MCP server lives inside the running app, so the toggle is only
-// actionable while a BootUI app (dev profile) exposes its endpoint. The
-// row stays visible in Settings either way; when unavailable we grey out
-// the switch and explain why instead of hiding it.
+// actionable while a BootUI app (dev profile) exposes its endpoint. For
+// Spring Boot modules the row stays visible in Settings even when the
+// endpoint is unavailable (greyed out with an explanation rather than
+// hidden); the whole panel is hidden for non-Spring modules in
+// updateDevSetup(), since BootUI is a Spring-only tier.
 function setMcpUnavailable() {
   mcpScansLoaded = false;
   mcpToggle.checked = false;
@@ -1611,6 +1614,9 @@ function updateDevSetup() {
   setSpring.hidden = !framework;
   setDevtools.hidden = !spring;
   setRandomport.hidden = !framework;
+  // BootUI (and its MCP advisor scans) is a Spring-only tier, so only surface
+  // the MCP server panel for Spring Boot modules.
+  setMcp.hidden = !spring;
 
   // Relabel the run-profile combo and swap its suggestions for the framework.
   if (lblProfiles) lblProfiles.textContent = quarkus ? "Quarkus profile" : "Spring Boot profiles";


### PR DESCRIPTION
## Summary

BootUI is a Spring-only tier, but its "BootUI MCP server" panel (toggle + advisor scans) was rendered in Settings for every project. On a Quarkus or plain Java module it still showed, greyed out, with "Start a BootUI app (dev profile) with Run to manage its MCP server and advisor scans." which is misleading since BootUI never applies there.

This gates the panel's visibility on the selected module being a Spring Boot app, in `updateDevSetup()`, right alongside the other Spring-only settings rows (DevTools). The panel is hidden via the `hidden` attribute, which the global `[hidden] { display: none !important; }` rule already enforces over the `#mcp` display rules. Because `updateDevSetup()` runs on environment load and on module-select change, the panel toggles correctly as the user switches modules in a mixed reactor.

For Spring Boot modules the existing behavior is unchanged: the row stays visible even when no running app exposes the endpoint (greyed out with an explanation), rather than being hidden.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A - no documented behavior changed)
- [x] No secrets committed.

## Notes for reviewers

The visibility is keyed off the selected module's `springBoot` flag (per-module), matching how the DevTools and run-profile rows already behave, so multi-module reactors mixing Spring and Quarkus show the panel only when a Spring module is selected.