### PR TITLE
ci: use latest Node LTS, bump setup-java to v5, gate e2e on build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "lts/*"
           cache: npm
 
       - name: Install dependencies
@@ -41,6 +41,7 @@ jobs:
 
   e2e-projects:
     name: E2E (${{ matrix.project }})
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -67,10 +68,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "lts/*"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
## Summary

Tidies up the CI workflow so it stays on current tooling and runs in a sensible order.

- **Track the latest Node LTS.** Both jobs now use `node-version: "lts/*"` instead of a pinned `20`, so CI follows the latest LTS line (currently Node 24, Krypton) without manual bumps.
- **Bump actions to their latest major.** `actions/setup-java` v4 -> v5. `actions/checkout` and `actions/setup-node` were already on their latest major (v6), so they're left as-is.
- **Order the jobs.** The `e2e-projects` matrix now declares `needs: build`, so the end-to-end Maven/Gradle builds only kick off after lint/format, syntax-check, and unit tests pass. This avoids spending JDK build time on a PR that already fails the cheap checks.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier, including the YAML).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project (CI-only change; not applicable).
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed (no behaviour change).
- [x] No secrets committed.

## Notes for reviewers

The `needs: build` dependency adds the build job (~15s) to the e2e critical path, which is the intended trade-off.

I also looked into whether the e2e jobs finishing in ~1 minute is suspicious: it's expected. The `--test-name-pattern "^<project>:"` makes each matrix shard build exactly one project and SKIP the other 8, and `setup-java`'s dependency cache keeps the Maven/Gradle downloads warm. The real builds do run (e.g. `spring-mvc-bootui` ~10s, `quarkus-rest` ~69s); the wall-clock is short because the shards run in parallel.