### PR TITLE
Add Quarkus loggers support and framework-specific loggers-unavailable UX

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -52,8 +52,9 @@ Shipped in the extension today:
   with a source badge.
 - Live log viewer on the Run console (minimum-severity filter + text search, with
   severity-colored lines and inherited levels for stack traces) and runtime log-level
-  control via Spring Boot Actuator `/loggers` (a Loggers side tab + the `set_log_level`
-  action), so loggers can be changed live without a restart.
+  control via Spring Boot Actuator `/loggers` or the Quarkus `quarkus-logging-manager`
+  extension (a Loggers side tab + the `set_log_level` action), so loggers can be
+  changed live without a restart.
 - On-demand CPU / allocation / wall-clock / lock-contention flame graph of the
   running app via async-profiler (`asprof`) when present, or the JDK-bundled JDK
   Flight Recorder (`jcmd JFR.*`) as a cross-platform fallback (so flame graphs work

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,7 +64,9 @@ Shipped in the extension today:
   available.
 - "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
   startup failures (including Quarkus dev-mode build/augmentation failures that keep
-  the process running), for flame-graph hotspots, and for BootUI advisor-scan findings.
+  the process running), for a running app with no runtime-logger endpoint (offers to
+  add Spring Boot Actuator or the Quarkus logging-manager extension), for flame-graph
+  hotspots, and for BootUI advisor-scan findings.
 - BootUI advisor scans run over REST (BootUI tab), plus an optional MCP-server
   toggle/register bridge, when the running app exposes BootUI.
 - Quarkus Agent MCP: a dedicated **Quarkus** right-panel tab with a "Register with

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ wins; when neither is found the console says so and stays disabled until one is 
 - **Live logs &amp; log levels** &mdash; the Run console doubles as a log viewer with a
   minimum-severity filter and text search (stack-trace lines inherit their parent
   level, and lines are colored by severity). A **Loggers** side tab lists the running
