### PR TITLE
Rename Scans tab to BootUI, restyle scan results, fix Gradle Run Stop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,7 +62,7 @@ are both first-class build tools, auto-detected per project.
   (`/bootui/api/panels` for discovery, `POST /bootui/api/{id}/scan` to run one), the
   MCP-server toggle/register bridge, and the fix-prompt builder.
 - `public/index.html`: the iframe UI markup (Build/Test/Package/Run + Live JVM +
-  Loggers + Scans + Settings tabs, live console, graphical test view, MCP-server
+  Loggers + BootUI + Settings tabs, live console, graphical test view, MCP-server
   bridge). Styles live in
   `public/styles.css` (canvas theme tokens, e.g. `var(--background-color-default, …)`)
   and client logic in `public/app.js`; both are served unauthenticated since they

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,7 +64,7 @@ Shipped in the extension today:
 - "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
   startup failures (including Quarkus dev-mode build/augmentation failures that keep
   the process running), for flame-graph hotspots, and for BootUI advisor-scan findings.
-- BootUI advisor scans run over REST (Scans tab), plus an optional MCP-server
+- BootUI advisor scans run over REST (BootUI tab), plus an optional MCP-server
   toggle/register bridge, when the running app exposes BootUI.
 - Per-project persisted settings (warm JVM, Spring profiles, devtools, random port,
   auto-open browser, auto-record flame graph at startup, and the last-opened

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ wins; when neither is found the console says so and stays disabled until one is 
   active JDK is shown as a pill next to the build tool. The change takes effect on
   the next launch, so stop a running app before switching.
 - **Advisor scans (with BootUI)** &mdash; when the running app exposes
-  [BootUI](https://github.com/jdubois/boot-ui), the **Scans** tab lists its advisor
+  [BootUI](https://github.com/jdubois/boot-ui), the **BootUI** tab lists its advisor
   scans (architecture, Spring, security, Hibernate, …) and runs them directly over
   BootUI's REST API; findings can be sent to the agent with one click. A separate
   **Register with Copilot** button can also enable BootUI's in-app MCP server and wire
@@ -135,7 +135,7 @@ The console adapts to whatever the project provides, detected from the build fil
 | **Quarkus**                   | Quarkus Maven plugin / `io.quarkus` Gradle plugin | Run via `quarkus:dev` (Maven) or `quarkusDev` (Gradle) — dev mode with built-in live reload — + editable Quarkus profile                                                                                                                |
 | **Actuator** (runtime)        | `/actuator/*` or `/management/*` answers          | Live metrics normalized from Actuator — JSON `/metrics` endpoint or the Prometheus scrape (heap, threads, health, uptime) — plus runtime log-level control when `/loggers` is exposed                                                   |
 | **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health                                                                                                                                                          |
-| **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the REST advisor-scan panel (Scans tab)                                                                                                                                                                     |
+| **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the REST advisor-scan panel (BootUI tab)                                                                                                                                                                    |
 
 A capability summary is shown in the status bar (including the active build tool), and
 the metrics panel carries a small badge (`BootUI` / `Actuator` / `Quarkus` / `process`)
@@ -245,7 +245,7 @@ Coffilot is a Node process (the extension) that:
 - proxies Spring Boot Actuator `/loggers` so the canvas can read and change logger
   levels on the running app without a restart;
 - runs BootUI's advisor scans straight from its REST API (`/bootui/api/panels` to
-  discover them, `POST /bootui/api/{id}/scan` to run one), surfaced in the **Scans**
+  discover them, `POST /bootui/api/{id}/scan` to run one), surfaced in the **BootUI**
   tab — no in-app MCP server required;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -4499,8 +4499,10 @@ function killChild(child) {
  * in a SEPARATE process, not in the spawned client's process group. So killing
  * the client (killChild) stops the streaming wrapper but can leave the daemon
  * compiling/testing in the background (CPU stays high, the run never really
- * stops). The Run lane never hits this because it runs the app as a direct child
- * in the killed group. The reliable, daemon-agnostic cancel is the tool's own
+ * stops). The Maven Run lane never hits this because it runs the app as a direct
+ * child in the killed group — but the Gradle Run lane does: Gradle executes the
+ * app inside the daemon, so stopApp() routes its Stop through here too. The
+ * reliable, daemon-agnostic cancel is the tool's own
  * `--stop`, which we've verified halts a *busy* daemon promptly. This trades the
  * warm JVM away on an explicit Stop (the next build starts cold), which is the
  * right call: Stop means stop, and the warm tier exists for back-to-back builds,
@@ -4558,6 +4560,7 @@ function stopApp(op) {
   else targets = ["build", "test", "package", "run", "debug"];
   let stopped = false;
   let warmBuildOp = null; // a build lane whose work is inside a daemon
+  let gradleAppOp = null; // a run/debug lane whose app JVM is owned by the Gradle daemon
   for (const o of targets) {
     if (o === "run" || o === "debug") {
       stopMetricsPolling();
@@ -4576,10 +4579,25 @@ function stopApp(op) {
       killChild(child);
       stopped = true;
       if (o !== "run" && o !== "debug" && lane.warm) warmBuildOp = o;
+      // Gradle runs the app (bootRun / quarkusDev / :module:run) inside its daemon,
+      // which forks the app JVM as a child of the daemon — not of the killed client
+      // — so killChild stops only the wrapper and leaves the app alive. Cancelling
+      // the daemon is the reliable Stop. (Maven's spring-boot:run / quarkus:dev fork
+      // the app inside the killed group, so they don't need this.)
+      if ((o === "run" || o === "debug") && buildTool === "gradle") gradleAppOp = o;
     }
   }
   // Build lanes are serialized, so at most one warm daemon build is ever live.
   if (warmBuildOp) stopBuildDaemon(warmBuildOp);
+  // An explicit Stop on a Gradle run/debug lane also cancels the daemon. We do this
+  // even when no client child is left to kill (op === "run"/"debug"): if the wrapper
+  // already exited on its own, the app is orphaned under the still-running daemon,
+  // and cancelling it is the only way to recover. Skip it when a build daemon stop
+  // already fired (same daemon) to avoid a redundant `--stop`.
+  if (!warmBuildOp && buildTool === "gradle" && (gradleAppOp || op === "run" || op === "debug")) {
+    stopBuildDaemon(gradleAppOp || (op === "debug" ? "debug" : "run"));
+    stopped = true;
+  }
   return stopped ? { ok: true, stopped: true } : { ok: true, stopped: false, note: "Nothing was running." };
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -92,7 +92,6 @@ const devtoolsToggle = document.getElementById("devtools-toggle");
 const devtoolsInput = document.getElementById("in-devtools");
 const setRandomport = document.getElementById("set-randomport");
 const randomportInput = document.getElementById("in-randomport");
-const setMcp = document.getElementById("mcp");
 const maskSecretsInput = document.getElementById("in-masksecrets");
 const metricsPollInput = document.getElementById("in-metricspoll");
 const openBrowserInput = document.getElementById("in-openbrowser");
@@ -377,6 +376,18 @@ function showAsideTab(name) {
   document.getElementById("atab-scans").classList.toggle("active", name === "scans");
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
   syncLoggersPolling();
+  syncAsideWide();
+}
+// BootUI scan reports can be wide (severity badges + expandable findings), so the
+// aside grows to a roomier width while scan results are on screen and snaps back
+// to its slim default on any other tab. The default stays the minimal width.
+let hasScanResults = false;
+function syncAsideWide() {
+  workspaceEl.classList.toggle("aside-wide", activeAsideTab() === "scans" && hasScanResults);
+}
+function markScanResults(on) {
+  hasScanResults = on;
+  syncAsideWide();
 }
 // Capture the current panel state as the persisted preference and save it. The
 // open/closed half is only meaningful for the docked (wide) layout — the narrow
@@ -442,24 +453,35 @@ workspaceEl.classList.remove("aside-open");
 syncAsideMode();
 
 // Tool-panel availability. Settings is always usable; the others need a running
-// app with the right capability (see updateAsideAvailability callers). Unavailable
-// panels are greyed and sorted to the bottom of the bar; clicking one still opens
-// it so its in-panel text explains what's missing.
+// app with the right capability (see updateAsideAvailability callers). Available
+// panels sort to the top of the bar and unavailable ones sink below, but within
+// each group the tabs keep a fixed canonical order (ASIDE_ORDER) so they never
+// shuffle relative to one another. Clicking a greyed tab still opens it so its
+// in-panel text explains what's missing.
 const ASIDE_ALWAYS = new Set(["settings"]);
+// Canonical left-to-right order, applied within both the available and the
+// unavailable group. Settings always leads the available group (it's never
+// unavailable); "quarkus" reserves the trailing slot for a future Quarkus tab.
+const ASIDE_ORDER = ["settings", "metrics", "loggers", "scans", "quarkus"];
 const ASIDE_REASON = {
   metrics:
     "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
   loggers: "Live log levels need a running Spring Boot app with the Actuator /loggers endpoint. Click to learn more.",
-  scans: "Advisor scans need a running BootUI app. Click to learn more.",
+  scans: "The BootUI panel needs a running BootUI app — Run a module with the BootUI starter. Click to learn more.",
 };
+// metrics / loggers / scans are each gated on the running app exposing the right
+// capability (see updateAsideAvailability callers); the BootUI (scans) tab is
+// available only while a BootUI app is actually up, exactly like the other two.
 function updateAsideAvailability(avail) {
   document.querySelectorAll(".atab").forEach((btn) => {
     const name = btn.dataset.atab;
     const ok = ASIDE_ALWAYS.has(name) || !!(avail && avail[name]);
     btn.classList.toggle("unavailable", !ok);
     btn.setAttribute("aria-disabled", ok ? "false" : "true");
-    // Available tools keep their DOM order at the top; unavailable ones sink down.
-    btn.style.order = ok ? "1" : "2";
+    // Available group sorts before the unavailable group; the canonical index
+    // fixes the order within each group regardless of DOM order.
+    const rank = ASIDE_ORDER.indexOf(name);
+    btn.style.order = String((ok ? 0 : 100) + (rank === -1 ? ASIDE_ORDER.length : rank));
     if (!btn.dataset.titleAvail) btn.dataset.titleAvail = btn.getAttribute("title") || "";
     btn.title = ok ? btn.dataset.titleAvail : ASIDE_REASON[name] || btn.dataset.titleAvail;
   });
@@ -1166,7 +1188,7 @@ function renderMetrics(m) {
 }
 
 // ---- BootUI MCP server panel (agent bridge only) ----------------------
-// Coffilot reads advisor scans over REST (see the Scans tab); this panel just
+// Coffilot reads advisor scans over REST (see the BootUI tab); this panel just
 // manages the in-app MCP server that exposes those scans to the Copilot CLI as
 // native tools, so the toggle/register controls are all that remain here.
 
@@ -1187,11 +1209,10 @@ function showMcpRegister(show) {
 }
 
 // The MCP server lives inside the running app, so the toggle is only
-// actionable while a BootUI app (dev profile) exposes its endpoint. For
-// Spring Boot modules the row stays visible in Settings even when the
-// endpoint is unavailable (greyed out with an explanation rather than
-// hidden); the whole panel is hidden for non-Spring modules in
-// updateDevSetup(), since BootUI is a Spring-only tier.
+// actionable while a BootUI app (dev profile) exposes its endpoint. The row
+// always stays visible in the BootUI panel; when the endpoint is unavailable
+// it's greyed out and disabled (rather than hidden) so the control is always
+// discoverable.
 function setMcpUnavailable() {
   mcpToggle.checked = false;
   mcpToggle.disabled = true;
@@ -1222,12 +1243,35 @@ async function getJson(path) {
   }
 }
 
-// ---- BootUI advisor scans (Scans aside tab) ---------------------------
+// ---- BootUI advisor scans (BootUI aside tab) --------------------------
 // Read straight from BootUI's REST API: /api/scans lists the advisor scans the
 // running app exposes (sourced from /bootui/api/panels), and /api/scan runs one
 // (POST /bootui/api/{id}/scan). No MCP server round-trip and no enable step — the
 // scans show up whenever a BootUI app is up on the metrics "bootui" tier.
 let scansLoaded = false;
+let currentScans = [];
+
+// A running BootUI app discovers its advisor scans at runtime, but we still show
+// the known set as disabled buttons while no BootUI app is up, so the panel keeps
+// presenting its scan controls (greyed) instead of an empty gap.
+const SCAN_PLACEHOLDERS = [
+  "Architecture",
+  "Spring",
+  "Hibernate",
+  "Memory",
+  "Security",
+  "Pentesting",
+  "REST API",
+  "GraalVM",
+  "CRaC",
+];
+function renderScanPlaceholders() {
+  scansListEl.innerHTML =
+    `<button class="tiny scan-all" disabled title="Available once a BootUI app is running.">Scan all</button>` +
+    SCAN_PLACEHOLDERS.map(
+      (label) => `<button class="tiny" disabled title="Available once a BootUI app is running.">${esc(label)}</button>`,
+    ).join("");
+}
 
 function renderScans(available) {
   if (!available) {
@@ -1235,8 +1279,9 @@ function renderScans(available) {
     scansSrc.hidden = true;
     scansHint.innerHTML =
       'Start a <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a> app (dev profile) with <strong>Run</strong> to run its advisor scans against the live app.';
-    scansListEl.innerHTML = "";
+    renderScanPlaceholders();
     scansResultEl.innerHTML = "";
+    markScanResults(false);
     return;
   }
   scansSrc.hidden = false;
@@ -1247,41 +1292,216 @@ async function loadScans() {
   const st = await getJson("/api/scans");
   const scans = (st && st.scans) || [];
   scansLoaded = true;
+  currentScans = scans;
   if (!scans.length) {
     scansHint.textContent = "No advisor scans are available on the running app.";
     scansListEl.innerHTML = "";
     return;
   }
   scansHint.textContent = "Run a BootUI advisor scan against the running app, then push its findings to Copilot.";
-  scansListEl.innerHTML = scans
-    .map(
-      (s) =>
-        `<button class="tiny" data-scan="${esc(s.id)}" title="${esc(s.description || s.label)}">${esc(s.label)}</button>`,
-    )
-    .join("");
+  scansListEl.innerHTML =
+    `<button class="tiny scan-all" id="scan-all" title="Run every advisor scan in turn.">Scan all</button>` +
+    scans
+      .map(
+        (s) =>
+          `<button class="tiny" data-scan="${esc(s.id)}" title="${esc(s.description || s.label)}">${esc(s.label)}</button>`,
+      )
+      .join("");
   scansListEl.querySelectorAll("button[data-scan]").forEach((b) => (b.onclick = () => runScan(b.dataset.scan)));
+  const all = document.getElementById("scan-all");
+  if (all) all.onclick = runAllScans;
 }
 
 async function runScan(scanKey) {
   scansResultEl.innerHTML = `<span class="muted">Running ${esc(scanKey)}\u2026</span>`;
+  markScanResults(true);
   const r = await postJson("/api/scan", { tool: scanKey });
   if (!r || r.ok === false) {
     scansResultEl.innerHTML = `<span style="color:var(--true-color-red,#cf222e)">Scan failed: ${esc((r && r.error) || "unknown error")}</span>`;
     return;
   }
-  lastScan = { tool: r.tool || scanKey, result: r.result };
-  const text = typeof r.result === "string" ? r.result : JSON.stringify(r.result, null, 2);
-  scansResultEl.innerHTML =
-    `<div style="display:flex;align-items:center;gap:0.5rem;justify-content:space-between">` +
+  const entry = { tool: r.tool || scanKey, result: r.result };
+  lastScan = entry;
+  scansResultEl.innerHTML = scanReportHtml(r, scanKey, "scan-send");
+  wireScanSend("scan-send", entry);
+}
+
+// Run every available advisor scan in turn, appending each report so the user
+// gets one combined run from the prominent "Scan all" button. Each report keeps
+// its own "Fix findings with Copilot" CTA.
+async function runAllScans() {
+  if (!currentScans.length) return;
+  const all = document.getElementById("scan-all");
+  const orig = all ? all.textContent : "Scan all";
+  setScanRowDisabled(true);
+  scansResultEl.innerHTML = "";
+  markScanResults(true);
+  for (let i = 0; i < currentScans.length; i++) {
+    const s = currentScans[i];
+    if (all) all.textContent = `Scanning\u2026 ${i + 1}/${currentScans.length}`;
+    scansResultEl.insertAdjacentHTML(
+      "beforeend",
+      `<div class="muted" id="scan-progress">Running ${esc(s.label)}\u2026</div>`,
+    );
+    const r = await postJson("/api/scan", { tool: s.id });
+    const prog = document.getElementById("scan-progress");
+    if (prog) prog.remove();
+    if (!r || r.ok === false) {
+      scansResultEl.insertAdjacentHTML(
+        "beforeend",
+        `<div class="scan-result-item"><strong>${esc(s.label)}</strong> <span style="color:var(--true-color-red,#cf222e)">scan failed: ${esc((r && r.error) || "unknown error")}</span></div>`,
+      );
+      continue;
+    }
+    const entry = { tool: r.tool || s.id, result: r.result };
+    lastScan = entry;
+    const sendId = `scan-send-${i}`;
+    scansResultEl.insertAdjacentHTML("beforeend", scanReportHtml(r, s.id, sendId));
+    wireScanSend(sendId, entry);
+  }
+  if (all) all.textContent = orig;
+  setScanRowDisabled(false);
+}
+
+function setScanRowDisabled(on) {
+  scansListEl.querySelectorAll("button").forEach((b) => (b.disabled = on));
+}
+
+// Render a scan report as a compact list: one collapsible line per finding
+// (severity badge + title), expanding to its details. Defensive about the report
+// shape — advisors return different DTOs — and falls back to a single collapsible
+// raw-JSON row when no findings array is recognised.
+const SCAN_FINDING_KEYS = ["results", "findings", "violations", "issues", "problems", "items", "messages", "entries"];
+const SCAN_TITLE_KEYS = ["title", "name", "message", "summary", "rule", "description", "id"];
+const SCAN_SKIP_KEYS = new Set(["severity", "level", "priority", "dismissed"]);
+
+function scanReportHtml(r, scanKey, sendId) {
+  const result = r.result;
+  const findings = extractFindings(result);
+  const head =
+    `<div class="scan-result-head">` +
     `<strong>${esc(r.label || scanKey)}</strong>` +
-    `<button class="fix fix-copilot tiny" id="scan-send">Fix findings with Copilot</button></div>` +
-    `<pre>${esc(text)}</pre>`;
-  const send = document.getElementById("scan-send");
+    scanCountsHtml(result, findings) +
+    `<button class="fix fix-copilot tiny" id="${sendId}">Fix findings with Copilot</button>` +
+    `</div>`;
+  let body;
+  if (Array.isArray(findings)) {
+    if (!findings.length) {
+      body = `<p class="scan-empty muted">${esc(scanStatusMessage(result) || "No findings \u2014 looks clean.")}</p>`;
+    } else {
+      body = `<div class="scan-findings">${findings.map(findingRowHtml).join("")}</div>`;
+    }
+  } else {
+    const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+    body =
+      `<details class="scan-finding"><summary><span class="finding-title">View report</span></summary>` +
+      `<div class="finding-body"><pre class="finding-json">${esc(text)}</pre></div></details>`;
+  }
+  return `<div class="scan-result-item">${head}${body}</div>`;
+}
+
+function extractFindings(result) {
+  if (Array.isArray(result)) return result;
+  if (result && typeof result === "object") {
+    for (const k of SCAN_FINDING_KEYS) if (Array.isArray(result[k])) return result[k];
+  }
+  return null;
+}
+
+function scanStatusMessage(result) {
+  if (!result || typeof result !== "object") return "";
+  return (result.scan && result.scan.message) || result.message || result.status || "";
+}
+
+function scanCountsHtml(result, findings) {
+  if (result && Array.isArray(result.severityCounts)) {
+    const badges = result.severityCounts
+      .filter((c) => c && Number(c.count) > 0)
+      .map(
+        (c) => `<span class="sev-badge ${sevClass(c.severity)}">${esc(String(c.severity))} ${Number(c.count)}</span>`,
+      )
+      .join("");
+    if (badges) return `<span class="scan-counts">${badges}</span>`;
+  }
+  if (Array.isArray(findings) && findings.length)
+    return `<span class="scan-counts muted">${findings.length} finding${findings.length === 1 ? "" : "s"}</span>`;
+  return "";
+}
+
+function findingRowHtml(item) {
+  const { sev, title, titleKey } = findingSummary(item);
+  const badge = sev ? `<span class="sev-badge ${sevClass(sev)}">${esc(sev)}</span>` : "";
+  const detail = findingDetailHtml(item, titleKey);
+  if (!detail) return `<div class="scan-finding flat">${badge}<span class="finding-title">${esc(title)}</span></div>`;
+  return (
+    `<details class="scan-finding"><summary>${badge}<span class="finding-title">${esc(title)}</span></summary>` +
+    `<div class="finding-body">${detail}</div></details>`
+  );
+}
+
+function findingSummary(item) {
+  if (item == null) return { sev: "", title: "\u2014", titleKey: null };
+  if (typeof item !== "object") return { sev: "", title: String(item), titleKey: null };
+  const sev = item.severity || item.level || item.priority || "";
+  let title = "Finding";
+  let titleKey = null;
+  for (const k of SCAN_TITLE_KEYS) {
+    const v = item[k];
+    if (v != null && String(v).trim() !== "") {
+      title = String(v);
+      titleKey = k;
+      break;
+    }
+  }
+  return { sev: String(sev), title, titleKey };
+}
+
+function findingDetailHtml(item, titleKey) {
+  if (item == null || typeof item !== "object") return "";
+  const rows = [];
+  for (const [k, v] of Object.entries(item)) {
+    if (k === titleKey || SCAN_SKIP_KEYS.has(k)) continue;
+    if (v == null || v === "" || (Array.isArray(v) && v.length === 0)) continue;
+    rows.push(
+      `<div class="finding-kv"><span class="fk">${esc(prettyKey(k))}</span><span class="fv">${renderScanVal(v)}</span></div>`,
+    );
+  }
+  return rows.join("");
+}
+
+function prettyKey(k) {
+  return String(k)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+function renderScanVal(v) {
+  if (Array.isArray(v))
+    return `<ul class="finding-list">${v
+      .map((x) => `<li>${x && typeof x === "object" ? `<code>${esc(JSON.stringify(x))}</code>` : esc(String(x))}</li>`)
+      .join("")}</ul>`;
+  if (v && typeof v === "object") return `<pre class="finding-json">${esc(JSON.stringify(v, null, 2))}</pre>`;
+  const s = String(v);
+  if (/^https?:\/\/\S+$/.test(s)) return `<a href="${esc(s)}" target="_blank" rel="noopener">${esc(s)}</a>`;
+  return esc(s);
+}
+
+function sevClass(sev) {
+  const s = String(sev || "").toLowerCase();
+  if (s.startsWith("crit")) return "sev-critical";
+  if (s.startsWith("high") || s === "error" || s === "blocker") return "sev-high";
+  if (s.startsWith("med") || s.startsWith("warn")) return "sev-medium";
+  if (s.startsWith("low") || s === "minor") return "sev-low";
+  return "sev-info";
+}
+
+function wireScanSend(sendId, entry) {
+  const send = document.getElementById(sendId);
   if (send)
     send.onclick = async () => {
       send.disabled = true;
       send.textContent = "Sent to Copilot \u2713";
-      await post("/api/fix", { kind: "mcp", tool: lastScan.tool, result: lastScan.result });
+      await post("/api/fix", { kind: "mcp", tool: entry.tool, result: entry.result });
     };
 }
 let lastScan = null;
@@ -1701,20 +1921,24 @@ function updateDevSetup() {
   setSpring.hidden = !framework;
   setDevtools.hidden = !spring;
   setRandomport.hidden = !framework;
-  // BootUI (and its MCP advisor scans) is a Spring-only tier, so only surface
-  // the MCP server panel for Spring Boot modules.
-  setMcp.hidden = !spring;
+  // The BootUI MCP server toggle stays visible in the BootUI panel; renderMcp /
+  // setMcpUnavailable grey and disable it until a running BootUI app exposes the
+  // endpoint, so it is never hidden.
 
   // Relabel the run-profile combo and swap its suggestions for the framework.
   if (lblProfiles) lblProfiles.textContent = quarkus ? "Quarkus profile" : "Spring Boot profiles";
   profileItems = quarkus ? quarkusItems : springItems;
 
-  const showBootui = spring && !mod.bootui;
-  btnAddBootui.hidden = !showBootui;
-  if (showBootui) {
-    btnAddBootui.disabled = false;
-    btnAddBootui.textContent = caps.gradle ? "Add BootUI (developmentOnly)" : "Add BootUI to dev profile";
-  }
+  // Activate-BootUI CTA: only available — shown and enabled — for a Spring Boot
+  // module that doesn't depend on BootUI yet. Hidden for non-Spring apps and once
+  // the module already has BootUI (since it's then active).
+  const hasBootui = !!(mod && mod.bootui);
+  const canAddBootui = spring && !hasBootui;
+  btnAddBootui.hidden = !canAddBootui;
+  btnAddBootui.disabled = !canAddBootui;
+  btnAddBootui.textContent = caps.gradle ? "Add BootUI (developmentOnly)" : "Add BootUI to dev profile";
+  btnAddBootui.title =
+    "Add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
 
   const hasDevtools = spring && !!mod.devtools;
   const showDevtools = spring && !mod.devtools;

--- a/public/index.html
+++ b/public/index.html
@@ -427,13 +427,23 @@
             </svg>
             <span class="atab-label">Loggers</span>
           </button>
-          <button class="atab" data-atab="scans" title="Run BootUI advisor scans against the live app">
+          <button
+            class="atab"
+            data-atab="scans"
+            title="BootUI: add it to your project, run advisor scans against the live app, and bridge its MCP server to Copilot"
+          >
+            <!-- BootUI brand mark (the "hot cup"), drawn monochrome via
+               currentColor so it sizes and greys exactly like the other rail icons. -->
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
-                d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"
+                fill-rule="evenodd"
+                d="M.5 6a.5.5 0 0 0-.488.608l1.652 7.434A2.5 2.5 0 0 0 4.104 16h5.792a2.5 2.5 0 0 0 2.44-1.958l.131-.59a3 3 0 0 0 1.3-5.854l.221-.99A.5.5 0 0 0 13.5 6zM13 12.5a2 2 0 0 1-.316-.025l.867-3.898A2.001 2.001 0 0 1 13 12.5"
+              />
+              <path
+                d="m4.4.8-.003.004-.014.019a4 4 0 0 0-.204.31 2 2 0 0 0-.141.267c-.026.06-.034.092-.037.103v.004a.6.6 0 0 0 .091.248c.075.133.178.272.308.445l.01.012c.118.158.26.347.37.543.112.2.22.455.22.745 0 .188-.065.368-.119.494a3 3 0 0 1-.202.388 5 5 0 0 1-.253.382l-.018.025-.005.008-.002.002A.5.5 0 0 1 3.6 4.2l.003-.004.014-.019a4 4 0 0 0 .204-.31 2 2 0 0 0 .141-.267c.026-.06.034-.092.037-.103a.6.6 0 0 0-.09-.252A4 4 0 0 0 3.6 2.8l-.01-.012a5 5 0 0 1-.37-.543A1.53 1.53 0 0 1 3 1.5c0-.188.065-.368.119-.494.059-.138.134-.274.202-.388a6 6 0 0 1 .253-.382l.025-.035A.5.5 0 0 1 4.4.8m3 0-.003.004-.014.019a4 4 0 0 0-.204.31 2 2 0 0 0-.141.267c-.026.06-.034.092-.037.103v.004a.6.6 0 0 0 .091.248c.075.133.178.272.308.445l.01.012c.118.158.26.347.37.543.112.2.22.455.22.745 0 .188-.065.368-.119.494a3 3 0 0 1-.202.388 5 5 0 0 1-.253.382l-.018.025-.005.008-.002.002A.5.5 0 0 1 6.6 4.2l.003-.004.014-.019a4 4 0 0 0 .204-.31 2 2 0 0 0 .141-.267c.026-.06.034-.092.037-.103a.6.6 0 0 0-.09-.252A4 4 0 0 0 6.6 2.8l-.01-.012a5 5 0 0 1-.37-.543A1.53 1.53 0 0 1 6 1.5c0-.188.065-.368.119-.494.059-.138.134-.274.202-.388a6 6 0 0 1 .253-.382l.025-.035A.5.5 0 0 1 7.4.8m3 0-.003.004-.014.019a4 4 0 0 0-.204.31 2 2 0 0 0-.141.267c-.026.06-.034.092-.037.103v.004a.6.6 0 0 0 .091.248c.075.133.178.272.308.445l.01.012c.118.158.26.347.37.543.112.2.22.455.22.745 0 .188-.065.368-.119.494a3 3 0 0 1-.202.388 5 5 0 0 1-.252.382l-.019.025-.005.008-.002.002A.5.5 0 0 1 9.6 4.2l.003-.004.014-.019a4 4 0 0 0 .204-.31 2 2 0 0 0 .141-.267c.026-.06.034-.092.037-.103a.6.6 0 0 0-.09-.252A4 4 0 0 0 9.6 2.8l-.01-.012a5 5 0 0 1-.37-.543A1.53 1.53 0 0 1 9 1.5c0-.188.065-.368.119-.494.059-.138.134-.274.202-.388a6 6 0 0 1 .253-.382l.025-.035A.5.5 0 0 1 10.4.8"
               />
             </svg>
-            <span class="atab-label">Scans</span>
+            <span class="atab-label">BootUI</span>
           </button>
           <button class="atab active" data-atab="settings" title="Per-project settings">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
@@ -483,7 +493,48 @@
           </div>
 
           <div id="atab-scans" class="apane">
-            <h2>Advisor scans<span id="scans-src" class="src bootui" hidden>BootUI</span></h2>
+            <h2>BootUI Spring Boot Starter<span id="scans-src" class="src bootui" hidden>live</span></h2>
+            <p class="hint" id="bootui-desc">
+              An embedded, local-only developer console for Spring Boot. Add the starter to a Spring Boot module to
+              unlock richer live metrics and its advisor scans (architecture, security, Hibernate, …), then push
+              findings to Copilot.
+              <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">Learn more</a>.
+            </p>
+            <!-- Activate BootUI: the CTA to add the starter. Enabled for a Spring
+               module without BootUI, shown disabled elsewhere, and hidden once the
+               module already depends on BootUI (then it's active). -->
+            <button id="btn-add-bootui" class="fix fix-copilot tiny" style="margin-top: 0.4rem" hidden>
+              Add BootUI to dev profile
+            </button>
+
+            <!-- BootUI MCP server: optional bridge that exposes the running app's
+               advisor scans to the Copilot CLI as native MCP tools. The advisor
+               scans below read them over REST and don't need this. -->
+            <div id="mcp" class="mcp-settings">
+              <div class="switch-row">
+                <label class="switch disabled" id="mcp-toggle-label">
+                  <input type="checkbox" id="mcp-toggle" disabled />
+                  <span class="track"><span class="thumb"></span></span>
+                  <span class="switch-label">BootUI MCP server</span>
+                </label>
+                <span id="mcp-state" class="mcp-state"></span>
+                <span
+                  class="info"
+                  tabindex="0"
+                  data-tip="Run BootUI's MCP server inside the running app and register it with the Copilot CLI so the agent can call its advisor scans (architecture, security, Hibernate, …) natively in chat. The advisor scans below run directly over REST and don't need this."
+                  >&#9432;</span
+                >
+                <button id="mcp-register" class="fix tiny" style="margin-left: auto" hidden>
+                  Register with Copilot
+                </button>
+              </div>
+              <p class="hint" id="mcp-hint">
+                Optional: expose the running app's advisor scans to the Copilot CLI as native MCP tools. The advisor
+                scans below run directly over REST without this.
+              </p>
+            </div>
+
+            <h2>Advisor scans</h2>
             <p class="hint" id="scans-hint">
               Start a <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a> app (dev
               profile) with <strong>Run</strong> to run its advisor scans against the live app.
@@ -655,37 +706,10 @@
               />
             </div>
 
-            <!-- Dev setup proposals (moved here from the top banners) -->
+            <!-- Dev setup proposal: add Spring Boot DevTools to the dev profile.
+               (The BootUI proposal now lives in the BootUI panel.) -->
             <div class="set-row set-proposals">
-              <button id="btn-add-bootui" class="fix tiny" hidden>Add BootUI to dev profile</button>
               <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
-            </div>
-
-            <!-- BootUI MCP server: optional bridge that exposes the running app's
-               advisor scans to the Copilot CLI as native MCP tools. Coffilot's own
-               Scans tab reads those scans over REST and does not need this. -->
-            <div id="mcp" class="mcp-settings">
-              <div class="switch-row">
-                <label class="switch disabled" id="mcp-toggle-label">
-                  <input type="checkbox" id="mcp-toggle" disabled />
-                  <span class="track"><span class="thumb"></span></span>
-                  <span class="switch-label">BootUI MCP server</span>
-                </label>
-                <span id="mcp-state" class="mcp-state"></span>
-                <span
-                  class="info"
-                  tabindex="0"
-                  data-tip="Run BootUI's MCP server inside the running app and register it with the Copilot CLI so the agent can call its advisor scans (architecture, security, Hibernate, …) natively in chat. The Scans tab runs these directly over REST and doesn't need this."
-                  >&#9432;</span
-                >
-                <button id="mcp-register" class="fix tiny" style="margin-left: auto" hidden>
-                  Register with Copilot
-                </button>
-              </div>
-              <p class="hint" id="mcp-hint">
-                Optional: expose the running app's advisor scans to the Copilot CLI as native MCP tools. The
-                <strong>Scans</strong> tab runs them directly over REST without this.
-              </p>
             </div>
           </div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -911,8 +911,10 @@ aside h2 {
 }
 #mcp.mcp-settings {
   border-top: 1px solid var(--border-color-default, #d0d7de);
+  border-bottom: 1px solid var(--border-color-default, #d0d7de);
   margin-top: 0.4rem;
   padding-top: 0.9rem;
+  padding-bottom: 0.9rem;
 }
 #mcp .mcp-state {
   color: var(--text-color-muted, #656d76);
@@ -925,6 +927,7 @@ aside h2 {
 .scans {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.35rem;
   margin: 0.6rem 0 0;
 }
@@ -932,9 +935,28 @@ aside h2 {
   padding: 0.2rem 0.55rem;
   font-size: 12px;
 }
+/* The "Scan all" CTA leads the row and is filled (blue) so it reads as the
+   prominent way to run every advisor scan at once, distinct from the neutral
+   per-scan buttons that follow it. */
+.scans button.scan-all {
+  font-weight: 600;
+  margin-right: 0.15rem;
+  border-color: var(--true-color-blue, #0969da);
+  color: var(--color-white, #fff);
+  background: var(--true-color-blue, #0969da);
+}
+.scans button.scan-all:not(:disabled):hover {
+  background: color-mix(in srgb, #000 14%, var(--true-color-blue, #0969da));
+  border-color: color-mix(in srgb, #000 14%, var(--true-color-blue, #0969da));
+}
 #scans-result {
   margin-top: 0.6rem;
   font-size: 12px;
+}
+.scan-result-item + .scan-result-item {
+  margin-top: 0.7rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--border-color-muted, #d8dee4);
 }
 #scans-result pre {
   margin: 0.35rem 0 0;
@@ -947,6 +969,130 @@ aside h2 {
   font-size: 11.5px;
   white-space: pre-wrap;
   word-break: break-word;
+}
+/* A scan report: a header row (label + severity/finding counts + Fix CTA) above a
+   list of findings, each finding a single collapsible line. */
+.scan-result-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.scan-result-head strong {
+  flex: 0 0 auto;
+}
+.scan-result-head .scan-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-right: auto;
+}
+.scan-result-head button {
+  flex: 0 0 auto;
+}
+.scan-findings {
+  margin-top: 0.5rem;
+  border: 1px solid var(--border-color-muted, #d8dee4);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.scan-finding {
+  border-top: 1px solid var(--border-color-muted, #d8dee4);
+}
+.scan-finding:first-child {
+  border-top: none;
+}
+.scan-finding > summary,
+.scan-finding.flat {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  cursor: pointer;
+  list-style: none;
+}
+.scan-finding.flat {
+  cursor: default;
+}
+.scan-finding > summary::-webkit-details-marker {
+  display: none;
+}
+/* Caret that rotates when the row is open. */
+.scan-finding > summary::before {
+  content: "\u203A";
+  flex: 0 0 auto;
+  color: var(--text-color-muted, #656d76);
+  transition: transform var(--dur-fast, 0.12s) var(--ease-out, ease);
+}
+.scan-finding[open] > summary::before {
+  transform: rotate(90deg);
+}
+.scan-finding > summary:hover {
+  background: var(--background-color-muted, #f6f8fa);
+}
+.scan-finding .finding-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.scan-finding[open] .finding-title {
+  white-space: normal;
+}
+.finding-body {
+  padding: 0.1rem 0.6rem 0.5rem 1.4rem;
+  font-size: 11.5px;
+}
+.finding-kv {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.15rem 0;
+}
+.finding-kv .fk {
+  flex: 0 0 8rem;
+  color: var(--text-color-muted, #656d76);
+}
+.finding-kv .fv {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+.finding-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+.finding-json {
+  margin: 0.2rem 0 0 !important;
+}
+.scan-empty {
+  margin: 0.5rem 0 0;
+}
+/* Severity badge, coloured by level. */
+.sev-badge {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  line-height: 1.5;
+}
+.sev-badge.sev-critical {
+  color: var(--true-color-red, #cf222e);
+}
+.sev-badge.sev-high {
+  color: var(--true-color-orange, #bc4c00);
+}
+.sev-badge.sev-medium {
+  color: var(--true-color-yellow, #9a6700);
+}
+.sev-badge.sev-low {
+  color: var(--true-color-blue, #0969da);
+}
+.sev-badge.sev-info {
+  color: var(--text-color-muted, #656d76);
 }
 
 /* Install hint banner (shown only when mvnd is missing) */
@@ -1534,6 +1680,7 @@ button.is-restarting .btn-spin::before {
   color: var(--text-color-muted, #656d76);
   padding: 0.25rem;
   margin-left: auto;
+  order: 200;
   border-radius: 6px;
   display: inline-flex;
   align-items: center;
@@ -1736,6 +1883,13 @@ button.is-restarting .btn-spin::before {
   flex: 0 0 auto;
   width: min(310px, 80vw);
   border-left: 1px solid var(--border-color-default, #d0d7de);
+  transition: width var(--dur-slow, 0.24s) var(--ease-out, ease);
+}
+/* Scan reports (severity badges + expandable findings) can be wide, so the aside
+   grows to a roomier width while scan results are on screen and snaps back to its
+   slim default otherwise. */
+#workspace.aside-rail.aside-wide .aside-body {
+  width: min(560px, 92vw);
 }
 #workspace.aside-rail:not(.aside-open) .aside-body {
   display: none;


### PR DESCRIPTION
## Summary

This reshapes the right-hand aside panel around BootUI and fixes a Stop bug that left Gradle apps running.

- **Rename the "Scans" tab to "BootUI"** (monochrome cup icon, fixed tab ordering) and consolidate the BootUI install button and the MCP-server toggle into it. The BootUI tab's availability is runtime-based, just like Live JVM and Loggers (active only while a BootUI app is running; greyed but still clickable otherwise).
- **Restyle advisor-scan reports.** Instead of dumping raw JSON, each report now renders a header row (label + severity-count badges + "Fix findings with Copilot") above one collapsible line per finding (severity badge + title that expands to clean key/value detail rows, with list/link/nested-object rendering). The renderer is defensive about the differing advisor DTO shapes and falls back to a single collapsible "View report" for anything it doesn't recognize.
- **Auto-widen the aside for scans.** The panel keeps its slim default width and grows to a roomier width only while scan results are on screen, then snaps back when you leave the BootUI tab.
- **Fix Stop doing nothing for Gradle Run/Debug.** Every Gradle run mode (`bootRun`, `quarkusDev`, `:module:run`) executes inside the Gradle daemon, which forks the app JVM as a child of the daemon rather than of the `gradlew` client we spawn. Killing that client left the app alive, so Stop appeared to do nothing. Stop now also cancels the daemon (`gradlew --stop`) for run/debug lanes, which terminates the forked app JVM. Maven `spring-boot:run`/`quarkus:dev` and the plain `java` paths fork inside the killed group, so they are unaffected.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the BootUI tab, restyled scan rendering, and auto-widen in a live Coffilot canvas; reloaded and re-opened the canvas after each change. Confirmed the scan renderer output against a realistic Spring report sample. (Note: the Gradle Stop fix is verified by code inspection plus the existing test suite; the test project here is Maven.)
- [x] Updated `README.md` / `PLAN.md` (and `.github/copilot-instructions.md`) for the Scans -> BootUI rename.
- [x] No secrets committed.

## Notes for reviewers

The most behavior-sensitive change is the Gradle Stop fix in `stopApp` (extension.mjs). An explicit Stop on a Gradle run/debug lane now issues `gradlew --stop` even when no client child remains, so an already-orphaned app can still be cleaned up; a redundant `--stop` is skipped when a warm-build daemon stop already covered it. This trades the warm Gradle daemon away on an explicit Run Stop (the next build starts cold), consistent with how the build lanes already treat Stop.

One interpretation call worth a look: BootUI tab availability is runtime-based (`appUp && tier === "bootui"`), which also satisfies the earlier "installed in the module" intent since the bootui tier only appears when BootUI is both installed in the running module and up. If static (configured-in-module) gating is preferred instead, it's an easy follow-up.