### PR TITLE
Document quarkus-rest as the modern, JDK-25+-ready Quarkus test target

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -30,6 +30,16 @@ exposing a trivial `GET /` plus two tests (a `@QuarkusTest` that boots the app a
 plain unit test). It adds SmallRye Health and the Micrometer/Prometheus registry so its
 `/q/health` and `/q/metrics` endpoints feed Coffilot's Quarkus metrics tier.
 
+Because it tracks a current Quarkus release, `quarkus-rest` builds, tests and runs in
+`quarkus:dev` on modern JDKs — verified through JDK 26 — so it's the Quarkus project to
+use when exercising Coffilot on a recent JDK. Legacy Quarkus 1.x/2.x apps are the
+opposite: their build-time bytecode enhancement (Hibernate/ByteBuddy) can't read newer
+class files, so they only build on the older JDK they were written for (often JDK 11) and
+fail on a newer one with a `net.bytebuddy…ClassReader` error during Quarkus augmentation —
+not a Coffilot bug. For those, pick the JDK the project targets in **Settings → JDK**; the
+selection is pinned via `JAVA_HOME` for every Build / Test / Package / Run (with Maven's
+`mvnd`, each pinned JDK gets its own daemon).
+
 ## Running them by hand
 
 Each project builds, tests, packages and runs on its own:


### PR DESCRIPTION
## What & why

While investigating a report that "JDK pinning doesn't work" for a Quarkus app, the pinning turned out to be working correctly — the real issue was the *project*, not Coffilot.

The session was driving Coffilot against an external **Quarkus 1.3.2 (2020)** sample whose build-time Hibernate/ByteBuddy enhancement can't read modern class files. Selecting JDK 17/21/26 made the build fail during Quarkus augmentation with a `net.bytebuddy…ClassReader` error; **only JDK 11 builds it**. The pinned JDK *did* reach the build every time (verified via `mvnd`'s daemon registry — one daemon per pinned `JAVA_HOME`: `@17`, `@21`, `@11`, `26`), so the selector wasn't broken.

The repo already ships a small, modern Quarkus fixture — `integration-tests/quarkus-rest` (Quarkus 3.36, Java 17) — which I verified end-to-end on the newest JDK available here (26):

- `clean package` → 2 tests pass, jar built, augmentation OK
- `quarkus:dev` → starts in ~1.6s, `GET /` → `Hello from quarkus-rest`
- `/q/health` UP and `/q/metrics` (Micrometer/Prometheus) both respond — Coffilot's Quarkus metrics tier

## Change

Docs only: a short note in `integration-tests/README.md` recording `quarkus-rest` as the Quarkus project to use on recent JDKs, explaining the legacy-Quarkus "too-new JDK" failure mode (and that it's not a Coffilot bug), and how to pin the right JDK for old apps via **Settings → JDK**.

No code changes. Prettier `--check` passes.