### PR TITLE
Enrich the Quarkus Live JVM panel

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -5298,6 +5298,23 @@ async function actuatorMetrics(base) {
 // Micrometer output, so we normalize them into the same shape as the BootUI /
 // Actuator tiers.
 
+/**
+ * Normalize SmallRye Health (/q/health) into { status, checks }, where each check
+ * is a MicroProfile Health entry ({ name, status }) — e.g. the datasource, Kafka or
+ * readiness probes a Quarkus app registers. This is the Quarkus tier's answer to
+ * Spring Boot's component health, and is available from /q/health even when the app
+ * ships no Micrometer registry (so the panel shows more than a bare "UP").
+ */
+function normalizeQuarkusHealth(health) {
+  if (!health) return null;
+  const checks = Array.isArray(health.checks)
+    ? health.checks
+        .filter((c) => c && (c.name != null || c.status != null))
+        .map((c) => ({ name: c.name != null ? String(c.name) : "check", status: c.status ?? null }))
+    : [];
+  return { status: health.status ?? null, checks };
+}
+
 /** Normalize Quarkus /q/metrics + /q/health into the same shape as the other tiers. */
 export function quarkusMetrics(metricsText, health) {
   const s = metricsText ? parsePrometheus(metricsText) : null;
@@ -5307,12 +5324,17 @@ export function quarkusMetrics(metricsText, health) {
     overview: {
       applicationName: null,
       springBootVersion: null,
-      javaVersion: s ? promFirstLabel(s, "jvm_info", "version") : null,
+      // Micrometer's legacy Prometheus client exposed the JVM gauge as jvm_info,
+      // while the current client (Quarkus 3.x) renames it to jvm_info_total — read
+      // the version label from whichever one this app emits.
+      javaVersion: s
+        ? (promFirstLabel(s, "jvm_info", "version") ?? promFirstLabel(s, "jvm_info_total", "version"))
+        : null,
       activeProfiles: [],
       startupTimeMillis: null,
     },
     memory: null,
-    health: health ? { status: health.status } : null,
+    health: normalizeQuarkusHealth(health),
     threads: null,
   };
   if (s) {

--- a/public/app.js
+++ b/public/app.js
@@ -482,7 +482,8 @@ function updateAsideAvailability(avail) {
     btn.setAttribute("aria-disabled", ok ? "false" : "true");
     // Available group sorts before the unavailable group; the canonical index
     // fixes the order within each group regardless of DOM order. The separator
-    // (.atab-sep, order 50) sits between the two ranges.
+    // (.atab-sep, order 50) sits between the two ranges. Settings is first in
+    // ASIDE_ORDER, so it stays pinned to the top of the bar.
     const rank = ASIDE_ORDER.indexOf(name);
     btn.style.order = String((ok ? 0 : 100) + (rank === -1 ? ASIDE_ORDER.length : rank));
     if (!btn.dataset.titleAvail) btn.dataset.titleAvail = btn.getAttribute("title") || "";
@@ -1157,6 +1158,15 @@ function renderMetrics(m) {
   if (o.activeProfiles && o.activeProfiles.length) html += row("Profiles", esc(o.activeProfiles.join(", ")));
   if (o.startupTimeMillis != null) html += row("Uptime", (o.startupTimeMillis / 1000).toFixed(2) + " s");
   if (m.health) html += row("Health", esc(m.health.status) || "\u2014");
+  if (m.health && Array.isArray(m.health.checks) && m.health.checks.length) {
+    for (const c of m.health.checks) {
+      const statusCls = c.status === "UP" ? "ok" : c.status === "DOWN" ? "down" : "unknown";
+      html += row(
+        `<span class="hc-name">${esc(c.name || "check")}</span>`,
+        `<span class="hc-status ${statusCls}">${esc(c.status) || "\u2014"}</span>`,
+      );
+    }
+  }
   if (m.threads) html += row("Threads", `${m.threads.totalThreads} (${m.threads.daemonThreads} daemon)`);
   if (heap.usedBytes != null || heap.maxBytes != null) {
     html += `<h2 style="margin-top:0.75rem">Heap</h2>`;
@@ -1181,8 +1191,9 @@ function renderMetrics(m) {
     renderMcp(m.mcp);
     renderScans(true);
   } else if (tier === "quarkus") {
-    metricsHint.innerHTML =
-      "Metrics read from Quarkus Micrometer (<code>/q/metrics</code>) and SmallRye Health (<code>/q/health</code>).";
+    metricsHint.innerHTML = m.memory
+      ? "Metrics read from Quarkus Micrometer (<code>/q/metrics</code>) and SmallRye Health (<code>/q/health</code>)."
+      : "Health read from Quarkus SmallRye Health (<code>/q/health</code>). Add <code>quarkus-micrometer-registry-prometheus</code> to surface heap, threads and uptime here.";
     renderMcp(null);
     renderScans(false);
   } else {

--- a/public/styles.css
+++ b/public/styles.css
@@ -828,6 +828,21 @@ aside h2 {
   font-weight: 600;
   text-align: right;
 }
+/* SmallRye / MicroProfile health checks (Quarkus tier): the per-component
+   breakdown (datasource, readiness, …) listed under the overall Health status. */
+.hc-name {
+  padding-left: 0.75rem;
+  font-weight: 400;
+}
+.hc-status.ok {
+  color: var(--true-color-green, #1a7f37);
+}
+.hc-status.down {
+  color: var(--true-color-red, #cf222e);
+}
+.hc-status.unknown {
+  color: var(--text-color-muted, #656d76);
+}
 .bar {
   height: 8px;
   border-radius: 999px;

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -237,6 +237,37 @@ test("quarkusMetrics tolerates a missing scrape", () => {
   assert.equal(out.memory, null);
 });
 
+test("quarkusMetrics reads the Java version from the jvm_info_total gauge", () => {
+  // Quarkus 3.x (Micrometer + Prometheus 1.x client) renames the jvm_info gauge
+  // to jvm_info_total; the version must still surface on the Quarkus tier.
+  const scrape = 'jvm_info_total{runtime="OpenJDK Runtime Environment",vendor="Homebrew",version="26.0.1"} 1.0\n';
+  const out = quarkusMetrics(scrape, { status: "UP" });
+  assert.equal(out.overview.javaVersion, "26.0.1");
+});
+
+test("quarkusMetrics surfaces the SmallRye health checks breakdown", () => {
+  // A Quarkus app with only smallrye-health (no Micrometer) still reports the
+  // per-component checks, so the panel shows more than a bare overall status.
+  const health = {
+    status: "DOWN",
+    checks: [
+      { name: "Database connections health check", status: "UP", data: {} },
+      { name: "Reactive Messaging - liveness check", status: "DOWN" },
+    ],
+  };
+  const out = quarkusMetrics(null, health);
+  assert.equal(out.health.status, "DOWN");
+  assert.deepEqual(out.health.checks, [
+    { name: "Database connections health check", status: "UP" },
+    { name: "Reactive Messaging - liveness check", status: "DOWN" },
+  ]);
+});
+
+test("quarkusMetrics defaults the health checks to an empty list", () => {
+  const out = quarkusMetrics(null, { status: "UP" });
+  assert.deepEqual(out.health, { status: "UP", checks: [] });
+});
+
 // ---------------------------------------------------------------------------
 // Secret masking
 // ---------------------------------------------------------------------------

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -87,11 +87,47 @@ test("renderMetrics handles the 'app down' and a populated Quarkus payload", () 
   );
   // The heap bar should have rendered for the populated payload.
   assert.ok(win.document.getElementById("metrics").innerHTML.includes("Heap"));
+
+  // Health-only Quarkus (smallrye-health, no Micrometer): the per-check breakdown
+  // shows, and the hint points the user at quarkus-micrometer-registry-prometheus.
+  assert.doesNotThrow(() =>
+    win.renderMetrics({
+      appUp: true,
+      metricsTier: "quarkus",
+      overview: {},
+      memory: null,
+      health: {
+        status: "DOWN",
+        checks: [
+          { name: "Database connections health check", status: "UP" },
+          { name: "messaging liveness", status: "DOWN" },
+        ],
+      },
+      threads: null,
+    }),
+  );
+  const healthHtml = win.document.getElementById("metrics").innerHTML;
+  assert.ok(healthHtml.includes("Database connections health check"), "expected the health check name");
+  assert.ok(!healthHtml.includes("Heap"), "no heap row without Micrometer metrics");
+  assert.ok(
+    win.document.getElementById("metrics-hint").innerHTML.includes("quarkus-micrometer-registry-prometheus"),
+    "expected the Micrometer hint when only health is available",
+  );
 });
 
 test("renderMcp tolerates an unavailable MCP server", () => {
   assert.doesNotThrow(() => win.renderMcp(null));
   assert.doesNotThrow(() => win.renderMcp({ available: false }));
+});
+
+test("the Settings tab is pinned to the top of the aside bar", () => {
+  win.updateAsideAvailability({ metrics: true, loggers: false, scans: false });
+  const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);
+  // Available group sorts below the separator (order 50); within it Settings is
+  // first (rank 0). Unavailable panels are offset by 100 so they sink to the bottom.
+  assert.equal(order("settings"), 0, "Settings is pinned to the top of the bar");
+  assert.ok(order("metrics") > order("settings"), "an available panel sits below Settings");
+  assert.ok(order("scans") > 100, "an unavailable panel sinks below the separator");
 });
 
 test("renderTests renders a graphical report with a failure", () => {


### PR DESCRIPTION
## Summary

The Live JVM panel already has a Quarkus tier, but on a real Quarkus app it showed little beyond a bare "UP" health status, so it felt second-class next to the Spring Boot / Actuator tier. This makes the Quarkus tier carry as much useful detail as Quarkus exposes:

- **Java version now populates.** Quarkus 3.x (Micrometer's Prometheus 1.x client) emits the JVM info gauge as `jvm_info_total` rather than the legacy `jvm_info`, so the version label was being dropped. The parser now reads the version from either name.
- **SmallRye health breakdown.** `/q/health` returns a `checks[]` array (datasource, readiness, messaging probes, ...). We keep that breakdown and render each component with its UP/DOWN status under the overall Health row, so a health-only Quarkus app (no Micrometer) shows more than a single status line.
- **Actionable hint when Micrometer is missing.** If `/q/metrics` doesn't answer, the panel now tells the user to add `quarkus-micrometer-registry-prometheus` to surface heap / threads / uptime, instead of silently showing just health.

The Settings tool panel is also expected to sit at the top of the aside bar. That is already handled by the `ASIDE_ORDER` scheme introduced in #65 (Settings is first in the canonical order); this PR just adds a clarifying comment and a regression test so it stays that way.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified against a live `quarkus-rest` run: `/q/health` and `/q/metrics` probed, real scrape fed through `quarkusMetrics()` (Java version, heap, threads, uptime all populate), and confirmed the canvas serves the updated assets. The health-checks UI is exercised by the jsdom smoke test since the sample app registers no checks.
- [x] No `README.md` / `PLAN.md` change needed: the docs already describe the Quarkus tier as Micrometer + SmallRye Health.
- [x] No secrets committed.

## Notes for reviewers

- Covered by unit tests (`jvm_info_total` parsing, health-checks normalization, empty-checks default) and the jsdom UI smoke test (checks render, the Micrometer hint, and Settings pinned to the top).
- `applicationName` stays null on the Quarkus tier: Quarkus does not expose it via `/q/metrics` or `/q/health` by default, so there is no reliable source without extra extensions.