### PR TITLE
Add a Spring Boot side tab (version/EOL advisor + DevTools)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -64,6 +64,11 @@ Shipped in the extension today:
 - "Fix with Copilot" for compile, package, test, plain-Java, Spring Boot and Quarkus
   startup failures (including Quarkus dev-mode build/augmentation failures that keep
   the process running), for flame-graph hotspots, and for BootUI advisor-scan findings.
+- For Spring Boot projects, a dedicated **Spring Boot** side tab (between Loggers and
+  BootUI) shows the detected Spring Boot version mapped to a support status (current /
+  supported / EOL) from an embedded endoflife.date table, with an "Upgrade with Copilot"
+  action when behind the latest GA, plus DevTools controls (Add DevTools, Enable live
+  reload, Live reload / Restart app).
 - BootUI advisor scans run over REST (BootUI tab), plus an optional MCP-server
   toggle/register bridge, when the running app exposes BootUI.
 - Per-project persisted settings (warm JVM, Spring profiles, devtools, random port,

--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ wins; when neither is found the console says so and stays disabled until one is 
   environment (no `sdk use` shelling out). **Auto** keeps the system default; the
   active JDK is shown as a pill next to the build tool. The change takes effect on
   the next launch, so stop a running app before switching.
+- **Spring Boot tab** &mdash; for Spring Boot projects a dedicated **Spring Boot** side
+  tab (between **Loggers** and **BootUI**) reports the project's Spring Boot version and
+  maps its release line to a support status (current / supported / end-of-life) from an
+  embedded [endoflife.date](https://endoflife.date/spring-boot) table, with an
+  **Upgrade with Copilot** button when the line trails the latest GA. It also hosts
+  **DevTools**: an **Add DevTools** button for Spring apps that lack it, an **Enable live
+  reload** toggle, and **Live reload** / **Restart app** actions while the app runs.
 - **Advisor scans (with BootUI)** &mdash; when the running app exposes
   [BootUI](https://github.com/jdubois/boot-ui), the **BootUI** tab lists its advisor
   scans (architecture, Spring, security, Hibernate, …) and runs them directly over

--- a/extension.mjs
+++ b/extension.mjs
@@ -177,6 +177,7 @@ function applyWorkspace(primary) {
   baseRunnerInfo = null;
   projectModules = null;
   javaVersion = undefined;
+  springBootVersionCache = undefined;
   mavenProfiles = null;
   springProfiles = null;
   quarkusProfiles = null;
@@ -1764,7 +1765,142 @@ function detectJavaVersion() {
   return javaVersion;
 }
 
+// --- Spring Boot version + support (EOL) advisor ---------------------------
+// The Spring Boot tab surfaces the project's Spring Boot version and whether its
+// release line is still supported, offering an "Upgrade with Copilot" prompt when
+// it isn't the latest line. The version is read straight from the build files
+// (cheap + offline); the support timeline is embedded below.
+
+// Spring Boot release-line support timeline, embedded from endoflife.date
+// (https://endoflife.date/spring-boot, fetched 2026-06). `ossEnd` is the open-source
+// support end date for that line; `latest` is the newest patch published for it at
+// embed time — a hint for the upgrade prompt, which the agent verifies. The list is
+// ordered newest line first, so the head is the latest GA line.
+const SPRING_BOOT_SUPPORT = [
+  { cycle: "4.1", ossEnd: "2027-07-31", latest: "4.1.0" },
+  { cycle: "4.0", ossEnd: "2026-12-31", latest: "4.0.7" },
+  { cycle: "3.5", ossEnd: "2026-06-30", latest: "3.5.15" },
+  { cycle: "3.4", ossEnd: "2025-12-31", latest: "3.4.13" },
+  { cycle: "3.3", ossEnd: "2025-06-30", latest: "3.3.13" },
+  { cycle: "3.2", ossEnd: "2024-12-31", latest: "3.2.12" },
+  { cycle: "3.1", ossEnd: "2024-06-30", latest: "3.1.12" },
+  { cycle: "3.0", ossEnd: "2023-12-31", latest: "3.0.13" },
+  { cycle: "2.7", ossEnd: "2023-06-30", latest: "2.7.18" },
+  { cycle: "2.6", ossEnd: "2022-11-24", latest: "2.6.15" },
+  { cycle: "2.5", ossEnd: "2022-05-19", latest: "2.5.15" },
+  { cycle: "2.4", ossEnd: "2021-11-18", latest: "2.4.13" },
+  { cycle: "2.3", ossEnd: "2021-05-20", latest: "2.3.12" },
+  { cycle: "2.2", ossEnd: "2020-10-16", latest: "2.2.13" },
+  { cycle: "2.1", ossEnd: "2019-10-30", latest: "2.1.18" },
+  { cycle: "2.0", ossEnd: "2019-03-01", latest: "2.0.9" },
+  { cycle: "1.5", ossEnd: "2019-08-06", latest: "1.5.22" },
+];
+
+// Spring Boot version from a pom: the spring-boot-starter-parent version, the
+// spring-boot.version property, the spring-boot-dependencies BOM, or the plugin.
+// The [^<${}] class skips unresolved `${…}` placeholders so we only return a literal.
+export function springBootVersionFromPom(xml) {
+  const parent = (xml.match(/<parent>([\s\S]*?)<\/parent>/) || [, ""])[1];
+  if (/spring-boot-starter-parent/.test(parent)) {
+    const v = parent.match(/<version>\s*([^<${}\s][^<${}]*?)\s*<\/version>/);
+    if (v) return v[1];
+  }
+  const prop = xml.match(/<spring-boot\.version>\s*([^<${}\s][^<${}]*?)\s*<\/spring-boot\.version>/);
+  if (prop) return prop[1];
+  const bom = xml.match(/spring-boot-dependencies<\/artifactId>\s*<version>\s*([^<${}\s][^<${}]*?)\s*<\/version>/);
+  if (bom) return bom[1];
+  const plugin = xml.match(/spring-boot-maven-plugin<\/artifactId>\s*<version>\s*([^<${}\s][^<${}]*?)\s*<\/version>/);
+  if (plugin) return plugin[1];
+  return null;
+}
+
+// Spring Boot version from a Gradle build script: the org.springframework.boot
+// plugin version, or the gradle-plugin classpath in a buildscript block. The
+// leading-digit anchor keeps version variables (`$springBootVersion`, libs.*) out.
+export function springBootVersionFromGradle(text) {
+  let m = text.match(/org\.springframework\.boot['"]\s*\)?\s*version\s*\(?\s*['"](\d[^'"]*)['"]/);
+  if (m) return m[1];
+  m = text.match(/spring-boot-gradle-plugin:(\d[^'":\s]*)/);
+  if (m) return m[1];
+  return null;
+}
+
+let springBootVersionCache = undefined;
+function detectSpringBootVersion() {
+  if (springBootVersionCache !== undefined) return springBootVersionCache;
+  springBootVersionCache = null;
+  try {
+    const dirs = [workspacePath, ...listModules().map((m) => path.join(workspacePath, m.name))];
+    for (const dir of dirs) {
+      let v = null;
+      if (buildTool === "maven") {
+        let xml;
+        try {
+          xml = readFileSync(path.join(dir, "pom.xml"), "utf8");
+        } catch {
+          continue;
+        }
+        v = springBootVersionFromPom(xml);
+      } else if (buildTool === "gradle") {
+        const text = readGradleBuildFile(dir);
+        if (text) v = springBootVersionFromGradle(text);
+      }
+      if (v) {
+        springBootVersionCache = v;
+        break;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return springBootVersionCache;
+}
+
+// Compare two "major.minor" release lines numerically; returns >0 if a is newer.
+function compareCycles(a, b) {
+  const [am, an] = a.split(".").map(Number);
+  const [bm, bn] = b.split(".").map(Number);
+  return am !== bm ? am - bm : an - bn;
+}
+
+// Map the detected Spring Boot version to a support status. Pure data for the UI;
+// the date comparison uses the local "today" so it stays accurate as time passes.
+export function springBootAdvisor() {
+  const detected = listModules().some((m) => m.springBoot);
+  if (!detected) return { detected: false };
+  const version = detectSpringBootVersion();
+  const latest = SPRING_BOOT_SUPPORT[0];
+  const cycle = version ? (version.match(/^(\d+\.\d+)/) || [])[1] || null : null;
+  let status = version ? "unknown" : "unreadable";
+  let ossEnd = null;
+  if (cycle) {
+    const entry = SPRING_BOOT_SUPPORT.find((e) => e.cycle === cycle);
+    if (entry) {
+      ossEnd = entry.ossEnd;
+      const today = new Date().toISOString().slice(0, 10);
+      if (cycle === latest.cycle) status = "current";
+      else if (ossEnd >= today) status = "supported";
+      else status = "eol";
+    } else {
+      // Not in the embedded table: treat a line newer than we know as current,
+      // anything older as unknown (we can't assert its support window).
+      status = compareCycles(cycle, latest.cycle) > 0 ? "current" : "unknown";
+    }
+  }
+  return {
+    detected: true,
+    version,
+    cycle,
+    status,
+    ossEnd,
+    latestLine: latest.cycle,
+    latestVersion: latest.latest,
+    upToDate: status === "current",
+  };
+}
+
 // Static capability tiers, derived from the build files. The runtime metrics tier
+// (refreshMetrics) is authoritative once the app is up; these are the hints the
 // (refreshMetrics) is authoritative once the app is up; these are the hints the
 // UI uses before/while running to decide what controls to show.
 function capabilitiesSnapshot() {
@@ -2355,6 +2491,21 @@ function maybeStartLiveReload() {
   }
 }
 
+// Manually trigger a live reload: recompile the running module's sources so Spring
+// Boot DevTools restarts the app in place. Requires a Spring app up with the
+// DevTools watcher active (DevTools enabled + on the classpath). Mirrors what the
+// watcher does on file save, exposed as an explicit button in the Spring Boot tab.
+function requestReload() {
+  if (lanes.run.phase !== "running" || app.runMode !== "spring") {
+    return { ok: false, error: "Start the Spring Boot app first." };
+  }
+  if (!liveReload || !reloadCtx) {
+    return { ok: false, error: "Live reload isn't active — enable DevTools, then Run the app." };
+  }
+  triggerRecompile();
+  return { ok: true, busy: reloadBusy };
+}
+
 // Merge incoming settings, persist, and react to changes (live reload). Returns
 // the saved snapshot.
 function applySettings(body) {
@@ -2380,7 +2531,7 @@ function applySettings(body) {
     settings.metricsPollMs = clampMetricsPollMs(body.metricsPollMs);
   }
   // Right-panel preference (which aside tab, and whether the panel is open).
-  if (["metrics", "loggers", "scans", "settings"].includes(body.asideTab)) settings.asideTab = body.asideTab;
+  if (["metrics", "loggers", "spring", "scans", "settings"].includes(body.asideTab)) settings.asideTab = body.asideTab;
   if (typeof body.asideOpen === "boolean") settings.asideOpen = body.asideOpen;
   // JDK selection. Don't switch the JDK out from under a running/debugging app —
   // the change applies to the next launch, so the user must stop it first. A new
@@ -2645,6 +2796,8 @@ function envSnapshot() {
     springProfiles: listSpringProfiles(),
     quarkusProfiles: listQuarkusProfiles(),
     capabilities: capabilitiesSnapshot(),
+    // Spring Boot version + support (EOL) advisor for the Spring Boot tab.
+    spring: springBootAdvisor(),
     settings: settingsSnapshot(),
     // CPU/alloc/wall/lock flame graphs via async-profiler (Run tab).
     profiler: profilerSnapshot(),
@@ -6208,6 +6361,31 @@ function buildFixPrompt(kind, extra = {}) {
         .filter(Boolean)
         .join("\n\n");
     }
+    case "upgrade-spring-boot": {
+      const moduleName = extra.module || "";
+      const current = extra.version ? `Spring Boot ${extra.version}` : "an older Spring Boot release";
+      const floor = extra.target || null;
+      const crossMajor = extra.version && /^2\./.test(String(extra.version));
+      const where =
+        buildTool === "gradle"
+          ? `the \`org.springframework.boot\` plugin version in \`${gradleModuleBuildFile(moduleName).rel}\``
+          : "the `spring-boot-starter-parent` version (or the `spring-boot.version` property / `spring-boot-dependencies` BOM) in the project's `pom.xml`";
+      return [
+        `This project uses ${current}. Upgrade it to the latest stable Spring Boot GA release.`,
+        [
+          `1. Determine the latest stable Spring Boot GA version${floor ? ` (it is at least ${floor}; ` : " ("}verify the newest patch on https://start.spring.io or Maven Central — don't pin a milestone, RC or SNAPSHOT).`,
+          `2. Bump ${where} to that version.`,
+          "3. Read the Spring Boot release notes and the migration guide for every release line between the current and target versions, and apply the required changes (renamed/removed configuration properties, removed or relocated APIs, dependency-management changes)." +
+            (crossMajor
+              ? " This crosses Spring Boot 2.x → 3.x: migrate `javax.*` imports to `jakarta.*`, ensure Java 17+, and account for the Spring Security / Hibernate / Jakarta EE 9+ baseline."
+              : ""),
+          "4. Build the project and run the tests to confirm the upgrade is clean; fix anything the upgrade breaks before finishing.",
+        ].join("\n"),
+        "Summarize the version you upgraded to and any notable breaking changes you had to handle.",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
     case "install-jdtls": {
       const platformName = extra.os || (process.platform === "darwin" ? "macOS" : isWindows ? "Windows" : "Linux");
       const installCmd = extra.installCmd || "brew install jdtls";
@@ -6991,6 +7169,10 @@ async function handleRequest(req, res) {
   if (req.method === "POST" && url.pathname === "/api/restart") {
     const body = await readBody(req);
     sendJson(res, 200, await restart(body.op, body)); // stop the lane, then relaunch it
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/reload") {
+    sendJson(res, 200, requestReload()); // recompile so DevTools restarts the app in place
     return;
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -90,6 +90,11 @@ const setSpring = document.getElementById("set-spring");
 const setDevtools = document.getElementById("set-devtools");
 const devtoolsToggle = document.getElementById("devtools-toggle");
 const devtoolsInput = document.getElementById("in-devtools");
+const devtoolsActions = document.getElementById("devtools-actions");
+const springVersionEl = document.getElementById("spring-version");
+const btnUpgradeSpring = document.getElementById("btn-upgrade-spring");
+const btnReload = document.getElementById("btn-reload");
+const btnRestartApp = document.getElementById("btn-restart-app");
 const setRandomport = document.getElementById("set-randomport");
 const randomportInput = document.getElementById("in-randomport");
 const maskSecretsInput = document.getElementById("in-masksecrets");
@@ -373,6 +378,7 @@ function showAsideTab(name) {
   document.querySelectorAll(".atab").forEach((t) => t.classList.toggle("active", t.dataset.atab === name));
   document.getElementById("atab-metrics").classList.toggle("active", name === "metrics");
   document.getElementById("atab-loggers").classList.toggle("active", name === "loggers");
+  document.getElementById("atab-spring").classList.toggle("active", name === "spring");
   document.getElementById("atab-scans").classList.toggle("active", name === "scans");
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
   syncLoggersPolling();
@@ -402,7 +408,7 @@ function rememberAsideState() {
 function applyAsideState(s) {
   if (asideStateApplied || !s) return;
   asideStateApplied = true;
-  asideTabPref = ["metrics", "loggers", "scans", "settings"].includes(s.asideTab) ? s.asideTab : "settings";
+  asideTabPref = ["metrics", "loggers", "spring", "scans", "settings"].includes(s.asideTab) ? s.asideTab : "settings";
   asideOpenPref = s.asideOpen === true;
   showAsideTab(asideTabPref);
   // The remembered open state applies to the in-flow layout only; on a narrow
@@ -462,21 +468,29 @@ const ASIDE_ALWAYS = new Set(["settings"]);
 // Canonical left-to-right order, applied within both the available and the
 // unavailable group. Settings always leads the available group (it's never
 // unavailable); "quarkus" reserves the trailing slot for a future Quarkus tab.
-const ASIDE_ORDER = ["settings", "metrics", "loggers", "scans", "quarkus"];
+const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "scans", "quarkus"];
 const ASIDE_REASON = {
   metrics:
     "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
   loggers: "Live log levels need a running Spring Boot app with the Actuator /loggers endpoint. Click to learn more.",
+  spring:
+    "The Spring Boot tab needs a Spring Boot module — version advisor and DevTools live reload. Click to learn more.",
   scans: "The BootUI panel needs a running BootUI app — Run a module with the BootUI starter. Click to learn more.",
 };
 // metrics / loggers / scans are each gated on the running app exposing the right
 // capability (see updateAsideAvailability callers); the BootUI (scans) tab is
 // available only while a BootUI app is actually up, exactly like the other two.
+// The spring tab is gated statically on the project having a Spring Boot module,
+// so it reads caps (not the running-app avail) and stays usable before/after Run.
+let lastMetricsAvail = null;
+function refreshAsideAvailability() {
+  updateAsideAvailability(lastMetricsAvail);
+}
 function updateAsideAvailability(avail) {
   let anyUnavailable = false;
   document.querySelectorAll(".atab").forEach((btn) => {
     const name = btn.dataset.atab;
-    const ok = ASIDE_ALWAYS.has(name) || !!(avail && avail[name]);
+    const ok = ASIDE_ALWAYS.has(name) || (name === "spring" ? !!(caps && caps.springBoot) : !!(avail && avail[name]));
     if (!ok) anyUnavailable = true;
     btn.classList.toggle("unavailable", !ok);
     btn.setAttribute("aria-disabled", ok ? "false" : "true");
@@ -726,6 +740,16 @@ function renderStatus(s) {
     reloadPill.className = "pill " + (reload.busy ? "running" : "idle");
   } else {
     reloadPill.hidden = true;
+  }
+  // Spring Boot tab dev-loop actions. "Live reload" needs the DevTools watcher
+  // active (and not already recompiling); "Restart app" needs the run lane up.
+  if (btnReload) {
+    const r = s.reload || {};
+    btnReload.disabled = !r.active || !!r.busy;
+    btnReload.textContent = r.busy ? "Reloading\u2026" : "Live reload";
+  }
+  if (btnRestartApp) {
+    btnRestartApp.disabled = !laneBusy("run") || !!restarting.run;
   }
   // Run-tab "Open in browser" button always tracks the run lane.
   const run = s.run || {};
@@ -1109,11 +1133,12 @@ function renderMetrics(m) {
   // The metrics tier is the single source of truth for which tool panels are
   // reachable, so refresh the bar's availability on every snapshot.
   const tier = nowUp ? m.metricsTier || "process" : null;
-  updateAsideAvailability({
+  lastMetricsAvail = {
     metrics: nowUp && tier !== "process",
     loggers: nowUp && (tier === "bootui" || tier === "actuator"),
     scans: nowUp && tier === "bootui",
-  });
+  };
+  updateAsideAvailability(lastMetricsAvail);
   if (nowUp !== appRunning) {
     appRunning = nowUp;
     // Reflect the app coming up / going down in the Loggers tab if it's open.
@@ -1913,11 +1938,11 @@ let moduleList = [];
 // Per selected module (one reactor can mix capabilities), decide which
 // settings rows/proposals to surface:
 // - Spring Boot or Quarkus -> show the run-profile + random-port rows.
-// - Spring Boot -> also show DevTools (Quarkus dev mode has live reload built
-//   in, so no DevTools row) and the BootUI / DevTools "add" proposals.
+// - Spring Boot -> drive the Spring Boot tab's DevTools section (Quarkus dev mode
+//   has live reload built in, so no DevTools row) and the BootUI "add" proposal.
 // - Spring Boot but no BootUI starter -> offer to add BootUI.
-// - Spring Boot but no DevTools -> offer to add DevTools and disable the
-//   "Enable Spring Boot DevTools" toggle until the dependency is present.
+// - Spring Boot but no DevTools -> offer to add DevTools (the live-reload toggle +
+//   actions only appear once the dependency is present).
 function updateDevSetup() {
   const mod = moduleList.find((m) => m.name === moduleSelect.value);
   const spring = !!(mod && mod.springBoot);
@@ -1925,7 +1950,6 @@ function updateDevSetup() {
   const framework = spring || quarkus;
   // Profiles + random-port apply to both frameworks; DevTools is Spring-only.
   setSpring.hidden = !framework;
-  setDevtools.hidden = !spring;
   setRandomport.hidden = !framework;
   // The BootUI MCP server toggle stays visible in the BootUI panel; renderMcp /
   // setMcpUnavailable grey and disable it until a running BootUI app exposes the
@@ -1946,22 +1970,72 @@ function updateDevSetup() {
   btnAddBootui.title =
     "Add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
 
+  // DevTools section (Spring Boot tab): show the live-reload toggle + manual
+  // actions once DevTools is on the classpath, otherwise offer to add it.
   const hasDevtools = spring && !!mod.devtools;
-  const showDevtools = spring && !mod.devtools;
-  btnAddDevtools.hidden = !showDevtools;
-  if (showDevtools) {
+  const showAddDevtools = spring && !mod.devtools;
+  setDevtools.hidden = !hasDevtools;
+  devtoolsActions.hidden = !hasDevtools;
+  devtoolsInput.disabled = !hasDevtools;
+  devtoolsToggle.classList.toggle("disabled", !hasDevtools);
+  btnAddDevtools.hidden = !showAddDevtools;
+  if (showAddDevtools) {
     btnAddDevtools.disabled = false;
     btnAddDevtools.textContent = caps.gradle ? "Add DevTools (developmentOnly)" : "Add DevTools to dev profile";
   }
-  // The DevTools toggle only makes sense once the dependency is on the
-  // classpath; grey it out and explain via the info tooltip otherwise.
-  devtoolsToggle.classList.toggle("disabled", !hasDevtools);
-  devtoolsInput.disabled = !hasDevtools;
-  document.getElementById("devtools-info").dataset.tip = hasDevtools
-    ? "Watch the running module's sources and recompile on save so DevTools restarts the app in place."
-    : caps.gradle
-      ? "Add Spring Boot DevTools (button below) to enable live reload."
-      : "Add Spring Boot DevTools to the dev profile first (button below) to enable live reload.";
+
+  // Keep the Spring Boot tab's availability in step with the build files (it's
+  // gated on the project owning a Spring Boot module, not on the running app).
+  refreshAsideAvailability();
+}
+
+// --- Spring Boot version + EOL/upgrade advisor (Spring Boot tab) -------------
+// The backend (springBootAdvisor) reports the detected version, its release line
+// and a support status; we render it and gate the "Upgrade with Copilot" button.
+const SPRING_STATUS = {
+  current: { label: "Latest release line", cls: "ok" },
+  supported: { label: "Supported — a newer release line is available", cls: "warn" },
+  eol: { label: "End of life — upgrade recommended", cls: "bad" },
+  unknown: { label: "Support status unknown", cls: "warn" },
+  unreadable: { label: "Version not found in the build file", cls: "warn" },
+};
+let springAdvisor = null;
+
+function renderSpringAdvisor(adv) {
+  springAdvisor = adv || null;
+  if (!springVersionEl) return;
+  if (!adv || !adv.detected) {
+    springVersionEl.innerHTML = '<p class="muted">No Spring Boot module detected.</p>';
+    btnUpgradeSpring.hidden = true;
+    return;
+  }
+  let html = "";
+  if (adv.version) {
+    html += row("Version", esc(adv.version));
+    if (adv.cycle) html += row("Release line", esc(adv.cycle));
+  }
+  const info = SPRING_STATUS[adv.status] || SPRING_STATUS.unknown;
+  html += `<div class="spring-status ${info.cls}">${esc(info.label)}</div>`;
+  if (adv.status === "eol" && adv.ossEnd) {
+    html += `<p class="hint">Open-source support for ${esc(adv.cycle)}.x ended ${esc(adv.ossEnd)}.</p>`;
+  } else if (adv.status === "supported" && adv.ossEnd) {
+    html += `<p class="hint">Open-source support for ${esc(adv.cycle)}.x runs until ${esc(adv.ossEnd)}; the latest line is ${esc(adv.latestLine)}.x.</p>`;
+  } else if (adv.status === "current") {
+    html += `<p class="hint">You're on the latest Spring Boot release line.</p>`;
+  } else if (adv.status === "unreadable") {
+    html += `<p class="hint">Couldn't read a literal Spring Boot version (it may come from a property or BOM).</p>`;
+  }
+  springVersionEl.innerHTML = html;
+
+  // Offer the upgrade whenever the project isn't on the latest line and we have a
+  // version to upgrade from.
+  const showUpgrade = !!adv.version && adv.status !== "current";
+  btnUpgradeSpring.hidden = !showUpgrade;
+  if (showUpgrade) {
+    btnUpgradeSpring.disabled = false;
+    btnUpgradeSpring.textContent = "Upgrade with Copilot";
+    btnUpgradeSpring.title = `Ask Copilot to upgrade from Spring Boot ${adv.version} to the latest stable release.`;
+  }
 }
 
 // Suggestion lists backing the custom comboboxes (kept editable).
@@ -2095,6 +2169,7 @@ function applyEnv(env) {
   quarkusItems = quarkus.length ? quarkus : ["dev", "test", "prod"];
   mavenItems = (env && env.mavenProfiles) || [];
   updateDevSetup();
+  renderSpringAdvisor(env && env.spring);
 
   // Degraded mode: no Maven or Gradle project. Show the banner and disable
   // the build/test/package/run actions; nothing can be invoked without a tool.
@@ -2422,16 +2497,22 @@ function stopLane(which, op) {
   post("/api/stop", { op: "maven" });
 }
 
+// The inputs that launch / restart the app, shared by the Run lane button and the
+// Spring Boot tab's "Restart app" action.
+function runBody() {
+  return {
+    module: document.getElementById("in-module").value.trim(),
+    profiles: document.getElementById("in-profiles").value.trim(),
+    mavenProfiles: mvnProfiles(),
+  };
+}
+
 // One button per lane: it starts the lane when idle, or stops it while busy.
 function laneAction(op) {
   if (op === "run") {
     if (laneBusy("run")) return stopLane("run");
     showTab("run");
-    triggerLane("run", "/api/run", {
-      module: document.getElementById("in-module").value.trim(),
-      profiles: document.getElementById("in-profiles").value.trim(),
-      mavenProfiles: mvnProfiles(),
-    });
+    triggerLane("run", "/api/run", runBody());
     return;
   }
   if (op === "debug") {
@@ -2537,6 +2618,27 @@ btnAddDevtools.onclick = async () => {
   btnAddDevtools.disabled = true;
   btnAddDevtools.textContent = "Asked Copilot \u2713";
   await post("/api/fix", { kind: "install-devtools", module: moduleSelect.value });
+};
+btnUpgradeSpring.onclick = async () => {
+  btnUpgradeSpring.disabled = true;
+  btnUpgradeSpring.textContent = "Asked Copilot \u2713";
+  await post("/api/fix", {
+    kind: "upgrade-spring-boot",
+    module: moduleSelect.value,
+    version: springAdvisor ? springAdvisor.version : null,
+    target: springAdvisor ? springAdvisor.latestVersion : null,
+  });
+};
+// Manual dev-loop actions. "Live reload" recompiles so DevTools restarts the app
+// in place; "Restart app" stops and relaunches the run lane. The status SSE drives
+// their enabled state (renderStatus), so just fire and let it re-render.
+btnReload.onclick = () => {
+  btnReload.disabled = true;
+  post("/api/reload", {});
+};
+btnRestartApp.onclick = () => {
+  if (!laneBusy("run")) return;
+  triggerLane("run", "/api/run", runBody());
 };
 btnSetupJdtls.onclick = async () => {
   btnSetupJdtls.disabled = true;

--- a/public/index.html
+++ b/public/index.html
@@ -429,6 +429,18 @@
           </button>
           <button
             class="atab"
+            data-atab="spring"
+            title="Spring Boot: version &amp; EOL advisor and DevTools live reload"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M11.251.068a.5.5 0 0 1 .227.58L9.677 6.5H13a.5.5 0 0 1 .364.843l-8 8.5a.5.5 0 0 1-.842-.49L6.323 9.5H3a.5.5 0 0 1-.364-.843l8-8.5a.5.5 0 0 1 .615-.09z"
+              />
+            </svg>
+            <span class="atab-label">Spring Boot</span>
+          </button>
+          <button
+            class="atab"
             data-atab="scans"
             title="BootUI: add it to your project, run advisor scans against the live app, and bridge its MCP server to Copilot"
           >
@@ -490,6 +502,58 @@
             </div>
             <div id="loggers-list">
               <p class="muted">App not running. Click <strong>Run</strong> to control its log levels.</p>
+            </div>
+          </div>
+
+          <div id="atab-spring" class="apane">
+            <h2>Spring Boot version</h2>
+            <div id="spring-version">
+              <p class="muted">Detecting the Spring Boot version…</p>
+            </div>
+            <div class="set-row set-proposals">
+              <button id="btn-upgrade-spring" class="fix tiny" hidden>Upgrade with Copilot</button>
+            </div>
+
+            <h2 class="spring-h2">DevTools</h2>
+            <p class="hint" id="devtools-hint">
+              Spring Boot DevTools recompiles on save and restarts the app in place — the canvas plays the IDE's
+              recompile role, so the dev loop works without an editor.
+            </p>
+            <!-- DevTools live-reload toggle (only meaningful once DevTools is on the
+               classpath). Moved here from Settings so the whole DevTools story lives
+               in one Spring-only place. -->
+            <div class="set-row switch-row" id="set-devtools" hidden>
+              <label class="switch" id="devtools-toggle">
+                <input type="checkbox" id="in-devtools" />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Enable live reload</span>
+              </label>
+              <span
+                class="info"
+                id="devtools-info"
+                tabindex="0"
+                data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
+                >&#9432;</span
+              >
+            </div>
+            <!-- Manual dev-loop actions, enabled while the app is running. -->
+            <div class="spring-actions" id="devtools-actions" hidden>
+              <button
+                id="btn-reload"
+                class="fix tiny"
+                disabled
+                title="Recompile now so DevTools restarts the running app in place."
+              >
+                Live reload
+              </button>
+              <button id="btn-restart-app" class="fix tiny" disabled title="Stop and relaunch the running app.">
+                Restart app
+              </button>
+            </div>
+            <!-- Add DevTools (dev profile): shown only for a Spring Boot module that
+               doesn't depend on DevTools yet. -->
+            <div class="set-row set-proposals">
+              <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
             </div>
           </div>
 
@@ -648,22 +712,6 @@
               <a id="warm-docs" href="#" target="_blank" rel="noopener">install guide</a>
             </div>
 
-            <!-- Enable Spring Boot DevTools (Spring only) -->
-            <div class="set-row switch-row" id="set-devtools" hidden>
-              <label class="switch" id="devtools-toggle">
-                <input type="checkbox" id="in-devtools" />
-                <span class="track"><span class="thumb"></span></span>
-                <span class="switch-label">Enable Spring Boot DevTools</span>
-              </label>
-              <span
-                class="info"
-                id="devtools-info"
-                tabindex="0"
-                data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
-                >&#9432;</span
-              >
-            </div>
-
             <!-- Use a random HTTP port (Spring Boot / Quarkus only) -->
             <div class="set-row switch-row" id="set-randomport" hidden>
               <label class="switch" id="randomport-toggle">
@@ -705,12 +753,6 @@
                 step="500"
                 title="How often the Live JVM panel refreshes metrics from the running app (500–30000 ms)."
               />
-            </div>
-
-            <!-- Dev setup proposal: add Spring Boot DevTools to the dev profile.
-               (The BootUI proposal now lives in the BootUI panel.) -->
-            <div class="set-row set-proposals">
-              <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
             </div>
           </div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1789,6 +1789,38 @@ button.is-restarting .btn-spin::before {
   align-items: flex-start;
   gap: 0.45rem;
 }
+/* Spring Boot tab: version/EOL advisor status chip + dev-loop action row */
+.spring-h2 {
+  margin-top: 1rem;
+}
+.spring-status {
+  display: inline-block;
+  margin: 0.4rem 0 0.2rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border-color-default, #d0d7de);
+  color: var(--text-color-muted, #656d76);
+}
+.spring-status.ok {
+  color: var(--true-color-green, #1a7f37);
+  border-color: var(--true-color-green, #1a7f37);
+}
+.spring-status.warn {
+  color: var(--true-color-orange, #bc4c00);
+  border-color: var(--true-color-orange, #bc4c00);
+}
+.spring-status.bad {
+  color: var(--true-color-red, #cf222e);
+  border-color: var(--true-color-red, #cf222e);
+}
+.spring-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+}
 /* Java language server (JDTLS) status row */
 .jdtls-row {
   display: flex;

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -25,6 +25,8 @@ const {
   pickAppPidFromJvmList,
   quarkusDevConsoleFailed,
   jdkSupportsNativeAccess,
+  springBootVersionFromPom,
+  springBootVersionFromGradle,
 } = await import("../extension.mjs");
 
 // ---------------------------------------------------------------------------
@@ -471,4 +473,52 @@ test("jdkSupportsNativeAccess: unknown/invalid majors omit the flag", () => {
   assert.equal(jdkSupportsNativeAccess(null), false);
   assert.equal(jdkSupportsNativeAccess(undefined), false);
   assert.equal(jdkSupportsNativeAccess(NaN), false);
+});
+
+// ---------------------------------------------------------------------------
+// Spring Boot version detection (Spring Boot tab EOL/upgrade advisor)
+// ---------------------------------------------------------------------------
+
+test("springBootVersionFromPom reads the spring-boot-starter-parent version", () => {
+  const xml = `<project>
+    <parent>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-parent</artifactId>
+      <version>3.4.13</version>
+    </parent>
+  </project>`;
+  assert.equal(springBootVersionFromPom(xml), "3.4.13");
+});
+
+test("springBootVersionFromPom falls back to the spring-boot.version property and BOM", () => {
+  const prop = `<project><properties><spring-boot.version>3.2.0</spring-boot.version></properties></project>`;
+  assert.equal(springBootVersionFromPom(prop), "3.2.0");
+  const bom = `<dependencyManagement><dependencies><dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-dependencies</artifactId>
+    <version>3.5.1</version>
+  </dependency></dependencies></dependencyManagement>`;
+  assert.equal(springBootVersionFromPom(bom), "3.5.1");
+});
+
+test("springBootVersionFromPom ignores an unresolved ${...} placeholder version", () => {
+  const xml = `<project><parent>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>\${spring.boot.version}</version>
+  </parent></project>`;
+  assert.equal(springBootVersionFromPom(xml), null);
+});
+
+test("springBootVersionFromGradle reads the plugin version (Groovy + Kotlin DSL)", () => {
+  const groovy = `plugins { id 'org.springframework.boot' version '3.3.5' }`;
+  assert.equal(springBootVersionFromGradle(groovy), "3.3.5");
+  const kotlin = `plugins { id("org.springframework.boot") version "3.4.0" }`;
+  assert.equal(springBootVersionFromGradle(kotlin), "3.4.0");
+});
+
+test("springBootVersionFromGradle reads a buildscript classpath and skips variables", () => {
+  const classpath = `buildscript { dependencies { classpath "org.springframework.boot:spring-boot-gradle-plugin:2.7.18" } }`;
+  assert.equal(springBootVersionFromGradle(classpath), "2.7.18");
+  const variable = `plugins { id 'org.springframework.boot' version "$springBootVersion" }`;
+  assert.equal(springBootVersionFromGradle(variable), null);
 });

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -225,3 +225,67 @@ test("a failed build shows the Fix button and replays the repaint pop", () => {
   assert.equal(btnFix.dataset.kind, "compile");
   assert.ok(btnFix.classList.contains("cof-pop-in"), "pop class added to force a repaint");
 });
+
+test("the Spring Boot tab and its pane are present in the rail", () => {
+  assert.ok(win.document.querySelector('.atab[data-atab="spring"]'), "Spring Boot rail button exists");
+  assert.ok(win.document.getElementById("atab-spring"), "Spring Boot pane exists");
+  // It sits between Loggers and BootUI (scans).
+  const order = [...win.document.querySelectorAll(".atab[data-atab]")].map((b) => b.dataset.atab);
+  assert.ok(order.indexOf("spring") > order.indexOf("loggers"), "spring after loggers");
+  assert.ok(order.indexOf("spring") < order.indexOf("scans"), "spring before BootUI");
+});
+
+test("renderSpringAdvisor reflects version status and gates the upgrade button", () => {
+  const btn = win.document.getElementById("btn-upgrade-spring");
+  const box = win.document.getElementById("spring-version");
+
+  // No Spring Boot module: empty state, no upgrade.
+  assert.doesNotThrow(() => win.renderSpringAdvisor({ detected: false }));
+  assert.equal(btn.hidden, true, "upgrade hidden without a Spring module");
+
+  // EOL line: a "bad" chip and the upgrade button offered.
+  win.renderSpringAdvisor({
+    detected: true,
+    version: "3.1.5",
+    cycle: "3.1",
+    status: "eol",
+    ossEnd: "2024-06-30",
+    latestLine: "4.1",
+    latestVersion: "4.1.0",
+  });
+  assert.equal(btn.hidden, false, "upgrade shown for an EOL line");
+  assert.ok(box.querySelector(".spring-status.bad"), "EOL renders a 'bad' status chip");
+
+  // Latest line: no upgrade offered, an "ok" chip.
+  win.renderSpringAdvisor({
+    detected: true,
+    version: "4.1.0",
+    cycle: "4.1",
+    status: "current",
+    ossEnd: "2027-07-31",
+    latestLine: "4.1",
+    latestVersion: "4.1.0",
+  });
+  assert.equal(btn.hidden, true, "no upgrade when on the latest line");
+  assert.ok(box.querySelector(".spring-status.ok"), "current renders an 'ok' status chip");
+});
+
+test("renderStatus drives the DevTools live-reload / restart buttons", () => {
+  const reload = win.document.getElementById("btn-reload");
+  const restart = win.document.getElementById("btn-restart-app");
+  const idle = { build: {}, test: {}, package: {}, run: {}, debug: {} };
+
+  // App down, no reload watcher: both disabled.
+  win.renderStatus({ ...idle, reload: { active: false }, run: { busy: false } });
+  assert.equal(reload.disabled, true, "live reload disabled when watcher inactive");
+  assert.equal(restart.disabled, true, "restart disabled when app not running");
+
+  // App running with an active reload watcher: both enabled.
+  win.renderStatus({ ...idle, reload: { active: true, busy: false }, run: { busy: true } });
+  assert.equal(reload.disabled, false, "live reload enabled when watcher active");
+  assert.equal(restart.disabled, false, "restart enabled while the app runs");
+
+  // Mid-recompile: live reload is busy and disabled.
+  win.renderStatus({ ...idle, reload: { active: true, busy: true }, run: { busy: true } });
+  assert.equal(reload.disabled, true, "live reload disabled while recompiling");
+});


### PR DESCRIPTION
## Summary

Spring Boot projects have two recurring needs that were not surfaced anywhere in the canvas: knowing whether the project's Spring Boot line is still supported, and driving the DevTools dev loop. This adds a dedicated, Spring-Boot-only **Spring Boot** tab to the right rail (between **Loggers** and **BootUI**) that covers both.

The tab has two sections:

- **Version + EOL/upgrade advisor** — detects the project's Spring Boot version from the build files (Maven parent / `spring-boot.version` property / `spring-boot-dependencies` BOM / plugin, or the Gradle plugin / buildscript classpath), maps its release line to a support status (current / supported / end-of-life) using an embedded [endoflife.date](https://endoflife.date/spring-boot) table, and offers an **Upgrade with Copilot** action when the line trails the latest GA.
- **DevTools** — relocates the live-reload toggle here from Settings (same element ids, so existing wiring is untouched) and adds an **Add DevTools** button for Spring apps that lack it, plus **Live reload** and **Restart app** actions while the app runs.

The tab is gated statically on the project owning a Spring Boot module (not on the running app), so it greys out for non-Spring projects the same way the other rail tabs do.

A couple of things worth a careful look:

- The EOL data is a snapshot embedded in `extension.mjs` (`SPRING_BOOT_SUPPORT`), compared against today's date, so status stays accurate over time but the table itself needs the occasional refresh as new lines ship / go EOL.
- DevTools moved out of the Settings pane into this tab; ids were preserved deliberately to avoid touching the rest of `app.js`.

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed.
- [x] No secrets committed.

Also ran `npm test` (92 pass / 0 fail / 9 skipped) and exercised `springBootAdvisor()` against the integration projects and synthetic poms across release lines (1.5/2.7/3.1/3.3 -> EOL, 4.1 -> current, non-Spring -> not detected). Added UI smoke tests (tab presence/order, advisor chip + upgrade gating, reload/restart enabling) and parser unit tests.

## Notes for reviewers

The Spring tab icon uses a bootstrap-icons lightning-charge glyph (thematic, trademark-safe). Status chip colors map current/supported/eol to ok/warn/bad via existing canvas color tokens.