### PR TITLE
Add divider between available and disabled aside panels

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -453,16 +453,22 @@ const ASIDE_REASON = {
   scans: "Advisor scans need a running BootUI app. Click to learn more.",
 };
 function updateAsideAvailability(avail) {
+  let anyUnavailable = false;
   document.querySelectorAll(".atab").forEach((btn) => {
     const name = btn.dataset.atab;
     const ok = ASIDE_ALWAYS.has(name) || !!(avail && avail[name]);
+    if (!ok) anyUnavailable = true;
     btn.classList.toggle("unavailable", !ok);
     btn.setAttribute("aria-disabled", ok ? "false" : "true");
-    // Available tools keep their DOM order at the top; unavailable ones sink down.
-    btn.style.order = ok ? "1" : "2";
+    // Available tools keep their DOM order at the top; unavailable ones sink to
+    // the bottom, below the separator (order 2).
+    btn.style.order = ok ? "1" : "3";
     if (!btn.dataset.titleAvail) btn.dataset.titleAvail = btn.getAttribute("title") || "";
     btn.title = ok ? btn.dataset.titleAvail : ASIDE_REASON[name] || btn.dataset.titleAvail;
   });
+  // The divider only makes sense when there's actually a disabled group below it.
+  const sep = document.querySelector(".atab-sep");
+  if (sep) sep.hidden = !anyUnavailable;
 }
 // Nothing is reachable until the first metrics snapshot lands, so start with only
 // Settings enabled (renderMetrics refines this on every push).

--- a/public/index.html
+++ b/public/index.html
@@ -446,6 +446,7 @@
             </svg>
             <span class="atab-label">Settings</span>
           </button>
+          <div class="atab-sep" role="separator" aria-hidden="true" hidden></div>
           <button id="aside-toggle" class="aside-toggle" type="button" aria-label="Hide panel" title="Hide panel">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path

--- a/public/styles.css
+++ b/public/styles.css
@@ -1528,6 +1528,21 @@ button.is-restarting .btn-spin::before {
   color: var(--text-color-default, #1f2328);
   border-bottom-color: var(--true-color-blue, #0969da);
 }
+/* Divider between the available tool panels and the greyed-out (unavailable)
+   ones that sink to the bottom of the bar. Sorted between the two groups via
+   `order` and only shown when an unavailable group actually exists. */
+.atab-sep {
+  flex: 0 0 auto;
+  order: 2;
+  align-self: stretch;
+  width: 1px;
+  height: auto;
+  margin: 0.1rem 0.15rem;
+  background: var(--border-color-muted, #d8dee4);
+}
+.atab-sep[hidden] {
+  display: none;
+}
 .aside-toggle {
   border: none;
   background: none;
@@ -1724,6 +1739,11 @@ button.is-restarting .btn-spin::before {
 }
 #workspace.aside-rail.aside-open .atab.active.unavailable {
   opacity: 1;
+}
+#workspace.aside-rail .atab-sep {
+  width: auto;
+  height: 1px;
+  margin: 0.2rem 0.3rem;
 }
 #workspace.aside-rail .aside-toggle {
   order: -1;


### PR DESCRIPTION
## Summary

The right-edge tool bar (Live JVM / Loggers / Scans / Settings) already sinks unavailable panels to the bottom via flex `order`, but nothing visually separated the active group from the greyed-out one, so the boundary was easy to miss.

This adds a thin horizontal rule between the two groups:

- `public/index.html` adds a `<div class="atab-sep" role="separator" hidden>` between the last tab and the collapse toggle.
- `public/app.js` sorts unavailable tabs to `order: 3` (separator is `order: 2`, available tabs `order: 1`) and unhides the separator only when at least one tab is actually disabled.
- `public/styles.css` styles `.atab-sep` as a subtle 1px rule (horizontal in the vertical rail) that collapses to nothing when hidden.

The divider only renders when there is a disabled group below it, so a fully-capable app shows no stray line.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas (served HTML/CSS/JS confirmed; all 7 UI smoke tests pass).
- [ ] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A - purely visual)
- [x] No secrets committed.

## Notes for reviewers

`aside-rail` is always on, so the bar is always a vertical column and the separator is a horizontal line. The base `.atab-sep` rule is written for the row layout too, with the rail override flipping it to full-width/1px-tall, in case the row layout is ever re-enabled.