### PR TITLE
Use official Spring Boot and Quarkus brand marks for rail icons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -432,9 +432,11 @@
             data-atab="spring"
             title="Spring Boot: version &amp; EOL advisor and DevTools live reload"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+            <!-- Spring Boot brand mark, drawn monochrome via currentColor so it
+               sizes and greys exactly like the other rail icons. -->
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path
-                d="M11.251.068a.5.5 0 0 1 .227.58L9.677 6.5H13a.5.5 0 0 1 .364.843l-8 8.5a.5.5 0 0 1-.842-.49L6.323 9.5H3a.5.5 0 0 1-.364-.843l8-8.5a.5.5 0 0 1 .615-.09z"
+                d="m23.693 10.7058-4.73-8.1844c-.4094-.7106-1.4166-1.2942-2.2402-1.2942H7.2725c-.819 0-1.8308.5836-2.2402 1.2942L.307 10.7058c-.4095.7106-.4095 1.873 0 2.5837l4.7252 8.189c.4094.7107 1.4166 1.2943 2.2402 1.2943h9.455c.819 0 1.826-.5836 2.2402-1.2942l4.7252-8.189c.4095-.7107.4095-1.8732 0-2.5838zM10.9763 5.7547c0-.5365.4377-.9742.9742-.9742s.9742.4377.9742.9742v5.8217c0 .5366-.4377.9742-.9742.9742s-.9742-.4376-.9742-.9742zm.9742 12.4294c-3.6427 0-6.6077-2.965-6.6077-6.6077.0047-2.0896.993-4.0521 2.6685-5.304a.8657.8657 0 0 1 1.2142.1788.8657.8657 0 0 1-.1788 1.2143c-2.1602 1.6048-2.612 4.6592-1.0072 6.8194 1.6049 2.1603 4.6593 2.612 6.8195 1.0072 1.2378-.9177 1.9673-2.372 1.9673-3.9157a4.8972 4.8972 0 0 0-1.9861-3.925c-.386-.2824-.466-.8284-.1836-1.2143.2824-.386.8283-.466 1.2143-.1835 1.6895 1.2471 2.6826 3.2238 2.6873 5.3228 0 3.6474-2.965 6.6077-6.6077 6.6077z"
               />
             </svg>
             <span class="atab-label">Spring Boot</span>
@@ -462,11 +464,11 @@
             data-atab="quarkus"
             title="Quarkus: register the standalone Quarkus Agent MCP server with Copilot and trigger its capabilities"
           >
-            <!-- Lightning bolt: a nod to Quarkus' "supersonic subatomic" mark,
-               drawn monochrome via currentColor like the other rail icons. -->
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+            <!-- Quarkus brand mark, drawn monochrome via currentColor so it
+               sizes and greys exactly like the other rail icons. -->
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path
-                d="M11.251.068a.5.5 0 0 1 .227.58L9.677 6.5H13a.5.5 0 0 1 .364.843l-8 8.5a.5.5 0 0 1-.842-.49L6.323 9.5H3a.5.5 0 0 1-.364-.843l8-8.5a.5.5 0 0 1 .615-.09z"
+                d="M3.981 0A3.993 3.993 0 0 0 0 3.981V20.02A3.993 3.993 0 0 0 3.981 24h10.983L12 16.8l-2.15 4.546H3.98c-.72 0-1.327-.608-1.327-1.327V3.98c0-.72.608-1.327 1.327-1.327h16.04c.72 0 1.327.608 1.327 1.327v16.04c0 .72-.608 1.327-1.327 1.327h-3.48L17.63 24h2.388A3.993 3.993 0 0 0 24 20.019V3.98A3.993 3.993 0 0 0 20.019 0zm4.324 4.217v3.858l3.341-1.93zm7.39 0l-3.341 1.929 3.34 1.929zM12 6.35L8.305 8.483 12 10.617l3.695-2.134zM8.104 8.832v4.266l3.695 2.133v-4.266zm7.792 0L12.2 10.965v4.266l3.695-2.133zm-8.146.204l-3.34 1.93 3.34 1.928zm8.5 0v3.858l3.34-1.929zm-8.146 4.47v3.859l3.341-1.93zm7.792 0l-3.341 1.93 3.34 1.929z"
               />
             </svg>
             <span class="atab-label">Quarkus</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Coffilot! -->

## Summary

The Spring Boot and Quarkus side-rail tabs both reused the same generic lightning-bolt glyph, so neither read as its own framework. This swaps in each project's official monochrome brand mark.

Both replacements are single-path SVGs drawn with `fill="currentColor"` and a `0 0 24 24` viewBox, so the existing rail CSS greys them (`--text-color-muted`) and sizes them (13px, 17px in rail mode) identically to the Live JVM and BootUI icons. No CSS changes were needed, the same treatment the BootUI mark already relies on.

## Related issue

N/A

## Verification

- [ ] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified the change in a live Coffilot canvas on a Maven or Gradle project.
- [x] Updated `README.md` / `PLAN.md` if behaviour changed. (N/A, icon-only, no behaviour change.)
- [x] No secrets committed.

## Notes for reviewers

Only `public/index.html` changed. The two SVG paths come from the official Spring Boot and Quarkus brand marks, used monochrome the same way the BootUI tab already uses its brand mark.