### PR TITLE
Remember the right-panel state across reloads

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -66,8 +66,9 @@ Shipped in the extension today:
   the process running), for flame-graph hotspots, and for BootUI advisor-scan findings.
 - BootUI MCP server toggle + advisor scans when the running app exposes BootUI.
 - Per-project persisted settings (warm JVM, Spring profiles, devtools, random port,
-  auto-open browser, auto-record flame graph at startup) and an always-visible
-  Settings panel.
+  auto-open browser, auto-record flame graph at startup, and the last-opened
+  right-panel tab / collapsed state) and an always-visible Settings panel that opens
+  on first launch.
 - `--enable-native-access=ALL-UNNAMED` applied to the build-tool JVM (via
   `MAVEN_OPTS` / `GRADLE_OPTS`) and, for Maven, the app JVM to silence JDK
   native-access warnings.

--- a/extension.mjs
+++ b/extension.mjs
@@ -1280,6 +1280,8 @@ const SETTINGS_KEYS = [
   "maskSecrets",
   "metricsPollMs",
   "jdkHome",
+  "asideTab",
+  "asideOpen",
 ];
 
 // Live-metrics polling cadence bounds (ms). Kept conservative so the UI stays
@@ -1331,6 +1333,12 @@ function defaultSettings() {
     // Selected JDK (absolute JAVA_HOME) for all build/test/package/run/debug
     // actions; null = inherit the system default (JAVA_HOME / PATH java).
     jdkHome: null,
+    // Right-panel (aside) preference, restored across reloads/sessions. asideTab
+    // is the last-opened tab; asideOpen is whether the docked (wide-canvas) panel
+    // is expanded. Defaults open on the Settings tab the first time the canvas
+    // is opened.
+    asideTab: "settings",
+    asideOpen: true,
   };
 }
 
@@ -2371,6 +2379,9 @@ function applySettings(body) {
   if (body.metricsPollMs != null && Number.isFinite(Number(body.metricsPollMs))) {
     settings.metricsPollMs = clampMetricsPollMs(body.metricsPollMs);
   }
+  // Right-panel preference (which aside tab, and whether the docked panel is open).
+  if (["metrics", "loggers", "settings"].includes(body.asideTab)) settings.asideTab = body.asideTab;
+  if (typeof body.asideOpen === "boolean") settings.asideOpen = body.asideOpen;
   // JDK selection. Don't switch the JDK out from under a running/debugging app —
   // the change applies to the next launch, so the user must stop it first. A new
   // selection must point at a real JAVA_HOME (containing bin/java).

--- a/public/app.js
+++ b/public/app.js
@@ -332,6 +332,15 @@ const workspaceEl = document.getElementById("workspace");
 const asideToggle = document.getElementById("aside-toggle");
 const asideDrawer = window.matchMedia("(max-width: 819px)");
 
+// Persisted right-panel preference (settings.asideTab / settings.asideOpen),
+// restored from the server on the first env load. asideTabPref is the last-opened
+// tab; asideOpenPref is whether the docked (wide-canvas) panel is expanded. The
+// narrow-canvas overlay is transient and never updates asideOpenPref. Defaults
+// open on Settings so the panel is shown the first time the canvas is opened.
+let asideTabPref = "settings";
+let asideOpenPref = true;
+let asideStateApplied = false;
+
 function activeAsideTab() {
   const t = document.querySelector(".atab.active");
   return t ? t.dataset.atab : null;
@@ -361,35 +370,64 @@ function showAsideTab(name) {
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
   syncLoggersPolling();
 }
+// Capture the current panel state as the persisted preference and save it. The
+// open/closed half is only meaningful for the docked (wide) layout — the narrow
+// overlay collapses transiently — so only update asideOpenPref when wide.
+function rememberAsideState() {
+  asideTabPref = activeAsideTab() || "settings";
+  if (!asideDrawer.matches) asideOpenPref = workspaceEl.classList.contains("aside-open");
+  saveSettings();
+}
+// Restore the persisted panel preference once the settings land. Runs a single
+// time so later env refreshes don't clobber live interaction.
+function applyAsideState(s) {
+  if (asideStateApplied || !s) return;
+  asideStateApplied = true;
+  asideTabPref = ["metrics", "loggers", "settings"].includes(s.asideTab) ? s.asideTab : "settings";
+  asideOpenPref = s.asideOpen !== false;
+  showAsideTab(asideTabPref);
+  // The remembered open state applies to the docked layout only; on a narrow
+  // canvas the overlay stays collapsed until the user opens it.
+  if (!asideDrawer.matches) setAsideOpen(asideOpenPref);
+}
 // Tab click: when collapsed, open the panel to that pane; when already expanded,
 // switch panes, or collapse if you re-tap the pane that's already showing.
 function onAsideTabClick(name) {
   if (!workspaceEl.classList.contains("aside-open")) {
     showAsideTab(name);
     setAsideOpen(true);
+    rememberAsideState();
     return;
   }
   if (activeAsideTab() === name) {
     setAsideOpen(false);
+    rememberAsideState();
     return;
   }
   showAsideTab(name);
+  rememberAsideState();
 }
 document.querySelectorAll(".atab").forEach((t) => (t.onclick = () => onAsideTabClick(t.dataset.atab)));
-if (asideToggle) asideToggle.onclick = () => setAsideOpen(!workspaceEl.classList.contains("aside-open"));
+if (asideToggle)
+  asideToggle.onclick = () => {
+    setAsideOpen(!workspaceEl.classList.contains("aside-open"));
+    rememberAsideState();
+  };
 // Esc collapses the overlay drawer on a narrow canvas.
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && asideDrawer.matches && workspaceEl.classList.contains("aside-open")) {
     setAsideOpen(false);
   }
 });
