### PR TITLE
Fix button hover flicker by removing the translateY lift

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -107,11 +107,10 @@ h1 {
 .update-btn:not(:disabled):hover {
   background: color-mix(in srgb, #000 14%, var(--true-color-green, #1a7f37));
   border-color: color-mix(in srgb, #000 14%, var(--true-color-green, #1a7f37));
-  transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
 .update-btn:not(:disabled):active {
-  transform: translateY(0) scale(0.96);
+  transform: scale(0.96);
   box-shadow: var(--shadow-sm);
 }
 .update-btn.is-busy,
@@ -227,20 +226,22 @@ button.tiny {
   padding: 0.15rem 0.5rem;
   font-size: 12px;
 }
-/* Hover-lift + press depth for the primary action buttons (header groups, the
-   green Run, the red Stops, the orange Fix). Excludes busy/disabled states so a
-   button that's mid-action doesn't bounce. The :active rules are declared after
-   the :hover rules so a press always wins the tie and reads as a real click. */
+/* Hover raise + press depth for the primary action buttons (header groups, the
+   green Run, the red Stops, the orange Fix). The raise is shadow-only: an earlier
+   `translateY(-1px)` lift shifted the hit-area off the cursor near a button's
+   bottom edge, which made hover oscillate (a visible cursor/shadow flicker).
+   Excludes busy/disabled states so a button that's mid-action doesn't bounce. The
+   :active rules are declared after the :hover rules so a press always wins the tie
+   and reads as a real click. */
 button.primary:not(:disabled):hover,
 button.danger:not(.is-stopping):not(.is-restarting):not(:disabled):hover,
 button.fix:not(:disabled):hover {
-  transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
 button.primary:not(:disabled):active,
 button.danger:not(:disabled):active,
 button.fix:not(:disabled):active {
-  transform: translateY(0) scale(0.96);
+  transform: scale(0.96);
   box-shadow: var(--shadow-sm);
 }
 input,


### PR DESCRIPTION
## Summary

Hovering over the action buttons made the cursor and button shadow flicker. The cause: `.primary` / `.danger` / `.fix` / `.update-btn` applied `transform: translateY(-1px)` on `:hover`. That 1px upward shift moves the button's hit-area off the cursor when the pointer is near the button's bottom edge, so `:hover` is lost, the button drops back, and hover re-triggers. That oscillation is what flickered the cursor (pointer ↔ default) and the shadow.

The raised look on hover is now carried entirely by the existing `box-shadow: var(--shadow-md)`, which does not move the hit-area, so hover stays steady. The press feedback is preserved via `:active { transform: scale(0.96) }` (a held state, so it never flickers).

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (CSS-only; no docs needed.)
- [x] No secrets committed.

## Notes for reviewers

CSS-only change in `public/styles.css`. The intentional hover-lift comment was updated to explain why the translate was dropped. Worth a quick manual hover check on the Build/Test/Package/Run buttons to confirm the flicker is gone and the shadow raise still reads as a lift.