-  app's loggers from Spring Boot Actuator <code>/loggers</code> and lets you change any
+  app's loggers from Spring Boot Actuator <code>/loggers</code> or the Quarkus
+  <code>quarkus-logging-manager</code> extension and lets you change any
   level live &mdash; no restart &mdash; so you can flip a package to <code>DEBUG</code>,
   reproduce, and dial it back.
 - **Flame graph (async-profiler or JFR)** &mdash; when [async-profiler](https://github.com/async-profiler/async-profiler)
@@ -145,7 +146,7 @@ The console adapts to whatever the project provides, detected from the build fil
 | **Spring Boot**               | Spring Boot Maven plugin / Gradle plugin          | Run via `spring-boot:run` (Maven) or `bootRun` (Gradle) + editable Spring profiles. (No Spring Boot ⇒ the generic runner uses the Gradle `application` plugin, an executable `java -jar`, or the configured main class via `java -cp`.)                                   |
 | **Quarkus**                   | Quarkus Maven plugin / `io.quarkus` Gradle plugin | Run via `quarkus:dev` (Maven) or `quarkusDev` (Gradle) — dev mode with built-in live reload — + editable Quarkus profile                                                                                                                                                  |
 | **Actuator** (runtime)        | `/actuator/*` or `/management/*` answers          | Live metrics normalized from Actuator — JSON `/metrics` endpoint or the Prometheus scrape (heap, threads, health, uptime) — plus runtime log-level control when `/loggers` is exposed                                                                                     |
-| **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health                                                                                                                                                                                            |
+| **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health — plus runtime log-level control when the `quarkus-logging-manager` extension (`/q/logging-manager`) is present                                                                             |
 | **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the REST advisor-scan panel (BootUI tab)                                                                                                                                                                                                      |
 | **Quarkus Agent MCP**         | Quarkus module + JBang or Java 21+ on `PATH`      | A dedicated **Quarkus** tab with a **Register with Copilot** button + one-click capability prompts wiring the external [Quarkus Agent MCP](https://github.com/quarkusio/quarkus-agent-mcp) server (skills, docs search, Dev UI proxy, structured exceptions) into the CLI |
 
@@ -254,7 +255,8 @@ Coffilot is a Node process (the extension) that:
   for Spring/app Gradle, or Quarkus's built-in `-Ddebug` for Quarkus) and attaches a
   self-contained JDWP client (`jdwp.mjs`, loopback only) that the UI and agent
   actions drive;
-- proxies Spring Boot Actuator `/loggers` so the canvas can read and change logger
+- proxies Spring Boot Actuator `/loggers` and the Quarkus logging-manager
+  extension (`/q/logging-manager`) so the canvas can read and change logger
   levels on the running app without a restart;
 - runs BootUI's advisor scans straight from its REST API (`/bootui/api/panels` to
   discover them, `POST /bootui/api/{id}/scan` to run one), surfaced in the **BootUI**

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ wins; when neither is found the console says so and stays disabled until one is 
   app's loggers from Spring Boot Actuator <code>/loggers</code> or the Quarkus
   <code>quarkus-logging-manager</code> extension and lets you change any
   level live &mdash; no restart &mdash; so you can flip a package to <code>DEBUG</code>,
-  reproduce, and dial it back.
+  reproduce, and dial it back. If the running app exposes no logger endpoint, the tab
+  shows a framework-specific hint with a one-click **Fix with Copilot** button that
+  asks the agent to add Spring Boot Actuator or the <code>quarkus-logging-manager</code>
+  extension.
 - **Flame graph (async-profiler or JFR)** &mdash; when [async-profiler](https://github.com/async-profiler/async-profiler)
   (`asprof`) is installed, the Run tab's **Flame graph** view records an on-demand
   CPU / allocation / wall-clock / lock-contention profile of the running app's JVM
@@ -95,9 +98,10 @@ wins; when neither is found the console says so and stays disabled until one is 
   Degrades gracefully with an install hint only when neither async-profiler nor a
   JDK `jcmd` is available.
 - **Fix with Copilot** &mdash; on a compile error, failing tests, a startup
-  crash, or a Quarkus dev-mode build/augmentation failure (where the process stays
-  up waiting for a fix), a button pushes a context-rich request back into the chat
-  so the agent can diagnose and fix it.
+  crash, a Quarkus dev-mode build/augmentation failure (where the process stays
+  up waiting for a fix), or a running app that exposes no runtime-logger endpoint,
+  a button pushes a context-rich request back into the chat so the agent can
+  diagnose and fix it.
 - **Responsive layout** &mdash; on a wide canvas the **Live JVM / Loggers / Settings**
   panel is docked on the right; as the canvas narrows it collapses to an icon rail on
   the right edge, and tapping an icon slides that pane out as an overlay over the main
@@ -146,7 +150,7 @@ The console adapts to whatever the project provides, detected from the build fil
 | **Spring Boot**               | Spring Boot Maven plugin / Gradle plugin          | Run via `spring-boot:run` (Maven) or `bootRun` (Gradle) + editable Spring profiles. (No Spring Boot ⇒ the generic runner uses the Gradle `application` plugin, an executable `java -jar`, or the configured main class via `java -cp`.)                                   |
 | **Quarkus**                   | Quarkus Maven plugin / `io.quarkus` Gradle plugin | Run via `quarkus:dev` (Maven) or `quarkusDev` (Gradle) — dev mode with built-in live reload — + editable Quarkus profile                                                                                                                                                  |
 | **Actuator** (runtime)        | `/actuator/*` or `/management/*` answers          | Live metrics normalized from Actuator — JSON `/metrics` endpoint or the Prometheus scrape (heap, threads, health, uptime) — plus runtime log-level control when `/loggers` is exposed                                                                                     |
-| **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health — plus runtime log-level control when the `quarkus-logging-manager` extension (`/q/logging-manager`) is present                                                                             |
+| **Quarkus metrics** (runtime) | `/q/metrics` / `/q/health` answer                 | Live metrics normalized from Quarkus Micrometer (Prometheus) + SmallRye Health — plus runtime log-level control when the `quarkus-logging-manager` extension (`/q/logging-manager`) is present                                                                            |
 | **BootUI** (runtime)          | `/bootui/api/*` answers                           | Rich BootUI metrics **and** the REST advisor-scan panel (BootUI tab)                                                                                                                                                                                                      |
 | **Quarkus Agent MCP**         | Quarkus module + JBang or Java 21+ on `PATH`      | A dedicated **Quarkus** tab with a **Register with Copilot** button + one-click capability prompts wiring the external [Quarkus Agent MCP](https://github.com/quarkusio/quarkus-agent-mcp) server (skills, docs search, Dev UI proxy, structured exceptions) into the CLI |
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -1942,7 +1942,8 @@ const app = {
   appUp: false,
   appReachedUp: false, // app served a metrics endpoint at least once this run
   actuatorPrefix: null, // discovered Actuator base path this run (/actuator or /management)
-  loggersPrefix: null, // discovered Actuator base path that serves /loggers this run
+  loggersSource: null, // which runtime-logger backend answered: "actuator" | "quarkus"
+  loggersPrefix: null, // base path that serves the loggers endpoint this run
   module: null, // module selected for the current run (for live reload)
   mavenProfiles: null, // Maven profiles used for the current run (for live reload)
 };
@@ -3876,6 +3877,7 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
   app.appUp = false;
   app.appReachedUp = false;
   app.actuatorPrefix = null;
+  app.loggersSource = null;
   app.loggersPrefix = null;
   csrfToken = null;
   lastMetrics = { appUp: false };
@@ -6556,15 +6558,39 @@ async function runScanRest(key) {
 }
 
 // ---------------------------------------------------------------------------
-// Runtime log levels — Spring Boot Actuator /loggers (read + live change)
+// Runtime log levels — Spring Boot Actuator /loggers + Quarkus logging-manager
 // ---------------------------------------------------------------------------
-// The /loggers endpoint lists every logger with its configured/effective level
-// and accepts a POST to change a level without restarting the app — the inner-loop
-// equivalent of an IDE's runtime log-level control. It lives under the same base
-// path as the other Actuator endpoints (/actuator or /management), so we reuse the
-// prefix discovered by the metrics tier when we have it.
+// A runtime-logger endpoint lists every logger with its configured/effective level
+// and accepts a write to change a level without restarting the app — the inner-loop
+// equivalent of an IDE's runtime log-level control. Two backends are supported and
+// normalized to the same shape: Spring Boot Actuator's /loggers (under /actuator or
+// /management, reusing the prefix the metrics tier discovered) and the Quarkiverse
+// quarkus-logging-manager extension's /q/logging-manager (a JSON array, a separate
+// /levels endpoint, and a form-encoded write). app.loggersSource records which one
+// answered so the write path can target it.
 
 const DEFAULT_LOG_LEVELS = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
+
+// quarkus-logging-manager mounts under the Quarkus non-application root (/q), the
+// same place the metrics tier finds /q/health and /q/metrics. Its /levels endpoint
+// reports the broader JBoss LogManager set, so accept those names on the write path.
+const QUARKUS_LOGGING_PATH = "/q/logging-manager";
+const QUARKUS_LOG_LEVELS = [
+  "OFF",
+  "SEVERE",
+  "ERROR",
+  "FATAL",
+  "WARNING",
+  "WARN",
+  "INFO",
+  "DEBUG",
+  "TRACE",
+  "CONFIG",
+  "FINE",
+  "FINER",
+  "FINEST",
+  "ALL",
+];
 
 /**
  * Generic CSRF-aware POST against the running app: seed an XSRF-TOKEN from a prior
@@ -6604,20 +6630,36 @@ async function appPostCsrf(base, seedPath, postPath, body) {
 }
 
 /**
- * Read the running app's loggers from Actuator. Returns the available levels and a
- * normalized logger list (ROOT first, then alphabetical), or { available:false } when
- * the app is down or exposes no /loggers endpoint.
+ * Read the running app's loggers from whichever backend matches how it was launched —
+ * the Quarkus logging-manager extension for a Quarkus run, else Spring Boot Actuator
+ * /loggers. Returns the available levels and a normalized logger list (ROOT first, then
+ * alphabetical) plus a `source` tag, or { available:false } when the app is down or the
+ * backend isn't exposed.
  */
 async function loggersStatus() {
   const base = appBase();
   if (!base) return { available: false };
-  // Prefer the prefix the metrics tier already confirmed, then the usual candidates.
+  // The framework is already known from how the app was launched (app.runMode), so go
+  // straight to the matching backend instead of probing both: Quarkus serves
+  // logging-manager under /q, everything else (Spring Boot or the generic runner) uses
+  // Actuator /loggers.
+  const status = app.runMode === "quarkus" ? await quarkusLoggersStatus(base) : await actuatorLoggersStatus(base);
+  return status || { available: false };
+}
+
+/**
+ * Read loggers from Spring Boot Actuator /loggers, discovering the base path (/actuator
+ * or /management, preferring the prefix the metrics tier already confirmed). Returns the
+ * normalized status, or null when no /loggers endpoint answers.
+ */
+async function actuatorLoggersStatus(base) {
   const prefixes = app.actuatorPrefix
     ? [app.actuatorPrefix, ...ACTUATOR_PREFIXES.filter((p) => p !== app.actuatorPrefix)]
     : ACTUATOR_PREFIXES;
   for (const prefix of prefixes) {
     const json = await fetchJson(base, `${prefix}/loggers`);
     if (!json || !json.loggers) continue;
+    app.loggersSource = "actuator";
     app.loggersPrefix = prefix;
     const levels = Array.isArray(json.levels) && json.levels.length ? json.levels : DEFAULT_LOG_LEVELS;
     const loggers = Object.entries(json.loggers).map(([name, v]) => ({
@@ -6626,9 +6668,60 @@ async function loggersStatus() {
       effectiveLevel: (v && v.effectiveLevel) || null,
     }));
     loggers.sort((a, b) => (a.name === "ROOT" ? -1 : b.name === "ROOT" ? 1 : a.name.localeCompare(b.name)));
-    return { available: true, prefix, levels, loggers };
+    return { available: true, source: "actuator", prefix, levels, loggers };
   }
-  return { available: false };
+  return null;
+}
+
+/**
+ * Read loggers from the Quarkus logging-manager extension. GET /q/logging-manager
+ * returns a JSON array of { name, configuredLevel, effectiveLevel } and /levels lists
+ * the accepted levels. Returns the normalized status, or null when the extension isn't present.
+ */
+async function quarkusLoggersStatus(base) {
+  const list = await fetchJson(base, QUARKUS_LOGGING_PATH);
+  if (!Array.isArray(list)) return null;
+  const levelsRaw = await fetchJson(base, `${QUARKUS_LOGGING_PATH}/levels`);
+  const status = normalizeQuarkusLoggers(list, levelsRaw);
+  if (!status) return null;
+  app.loggersSource = "quarkus";
+  app.loggersPrefix = QUARKUS_LOGGING_PATH;
+  return { ...status, prefix: QUARKUS_LOGGING_PATH };
+}
+
+/**
+ * Normalize a Quarkus logging-manager listing into the shared loggers shape (ROOT first,
+ * then alphabetical). The root logger's JBoss name is the empty string, normalized to ROOT
+ * here. Falls back to the full JBoss level set when /levels is unavailable. Returns null
+ * when the input isn't a logger array (i.e. the extension isn't present).
+ */
+export function normalizeQuarkusLoggers(list, levelsRaw) {
+  if (!Array.isArray(list)) return null;
+  const levels = Array.isArray(levelsRaw) && levelsRaw.length ? levelsRaw : QUARKUS_LOG_LEVELS;
+  const loggers = list
+    .filter((l) => l && typeof l.name === "string")
+    .map((l) => ({
+      name: l.name === "" ? "ROOT" : l.name,
+      configuredLevel: l.configuredLevel || null,
+      effectiveLevel: l.effectiveLevel || null,
+    }));
+  loggers.sort((a, b) => (a.name === "ROOT" ? -1 : b.name === "ROOT" ? 1 : a.name.localeCompare(b.name)));
+  return { available: true, source: "quarkus", levels, loggers };
+}
+
+/**
+ * Change one logger's level on the Quarkus logging-manager extension: a form-encoded
+ * POST to /q/logging-manager (ROOT maps back to JBoss's empty-string root name, an empty
+ * level resets the logger to its inherited level). Returns the raw response.
+ */
+function quarkusSetLevel(base, name, level) {
+  const loggerName = name === "ROOT" ? "" : name;
+  const body = new URLSearchParams({ loggerName, loggerLevel: level || "" });
+  return fetch(base + QUARKUS_LOGGING_PATH, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+    body: body.toString(),
+  });
 }
 
 /**
@@ -6641,25 +6734,33 @@ async function setLoggerLevel(name, level) {
   if (!base) return { ok: false, error: "App is not running." };
   if (!name) return { ok: false, error: "No logger specified." };
   const lvl = level ? String(level).toUpperCase() : null;
-  if (lvl && !DEFAULT_LOG_LEVELS.includes(lvl)) return { ok: false, error: `Unknown level "${level}".` };
   // The agent's set_log_level action can run before any GET has cached the
-  // Actuator base path, so discover it now (this also rejects apps with no
-  // /loggers endpoint up front rather than blindly POSTing to /actuator).
-  if (!app.loggersPrefix) await loggersStatus();
-  if (!app.loggersPrefix) {
-    return { ok: false, error: "The app's /loggers endpoint isn't exposed (or is read-only)." };
+  // logger backend, so discover it now (this also rejects apps that expose
+  // neither backend up front rather than blindly POSTing).
+  if (!app.loggersSource) await loggersStatus();
+  if (!app.loggersSource) {
+    return {
+      ok: false,
+      error: "No runtime logger endpoint is exposed (Spring Boot Actuator /loggers or Quarkus logging-manager).",
+    };
   }
+  const quarkus = app.loggersSource === "quarkus";
+  const validLevels = quarkus ? QUARKUS_LOG_LEVELS : DEFAULT_LOG_LEVELS;
+  if (lvl && !validLevels.includes(lvl)) return { ok: false, error: `Unknown level "${level}".` };
   const prefix = app.loggersPrefix;
   try {
-    const res = await appPostCsrf(base, `${prefix}/loggers`, `${prefix}/loggers/${encodeURIComponent(name)}`, {
-      configuredLevel: lvl,
-    });
+    const res = quarkus
+      ? await quarkusSetLevel(base, name, lvl)
+      : await appPostCsrf(base, `${prefix}/loggers`, `${prefix}/loggers/${encodeURIComponent(name)}`, {
+          configuredLevel: lvl,
+        });
     await res.text().catch(() => null);
     if (!res.ok) {
+      const backend = quarkus ? "Logging Manager" : "Actuator";
       const why =
         res.status === 404
-          ? "The app's /loggers endpoint isn't exposed (or is read-only)."
-          : `Actuator returned ${res.status}.`;
+          ? "The app's logger endpoint isn't exposed (or is read-only)."
+          : `${backend} returned ${res.status}.`;
       return { ok: false, error: why, status: await loggersStatus() };
     }
     return { ok: true, name, level: lvl, status: await loggersStatus() };
@@ -7736,7 +7837,7 @@ function makeCanvas() {
       {
         name: "set_log_level",
         description:
-          "Change a logger's level at runtime on the running app via Spring Boot Actuator /loggers (no restart). Requires the app up with the loggers endpoint exposed. e.g. logger=com.example.service level=DEBUG. Omit level to reset the logger to its inherited default.",
+          "Change a logger's level at runtime on the running app (no restart) via Spring Boot Actuator /loggers or the Quarkus logging-manager extension. Requires the app up with one of those logger endpoints exposed. e.g. logger=com.example.service level=DEBUG. Omit level to reset the logger to its inherited default.",
         inputSchema: {
           type: "object",
           properties: {

--- a/extension.mjs
+++ b/extension.mjs
@@ -6307,6 +6307,76 @@ function buildFixPrompt(kind, extra = {}) {
         .filter(Boolean)
         .join("\n\n");
     }
+    case "install-actuator-loggers": {
+      const moduleName = extra.module || "";
+      const resDir = moduleName ? `${moduleName}/src/main/resources` : "src/main/resources";
+      if (buildTool === "gradle") {
+        const { rel, kts } = gradleModuleBuildFile(moduleName);
+        const dep = kts
+          ? `implementation("org.springframework.boot:spring-boot-starter-actuator")`
+          : `implementation 'org.springframework.boot:spring-boot-starter-actuator'`;
+        return [
+          "This is a Spring Boot application whose runtime log-level endpoint isn't reachable, so the canvas can't read or change loggers live. Add Spring Boot Actuator and expose its `/loggers` endpoint.",
+          `1. Edit \`${rel}\` and add the Actuator starter inside \`dependencies { }\`:`,
+          codeBlock(`dependencies {\n  ${dep}\n}`, kts ? "kotlin" : "groovy"),
+          "   Omit the version so it inherits from the Spring Boot plugin's dependency management. Don't duplicate the line if it's already present.",
+          `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the loggers endpoint over HTTP:`,
+          codeBlock("management.endpoints.web.exposure.include=health,loggers", "properties"),
+          "   If an `exposure.include` line already exists, add `loggers` to it rather than replacing it. The `/loggers` endpoint serves both reads and live level changes — no extra config needed.",
+          "After editing, tell me to run the app again (e.g. `./gradlew bootRun`); the Loggers tab then lists every logger and lets you change levels live.",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+      }
+      const pomRel = moduleName ? `${moduleName}/pom.xml` : "pom.xml";
+      return [
+        "This is a Spring Boot application whose runtime log-level endpoint isn't reachable, so the canvas can't read or change loggers live. Add Spring Boot Actuator and expose its `/loggers` endpoint.",
+        `1. Edit \`${pomRel}\` and add a dependency on \`org.springframework.boot:spring-boot-starter-actuator\` inside the \`<dependencies>\` block (omit the \`<version>\` so it inherits from the Spring Boot parent/BOM). Don't duplicate it if it's already present.`,
+        `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the loggers endpoint over HTTP:`,
+        codeBlock("management.endpoints.web.exposure.include=health,loggers", "properties"),
+        "   If an `exposure.include` line already exists, add `loggers` to it rather than replacing it. The `/loggers` endpoint serves both reads and live level changes — no extra config needed.",
+        "After editing, tell me to run the app again (e.g. `./mvnw spring-boot:run`); the Loggers tab then lists every logger and lets you change levels live.",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
+    case "install-logging-manager": {
+      const moduleName = extra.module || "";
+      if (buildTool === "gradle") {
+        const { rel, kts } = gradleModuleBuildFile(moduleName);
+        const dep = kts
+          ? `runtimeOnly("io.quarkiverse.loggingmanager:quarkus-logging-manager:VERSION")`
+          : `runtimeOnly 'io.quarkiverse.loggingmanager:quarkus-logging-manager:VERSION'`;
+        return [
+          "This is a Quarkus application that doesn't expose a runtime log-level endpoint, so the canvas can't read or change loggers live. Add the Quarkus Logging Manager extension, which serves `/q/logging-manager`.",
+          `Edit \`${rel}\` and add the extension inside \`dependencies { }\`:`,
+          codeBlock(`dependencies {\n  ${dep}\n}`, kts ? "kotlin" : "groovy"),
+          [
+            "- If a line for this extension already exists, leave it; don't duplicate it.",
+            "- Use the latest released version of `io.quarkiverse.loggingmanager:quarkus-logging-manager` from Maven Central; pin a concrete version rather than a range (replace `VERSION`).",
+          ].join("\n"),
+          "After editing, tell me to run the app again (e.g. `./gradlew quarkusDev`); the Loggers tab then lists every logger and lets you change levels live.",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+      }
+      const pomRel = moduleName ? `${moduleName}/pom.xml` : "pom.xml";
+      return [
+        "This is a Quarkus application that doesn't expose a runtime log-level endpoint, so the canvas can't read or change loggers live. Add the Quarkus Logging Manager extension, which serves `/q/logging-manager`.",
+        `Edit \`${pomRel}\` and add this dependency inside the \`<dependencies>\` block:`,
+        codeBlock(
+          "<dependency>\n  <groupId>io.quarkiverse.loggingmanager</groupId>\n  <artifactId>quarkus-logging-manager</artifactId>\n  <version>VERSION</version>\n  <scope>runtime</scope>\n</dependency>",
+          "xml",
+        ),
+        [
+          "- If this dependency already exists, leave it; don't duplicate it.",
+          "- Use the latest released version of `io.quarkiverse.loggingmanager:quarkus-logging-manager` from Maven Central; pin a concrete version rather than a range (replace `VERSION`).",
+        ].join("\n"),
+        "After editing, tell me to run the app again (e.g. `./mvnw quarkus:dev`); the Loggers tab then lists every logger and lets you change levels live.",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
     case "register-mcp": {
       const base = appBase();
       const mcpUrl = base ? `${base}/bootui/api/mcp` : "http://127.0.0.1:<app-port>/bootui/api/mcp";
@@ -7349,7 +7419,10 @@ async function handleRequest(req, res) {
   }
 
   if (req.method === "GET" && url.pathname === "/api/loggers") {
-    sendJson(res, 200, await loggersStatus());
+    const status = await loggersStatus();
+    // runMode lets the UI tailor the "no logger endpoint" hint (and its fix button)
+    // to the framework actually running.
+    sendJson(res, 200, { ...status, runMode: app.runMode });
     return;
   }
   if (req.method === "POST" && url.pathname === "/api/loggers") {

--- a/public/app.js
+++ b/public/app.js
@@ -1631,6 +1631,12 @@ const LOGGER_LEVELS = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 let appRunning = false;
 let loggersData = null;
 let loggersTimer = null;
+// Tracks whether the user already pressed "Fix with Copilot" on the current
+// no-endpoint view, so the 5s poll re-render doesn't reset the button. Cleared when
+// the app goes down or loggers become available. loggersUnavailKey guards against
+// rebuilding an identical unavailable view on every poll.
+let loggersFixAsked = false;
+let loggersUnavailKey = null;
 
 function loggersTabActive() {
   const pane = document.getElementById("atab-loggers");
@@ -1663,26 +1669,23 @@ async function loadLoggers() {
 }
 
 function renderLoggers(data, force) {
-  if (!data || data.appDown || (!data.available && !appRunning)) {
+  if (!data || data.appDown) {
     loggersSrc.hidden = true;
     loggersControls.hidden = true;
     loggersListEl.innerHTML =
       '<p class="muted">App not running. Click <strong>Run</strong> to control its log levels.</p>';
     loggersData = null;
+    loggersFixAsked = false;
+    loggersUnavailKey = null;
     return;
   }
   if (!data.available) {
-    loggersSrc.hidden = true;
-    loggersControls.hidden = true;
-    loggersListEl.innerHTML =
-      '<p class="muted">No runtime logger endpoint is exposed on the running app, so log levels ' +
-      "can\u2019t be changed here. For Spring Boot, add <code>spring-boot-starter-actuator</code> and expose it " +
-      "(<code>management.endpoints.web.exposure.include=loggers</code>). For Quarkus, add the " +
-      "<code>quarkus-logging-manager</code> extension.</p>";
-    loggersData = null;
+    renderLoggersUnavailable(data.runMode);
     return;
   }
   loggersData = data;
+  loggersFixAsked = false;
+  loggersUnavailKey = null;
   loggersSrc.hidden = false;
   const quarkus = data.source === "quarkus";
   loggersSrc.className = quarkus ? "src quarkus" : "src actuator";
@@ -1692,6 +1695,53 @@ function renderLoggers(data, force) {
   // (an open select or focused search box) unless explicitly forced.
   if (!force && loggersListEl.contains(document.activeElement)) return;
   renderLoggersList();
+}
+
+// The app is up but exposes no runtime-logger endpoint. Tailor the hint to the
+// framework: Spring Boot and Quarkus each get a one-click "Fix with Copilot" that
+// asks the agent to add the missing dependency; anything else just explains the
+// feature only works for those two.
+function renderLoggersUnavailable(runMode) {
+  loggersSrc.hidden = true;
+  loggersControls.hidden = true;
+  loggersData = null;
+  const key = (runMode || "other") + ":" + (loggersFixAsked ? "asked" : "open");
+  if (key === loggersUnavailKey) return;
+  loggersUnavailKey = key;
+  let html;
+  let fix = null;
+  if (runMode === "spring") {
+    html =
+      '<p class="muted">No Spring Boot Actuator <code>/loggers</code> endpoint is exposed on the running app, ' +
+      "so log levels can\u2019t be changed here. Add <code>spring-boot-starter-actuator</code> and expose it " +
+      "(<code>management.endpoints.web.exposure.include=loggers</code>).</p>";
+    fix = "install-actuator-loggers";
+  } else if (runMode === "quarkus") {
+    html =
+      '<p class="muted">No Quarkus logging-manager endpoint is exposed on the running app, so log levels ' +
+      "can\u2019t be changed here. Add the <code>quarkus-logging-manager</code> extension.</p>";
+    fix = "install-logging-manager";
+  } else {
+    html =
+      '<p class="muted">Live log-level control works only for Spring Boot apps (via the Actuator ' +
+      "<code>/loggers</code> endpoint) or Quarkus apps (via the <code>quarkus-logging-manager</code> extension).</p>";
+  }
+  if (fix) {
+    html += loggersFixAsked
+      ? '<button class="fix fix-copilot tiny" style="margin-top: 0.4rem" disabled>Asked Copilot \u2713</button>'
+      : '<button id="loggers-fix" class="fix fix-copilot tiny" style="margin-top: 0.4rem">Fix with Copilot</button>';
+  }
+  loggersListEl.innerHTML = html;
+  const btn = fix && document.getElementById("loggers-fix");
+  if (btn) {
+    btn.onclick = () => {
+      loggersFixAsked = true;
+      loggersUnavailKey = null;
+      btn.disabled = true;
+      btn.textContent = "Asked Copilot \u2713";
+      post("/api/fix", { kind: fix, module: moduleSelect.value });
+    };
+  }
 }
 
 function renderLoggersList() {

--- a/public/app.js
+++ b/public/app.js
@@ -472,7 +472,8 @@ const ASIDE_ORDER = ["settings", "metrics", "loggers", "scans", "quarkus"];
 const ASIDE_REASON = {
   metrics:
     "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
-  loggers: "Live log levels need a running Spring Boot app with the Actuator /loggers endpoint. Click to learn more.",
+  loggers:
+    "Live log levels need a running Spring Boot app (Actuator /loggers) or a Quarkus app with the logging-manager extension. Click to learn more.",
   scans: "The BootUI panel needs a running BootUI app — Run a module with the BootUI starter. Click to learn more.",
   quarkus:
     "The Quarkus panel needs a Quarkus module — open a Quarkus project to register its Agent MCP server with Copilot. Click to learn more.",
@@ -1125,7 +1126,7 @@ function renderMetrics(m) {
   const tier = nowUp ? m.metricsTier || "process" : null;
   updateAsideAvailability({
     metrics: nowUp && tier !== "process",
-    loggers: nowUp && (tier === "bootui" || tier === "actuator"),
+    loggers: nowUp && (tier === "bootui" || tier === "actuator" || tier === "quarkus"),
     scans: nowUp && tier === "bootui",
   });
   if (nowUp !== appRunning) {
@@ -1618,9 +1619,10 @@ quarkusMcpRegisterBtn.onclick = async () => {
 };
 
 // ---- Runtime log levels (Loggers aside tab) ----------------------------
-// Lists the running app's loggers from Spring Boot Actuator /loggers and lets
-// you change a level live (no restart). Self-describes by capability: degrades to
-// a hint when the app is down or exposes no /loggers endpoint.
+// Lists the running app's loggers from Spring Boot Actuator /loggers or the Quarkus
+// logging-manager extension and lets you change a level live (no restart).
+// Self-describes by capability: degrades to a hint when the app is down or exposes
+// no logger endpoint.
 const loggersListEl = document.getElementById("loggers-list");
 const loggersControls = document.getElementById("loggers-controls");
 const loggersSearch = document.getElementById("loggers-search");
@@ -1673,16 +1675,18 @@ function renderLoggers(data, force) {
     loggersSrc.hidden = true;
     loggersControls.hidden = true;
     loggersListEl.innerHTML =
-      '<p class="muted">No Spring Boot Actuator <code>/loggers</code> endpoint is exposed on the running app, so log ' +
-      "levels can\u2019t be changed here. Add <code>spring-boot-starter-actuator</code> and expose it " +
-      "(<code>management.endpoints.web.exposure.include=loggers</code>).</p>";
+      '<p class="muted">No runtime logger endpoint is exposed on the running app, so log levels ' +
+      "can\u2019t be changed here. For Spring Boot, add <code>spring-boot-starter-actuator</code> and expose it " +
+      "(<code>management.endpoints.web.exposure.include=loggers</code>). For Quarkus, add the " +
+      "<code>quarkus-logging-manager</code> extension.</p>";
     loggersData = null;
     return;
   }
   loggersData = data;
   loggersSrc.hidden = false;
-  loggersSrc.className = "src actuator";
-  loggersSrc.textContent = "Actuator";
+  const quarkus = data.source === "quarkus";
+  loggersSrc.className = quarkus ? "src quarkus" : "src actuator";
+  loggersSrc.textContent = quarkus ? "Quarkus" : "Actuator";
   loggersControls.hidden = false;
   // Don't rebuild the list out from under the user while they're using it
   // (an open select or focused search box) unless explicitly forced.

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -17,6 +17,7 @@ const {
   promSingle,
   promFirstLabel,
   quarkusMetrics,
+  normalizeQuarkusLoggers,
   maskSecrets,
   buildHistoryEntry,
   clampHistory,
@@ -266,6 +267,34 @@ test("quarkusMetrics surfaces the SmallRye health checks breakdown", () => {
 test("quarkusMetrics defaults the health checks to an empty list", () => {
   const out = quarkusMetrics(null, { status: "UP" });
   assert.deepEqual(out.health, { status: "UP", checks: [] });
+});
+
+test("normalizeQuarkusLoggers maps the listing to the shared shape (ROOT first)", () => {
+  const out = normalizeQuarkusLoggers(
+    [
+      { name: "org.acme.Svc", configuredLevel: "DEBUG", effectiveLevel: "DEBUG" },
+      { name: "", configuredLevel: "INFO", effectiveLevel: "INFO" },
+      { name: "io.quarkus", configuredLevel: null, effectiveLevel: "INFO" },
+    ],
+    ["INFO", "DEBUG"],
+  );
+  assert.equal(out.available, true);
+  assert.equal(out.source, "quarkus");
+  assert.deepEqual(
+    out.loggers.map((l) => l.name),
+    ["ROOT", "io.quarkus", "org.acme.Svc"],
+  );
+  // The empty JBoss root name becomes ROOT and keeps its level.
+  assert.equal(out.loggers[0].configuredLevel, "INFO");
+  // A null configuredLevel normalizes to null (the UI's "inherit" state).
+  assert.equal(out.loggers[1].configuredLevel, null);
+  assert.deepEqual(out.levels, ["INFO", "DEBUG"]);
+});
+
+test("normalizeQuarkusLoggers falls back to JBoss levels and rejects non-arrays", () => {
+  const out = normalizeQuarkusLoggers([{ name: "ROOT", configuredLevel: "INFO", effectiveLevel: "INFO" }], null);
+  assert.ok(out.levels.includes("TRACE") && out.levels.includes("FINEST"));
+  assert.equal(normalizeQuarkusLoggers(null, ["INFO"]), null);
 });
 
 // ---------------------------------------------------------------------------

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -120,6 +120,27 @@ test("renderMcp tolerates an unavailable MCP server", () => {
   assert.doesNotThrow(() => win.renderMcp({ available: false }));
 });
 
+test("renderLoggers tailors the no-endpoint hint and fix button per framework", () => {
+  const list = () => win.document.getElementById("loggers-list").innerHTML;
+
+  // Spring Boot: Actuator hint + a Fix button wired to install-actuator-loggers.
+  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "spring" }));
+  assert.ok(list().includes("Actuator"), "expected the Spring Boot Actuator hint");
+  assert.ok(!list().includes("quarkus-logging-manager"), "no Quarkus copy for a Spring app");
+  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button");
+
+  // Quarkus: logging-manager hint + a Fix button, no Actuator copy.
+  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "quarkus" }));
+  assert.ok(list().includes("quarkus-logging-manager"), "expected the Quarkus logging-manager hint");
+  assert.ok(!/Actuator/.test(list()), "no Spring Boot copy for a Quarkus app");
+  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button");
+
+  // Plain Java (or unknown): generic message, no fix button.
+  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "java" }));
+  assert.ok(list().includes("only"), "expected the generic 'only Spring Boot or Quarkus' message");
+  assert.equal(win.document.getElementById("loggers-fix"), null, "no fix button for a non-framework app");
+});
+
 test("the Settings tab is pinned to the top of the aside bar", () => {
   win.updateAsideAvailability({ metrics: true, loggers: false, scans: false });
   const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);


### PR DESCRIPTION
## Summary

The Loggers panel previously only worked for Spring Boot (via Actuator `/loggers`). This makes runtime log-level control work for Quarkus too, and turns the "no logger endpoint" dead end into an actionable, framework-aware prompt.

- **Quarkus logger tier.** When the app was launched as Quarkus, the backend now reads loggers from the Quarkiverse `quarkus-logging-manager` extension (`/q/logging-manager`) instead of Actuator. The two wire formats (Actuator's name-keyed map vs. logging-manager's JSON array, form-encoded writes, JBoss level set, `ROOT` <-> empty-string root) are normalized to one shape, and `loggersStatus()` dispatches on `app.runMode` so it hits the right backend directly rather than probing both URLs.
- **Framework-specific unavailable view.** If the app runs but exposes no logger endpoint, the tab now tailors its hint: Spring Boot apps get an Actuator message plus a one-click "Fix with Copilot" that asks the agent to add `spring-boot-starter-actuator` and expose `/loggers`; Quarkus apps get a message plus a button that asks for the `quarkus-logging-manager` extension; anything else gets a plain "only works for Spring Boot or Quarkus" message with no button. `/api/loggers` now returns `runMode` so the UI can branch, and `buildFixPrompt` gained `install-actuator-loggers` and `install-logging-manager` cases (Maven and Gradle variants each).

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [ ] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

`npm test` is green (91 pass, 9 skipped), including new unit tests for `normalizeQuarkusLoggers` and a ui-smoke test covering the three unavailable branches.

## Notes for reviewers

- A couple of things worth a careful look: `renderLoggers` was made a pure function of its argument (it now keys off `data.appDown` instead of the module-level `appRunning`), and the unavailable view uses a small `loggersFixAsked` / `loggersUnavailKey` guard so the 5s poll keeps the "Asked Copilot" state and avoids needless innerHTML rebuilds.
- The two new fix prompts intentionally leave the dependency version as `VERSION` for Quarkus (the agent is told to pin the latest from Maven Central) and omit the version for the Actuator starter (inherited from the Spring Boot parent/BOM).
- Live verification still needs a real Spring Boot / Quarkus app, which isn't available in this environment.