-// Crossing the breakpoint resets to the natural default for that width: docked
-// and open when wide, collapsed to the rail when narrow.
-asideDrawer.addEventListener("change", () => setAsideOpen(!asideDrawer.matches));
+// Crossing the breakpoint resets to the natural default for that width: the
+// remembered docked preference when wide, collapsed to the overlay rail when
+// narrow. Neither transition is persisted (it's layout-driven, not a user choice).
+asideDrawer.addEventListener("change", () => setAsideOpen(asideDrawer.matches ? false : asideOpenPref));
 // Initial state: open on a wide canvas, collapsed on a narrow one. No loggers
 // sync here (it would touch state declared later in this module) — polling is
 // driven by tab activation and the Settings tab is the default, so loggers
-// polling stays off until that tab is opened.
+// polling stays off until that tab is opened. The persisted preference is
+// applied later by applyAsideState once the settings land.
 workspaceEl.classList.toggle("aside-open", !asideDrawer.matches);
 syncAsideMode();
 
@@ -1760,6 +1798,7 @@ function applySettingsState(s) {
     // JDK doesn't leave the control on a phantom value.
     jdkSelect.value = [...jdkSelect.options].some((o) => o.value === want) ? want : "";
   }
+  applyAsideState(s);
 }
 
 function applyEnv(env) {
@@ -2254,6 +2293,8 @@ function saveSettings() {
     autoProfileEvent: flameEvent ? flameEvent.value : "cpu",
     autoProfileDuration: flameDuration ? Number(flameDuration.value) : 30,
     jdkHome: jdkSelect ? jdkSelect.value : "",
+    asideTab: asideTabPref,
+    asideOpen: asideOpenPref,
   });
 }
 warmInput.addEventListener("change", saveSettings);


### PR DESCRIPTION
## Summary

The right-side panel (Live JVM / Loggers / Settings tabs, plus the hide/show toggle) always reset to its default layout on every canvas reload, so a developer who collapsed it or switched to a different tab lost that choice every time. This persists the panel state per project so the canvas comes back the way you left it.

The first time the canvas is opened (no saved settings yet) it now defaults open on the Settings tab, which makes the most useful panel visible up front.

Approach: adds two values, `asideTab` and `asideOpen`, to the existing per-project persisted settings store (`settings-<hash>.json`, served through `/api/settings`). The client captures the panel state on every tab click and on the hide/show toggle, and restores it exactly once on the first env load so later env refreshes (focus/visibility re-sample, recheck) don't clobber live interaction.

One non-obvious trade-off worth a look: the open/closed half is only persisted for the docked (wide-canvas) layout. On a narrow canvas the panel is a transient overlay that auto-collapses, so persisting its collapsed state there would wrongly overwrite the user's docked preference. The remembered tab is persisted in both layouts; only the open/closed bit is gated to wide.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed (PLAN.md persisted-settings list updated).
- [x] No secrets committed.

Existing test suite still passes (84 passed, 9 skipped).

## Notes for reviewers

- Server changes are mechanical and mirror the existing settings keys: added to `SETTINGS_KEYS`, `defaultSettings()`, and validated in `applySettings()`.
- Client logic lives in the aside control block in `public/app.js`: `rememberAsideState()` (capture + save), `applyAsideState()` (one-time restore), and the breakpoint handler now restores the remembered docked state when crossing back to wide instead of always re-opening.