### PR TITLE
Add the Updates panel and a spec-driven right-panel rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
       # the produced JUnit reports through Coffilot's own report discovery + parser
       # (collectSurefireReport) and asserts the results. The failing-tests shard
       # also covers the failure path (build exits non-zero, report still parses).
+      # The hello-world / gradle-hello-world shards additionally run the real
+      # outdated-library scan and assert the ancient guava 19.0 is flagged.
       - name: Build, test, package & validate Coffilot parsing
         env:
           COFFILOT_E2E: "1"

--- a/PLAN.md
+++ b/PLAN.md
@@ -95,11 +95,12 @@ Shipped in the extension today:
   plus the debug actions `start_debug`, `stop_debug`, `set_breakpoint`,
   `remove_breakpoint`, `debug_continue`, `debug_step`, `debug_stack`,
   `get_variables`, `debug_evaluate` and `debug_status`.
-- **Upgrades tab** &mdash; a right-panel tab (no running app needed) that, for Maven,
-  lists outdated libraries from `dependency:tree` + `versions:display-dependency-updates`
-  (current → latest, major/minor/patch badge, pre-release warning, direct/transitive marker
-  with a "Direct only" toggle). Each finding has a "Fix with Copilot" button. Endpoints
-  `GET /api/deps` / `POST /api/deps/scan`.
+- **Upgrades tab** &mdash; a right-panel tab (no running app needed) that lists outdated
+  libraries for **Maven** (`dependency:tree` + `versions:display-dependency-updates`) and
+  **Gradle** (the built-in `dependencies` report + the ben-manes `dependencyUpdates` task,
+  injected via a throwaway `--init-script`) &mdash; current → latest, major/minor/patch
+  badge, pre-release warning, direct/transitive marker with a "Direct only" toggle. Each
+  finding has a "Fix with Copilot" button. Endpoints `GET /api/deps` / `POST /api/deps/scan`.
 
 ## Known limitations
 
@@ -145,8 +146,9 @@ Near-term, roughly in priority order:
       integration-project matrix (Maven + Gradle) in CI.
 - [x] Add an Upgrades tab: a Maven outdated-library scan with a direct/transitive filter
       and per-finding "Fix with Copilot".
-- [ ] Extend the outdated-library scan to Gradle (e.g. the `dependencyUpdates` task / a
-      version-catalog reader) so the Upgrades tab covers Gradle too.
+- [x] Extend the outdated-library scan to Gradle (the ben-manes `dependencyUpdates` task
+      injected via a throwaway `--init-script`, plus the `dependencies` report for the
+      direct/transitive tree) so the Upgrades tab covers Gradle too.
 - [ ] Document and test the share-as-gist / install-from-repo round trip.
 
 Explicitly **out of scope**: remote (non-loopback) access, and anything that mutates

--- a/PLAN.md
+++ b/PLAN.md
@@ -91,10 +91,15 @@ Shipped in the extension today:
   native-access warnings.
 - Agent-facing actions: `build_app`, `run_tests`, `run_affected_tests`,
   `package_app`, `start_app`, `stop_app`, `get_status`, `get_metrics`,
-  `profile_app`, `fix_issue`, `run_scan`, `set_log_level`, plus the debug actions
-  `start_debug`, `stop_debug`, `set_breakpoint`, `remove_breakpoint`,
-  `debug_continue`, `debug_step`, `debug_stack`, `get_variables`, `debug_evaluate`
-  and `debug_status`.
+  `profile_app`, `fix_issue`, `run_scan`, `check_dependencies`, `set_log_level`,
+  plus the debug actions `start_debug`, `stop_debug`, `set_breakpoint`,
+  `remove_breakpoint`, `debug_continue`, `debug_step`, `debug_stack`,
+  `get_variables`, `debug_evaluate` and `debug_status`.
+- **Upgrades tab** &mdash; a right-panel tab (no running app needed) that, for Maven,
+  lists outdated libraries from `dependency:tree` + `versions:display-dependency-updates`
+  (current → latest, major/minor/patch badge, pre-release warning, direct/transitive marker
+  with a "Direct only" toggle). Each finding has a "Fix with Copilot" button. Endpoints
+  `GET /api/deps` / `POST /api/deps/scan`.
 
 ## Known limitations
 
@@ -138,6 +143,10 @@ Near-term, roughly in priority order:
       `public/index.html` + `public/app.js`) wired into CI alongside `npm run check`,
       plus `node:test` unit tests for the pure parsers/normalizers and an
       integration-project matrix (Maven + Gradle) in CI.
+- [x] Add an Upgrades tab: a Maven outdated-library scan with a direct/transitive filter
+      and per-finding "Fix with Copilot".
+- [ ] Extend the outdated-library scan to Gradle (e.g. the `dependencyUpdates` task / a
+      version-catalog reader) so the Upgrades tab covers Gradle too.
 - [ ] Document and test the share-as-gist / install-from-repo round trip.
 
 Explicitly **out of scope**: remote (non-loopback) access, and anything that mutates

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ wins; when neither is found the console says so and stays disabled until one is 
   Quarkus module is detected and JBang or Java 21+ is available (docs search also
   needs Docker/Podman).
 - **Upgrades** &mdash; an **Upgrades** side tab that doesn't need the app running. For
-  Maven projects it lists **outdated libraries** &mdash; each shown with its current →
-  latest version, an upgrade-size badge (major / minor / patch), pre-release warnings,
-  and a direct/transitive marker (with a **Direct only** toggle to hide transitive ones).
-  Each finding expands for detail and carries a **Fix with Copilot** button. (Outdated-library
-  scanning is Maven-only for now.)
+  Maven and Gradle projects it lists **outdated libraries** &mdash; each shown with its
+  current → latest version, an upgrade-size badge (major / minor / patch), pre-release
+  warnings, and a direct/transitive marker (with a **Direct only** toggle to hide
+  transitive ones). Each finding expands for detail and carries a **Fix with Copilot**
+  button.
 
 ## Graceful degradation by capability
 
@@ -278,9 +278,12 @@ Coffilot is a Node process (the extension) that:
   discover them, `POST /bootui/api/{id}/scan` to run one), surfaced in the **BootUI**
   tab — no in-app MCP server required;
 - checks for outdated libraries without the app running: a Maven `dependency:tree` +
-  `versions:display-dependency-updates` run whose output it parses into the outdated-library
-  list (the build tool's own plugins resolve the latest versions — Coffilot never talks to a
-  package registry directly), surfaced in the **Upgrades** tab;
+  `versions:display-dependency-updates` run, or for Gradle the built-in `dependencies`
+  report plus the ben-manes `dependencyUpdates` task (injected through a throwaway
+  `--init-script`, so the project's build files are never touched), whose output it
+  parses into the outdated-library list (the build tool's own plugins resolve the latest
+  versions — Coffilot never talks to a package registry directly), surfaced in the
+  **Upgrades** tab;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 
 The loopback HTTP server that backs the iframe binds to `127.0.0.1` only. See

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ wins; when neither is found the console says so and stays disabled until one is 
   up waiting for a fix), or a running app that exposes no runtime-logger endpoint,
   a button pushes a context-rich request back into the chat so the agent can
   diagnose and fix it.
-- **Responsive layout** &mdash; on a wide canvas the **Live JVM / Loggers / Settings**
-  panel is docked on the right; as the canvas narrows it collapses to an icon rail on
+- **Responsive layout** &mdash; on a wide canvas the **Live JVM / Loggers / Upgrades /
+  Settings** panel is docked on the right; as the canvas narrows it collapses to an icon rail on
   the right edge, and tapping an icon slides that pane out as an overlay over the main
   console. A toggle button (the chevron in the panel's tab bar / rail) hides or shows
   the panel on demand in any layout &mdash; even when docked &mdash; so you can give the
@@ -144,6 +144,12 @@ wins; when neither is found the console says so and stays disabled until one is 
   detects and registers it &mdash; the server runs as a separate process. Shown when a
   Quarkus module is detected and JBang or Java 21+ is available (docs search also
   needs Docker/Podman).
+- **Upgrades** &mdash; an **Upgrades** side tab that doesn't need the app running. For
+  Maven projects it lists **outdated libraries** &mdash; each shown with its current →
+  latest version, an upgrade-size badge (major / minor / patch), pre-release warnings,
+  and a direct/transitive marker (with a **Direct only** toggle to hide transitive ones).
+  Each finding expands for detail and carries a **Fix with Copilot** button. (Outdated-library
+  scanning is Maven-only for now.)
 
 ## Graceful degradation by capability
 
@@ -240,11 +246,10 @@ In a Copilot app session on a Maven or Gradle project, open the **Coffilot** can
 6. **Stop** when done.
 
 The agent can drive the same flow with the `build_app`, `run_tests`,
-The agent can drive the same flow with the `build_app`, `run_tests`,
 `run_affected_tests`, `package_app`, `start_app`, `stop_app`, `get_status`,
-`get_metrics`, `profile_app`, `fix_issue`, `run_scan` and `set_log_level` actions,
-plus the debug actions `start_debug`, `stop_debug`, `set_breakpoint`,
-`remove_breakpoint`, `debug_continue`, `debug_step`, `debug_stack`,
+`get_metrics`, `profile_app`, `fix_issue`, `run_scan`, `check_dependencies` and
+`set_log_level` actions, plus the debug actions `start_debug`, `stop_debug`,
+`set_breakpoint`, `remove_breakpoint`, `debug_continue`, `debug_step`, `debug_stack`,
 `get_variables`, `debug_evaluate` and `debug_status`.
 
 ## How it works
@@ -272,6 +277,10 @@ Coffilot is a Node process (the extension) that:
 - runs BootUI's advisor scans straight from its REST API (`/bootui/api/panels` to
   discover them, `POST /bootui/api/{id}/scan` to run one), surfaced in the **BootUI**
   tab — no in-app MCP server required;
+- checks for outdated libraries without the app running: a Maven `dependency:tree` +
+  `versions:display-dependency-updates` run whose output it parses into the outdated-library
+  list (the build tool's own plugins resolve the latest versions — Coffilot never talks to a
+  package registry directly), surfaced in the **Upgrades** tab;
 - pushes contextual "fix this" turns back into the chat through the Copilot SDK.
 
 The loopback HTTP server that backs the iframe binds to `127.0.0.1` only. See

--- a/RIGHT-PANEL-SPEC.md
+++ b/RIGHT-PANEL-SPEC.md
@@ -1,0 +1,253 @@
+# Right‑panel (aside rail) specification
+
+> **Status:** _draft — this captures the rules **as currently implemented** so we can
+> review and correct them._ Edit freely; the “Open questions / desired changes” section
+> at the bottom is the place to record what should be different.
+
+The **right panel** is the aside rail of the Coffilot canvas: a vertical list of tabs
+(`.atab`, each with a `data-atab` key) and their panes (`.apane`). This document
+specifies which tabs exist, how they are ordered, when each is active vs. inactive, and
+exactly what each pane shows in either state.
+
+Source of truth in code: `public/index.html` (markup), `public/app.js` (behaviour),
+`public/styles.css` (styling), with capability/metrics data coming from
+`extension.mjs`.
+
+---
+
+## 1. Tab inventory
+
+Internal `data-atab` keys vs. the labels users see:
+
+| Order | `data-atab` | User‑facing label | Pane purpose                                                     |
+| ----: | ----------- | ----------------- | ---------------------------------------------------------------- |
+|     1 | `settings`  | **Settings**      | Project/run settings                                             |
+|     2 | `metrics`   | **Live JVM**      | Live heap / threads / uptime                                     |
+|     3 | `loggers`   | **Logs**          | Live log‑level control                                           |
+|     4 | `spring`    | **Spring**        | Spring Boot version advisor + Actuator / BootUI / DevTools setup |
+|     5 | `quarkus`   | **Quarkus**       | Quarkus MCP register + metrics/logging setup                     |
+|     6 | `scans`     | **BootUI**        | BootUI advisor scans                                             |
+|     7 | `deps`      | **Dependencies**  | OSIV check + outdated‑library upgrades                           |
+
+Canonical order is `ASIDE_ORDER = ["settings", "metrics", "loggers", "spring",
+"quarkus", "scans", "deps"]` (`public/app.js`).
+
+---
+
+## 2. Ordering & active/inactive grouping
+
+**Rule:** the canonical order above is _always_ preserved **within** each group, but the
+rail is split into two groups:
+
+1. **Active (available) tabs** float to the top, in canonical order.
+2. A separator (`.atab-sep`) divides the groups.
+3. **Inactive (unavailable) tabs** sink to the bottom, in canonical order.
+
+Implementation: `computeAsideOrder(name, ok) = (ok ? 0 : 100) + rank`, where `rank` is
+the canonical index. Available → `0 + rank`; unavailable → `100 + rank`.
+
+**Animation:** when a tab crosses the active/inactive boundary it animates with a FLIP
+transition (≈200 ms) via `flipAsideTabs`. The animation is skipped on the very first
+layout and when the user has `prefers-reduced-motion`.
+
+**Always‑available tabs:** `ASIDE_ALWAYS = { settings, deps }`. These never go inactive.
+
+---
+
+## 3. Availability (active vs. inactive) per tab
+
+Two independent gates drive availability, merged per‑key in `updateAsideAvailability`:
+
+- **Project capabilities** (static, from `pomCaps` / `gradleCaps`): does the project use
+  Spring Boot? Quarkus? etc. Drives `spring` and `quarkus`.
+- **Runtime metrics tier** (dynamic, from the running app — see §4): drives `metrics`,
+  `loggers`, `scans`.
+
+| Tab                   | Active when                                                                            | Gate source    |
+| --------------------- | -------------------------------------------------------------------------------------- | -------------- |
+| `settings`            | Always                                                                                 | `ASIDE_ALWAYS` |
+| `metrics` (Live JVM)  | App running **and** metrics tier ≠ `process` (i.e. tier ∈ {bootui, actuator, quarkus}) | runtime        |
+| `loggers` (Logs)      | App running **and** metrics tier ∈ {bootui, actuator, quarkus}                         | runtime        |
+| `scans` (BootUI)      | App running **and** metrics tier = `bootui`                                            | runtime        |
+| `spring`              | `caps.springBoot` is true                                                              | project caps   |
+| `quarkus`             | `caps.quarkus` is true                                                                 | project caps   |
+| `deps` (Dependencies) | Always                                                                                 | `ASIDE_ALWAYS` |
+
+> **Note (possible inconsistency):** `metrics` and `loggers` currently share the same
+> gate (tier ∈ {bootui, actuator, quarkus}). For a Quarkus app this marks **Logs**
+> active on the basis of the metrics tier even when the `logging-manager` extension is
+> absent; the pane content then explains the gap. Flag for review.
+
+Each inactive tab also has a greyed‑tab tooltip from `ASIDE_REASON`.
+
+---
+
+## 4. Metrics tiers (runtime detection)
+
+`refreshMetrics` (`extension.mjs`) probes the running app in precedence order and sets
+`metricsTier`:
+
+1. **`bootui`** — `/bootui/api/overview` answers. Richest tier (console + richer metrics
+   - advisor scans). _Implies Actuator._
+2. **`actuator`** — Spring Boot Actuator reachable at `/actuator` or `/management`.
+3. **`quarkus`** — Quarkus `/q/health` (+ optional `/q/metrics`) answers.
+4. **`process`** — nothing answered (or app down). Live JVM/Logs/BootUI all inactive.
+
+When the app is down: `appUp = false`, `metricsTier = process`.
+
+---
+
+## 5. Governing principle — **BootUI ⟹ Actuator**
+
+BootUI bundles Spring Boot Actuator. Therefore, **everywhere**, when BootUI is
+configured:
+
+- Do **not** show an “Add Actuator” CTA.
+- Do **not** show an Actuator “is set up” confirmation (BootUI’s confirmation stands in
+  for it).
+- The BootUI tier covers all the metrics/loggers needs Actuator would.
+
+This is the rule that keeps biting; treat it as invariant unless we deliberately change
+it.
+
+---
+
+## 6. Per‑tab content rules
+
+### 6.1 Settings (`settings`) — always active
+
+Project + run configuration. No active/inactive story.
+
+### 6.2 Live JVM (`metrics`)
+
+**Active:** live heap / non‑heap / threads / uptime from the current tier.
+
+**Inactive** (`renderMetricsInactive` → `diagnosticInactiveBody("metrics", appDown)`):
+
+- **Lead line:** app down → “The app isn’t running.” Otherwise → “The running app
+  exposes no metrics endpoint.”
+- **Body** depends on the selected run module:
+
+| Module state                           | Message                                                                                                                      | Fix CTAs                                                   |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Spring Boot + **BootUI**               | ✓ BootUI is set up — _{run the app / expose its endpoints…}_                                                                 | none                                                       |
+| Spring Boot + **Actuator** (no BootUI) | ✓ Spring Boot Actuator is set up — _{next}_ · plus “Add BootUI for its developer console, richer metrics and advisor scans.” | **Add BootUI with Copilot**                                |
+| Spring Boot, **neither**               | “This Spring Boot app doesn’t include Spring Boot Actuator, so the Live JVM tab can’t read metrics.”                         | **Add Actuator with Copilot**, **Add BootUI with Copilot** |
+| Quarkus + **Micrometer**               | ✓ Quarkus Micrometer is set up — _{next}_                                                                                    | none                                                       |
+| Quarkus, no Micrometer                 | “This Quarkus app doesn’t include Micrometer metrics, so the Live JVM tab can’t read metrics.”                               | **Add Quarkus metrics with Copilot**                       |
+| Plain Java                             | “Live JVM metrics need a Spring Boot app (Actuator or BootUI) or a Quarkus app (Micrometer).”                                | none                                                       |
+
+_“{next}” = “run the app to use this tab” (app down) or “expose its endpoints and
+restart to use this tab” (running but no endpoint)._
+
+Fix buttons use the orange **`fix fix-copilot`** style; once clicked they disable and
+read “Asked Copilot ✓” (tracked in `metricsAskedKinds`).
+
+### 6.3 Logs (`loggers`)
+
+**Active:** live logger list + level controls; source badge reads “Actuator” or
+“Quarkus”.
+
+**Inactive** (`renderLoggersInactive` → `diagnosticInactiveBody("loggers", appDown)`):
+same structure as Live JVM, with logger‑specific wording:
+
+- **Lead line:** app down → “The app isn’t running.” Otherwise → “The running app
+  exposes no runtime‑logger endpoint.”
+- **Body:** mirrors the Live JVM table, but the “neither” / “no extension” messages talk
+  about log levels:
+  - Spring Boot, neither → “…doesn’t include Spring Boot Actuator, so log levels can’t be
+    changed live.” → **Add Actuator**, **Add BootUI**.
+  - Quarkus + **logging‑manager** → ✓ Quarkus logging‑manager is set up — _{next}_.
+  - Quarkus, no logging‑manager → “…doesn’t include the logging‑manager extension, so log
+    levels can’t be changed live.” → **Add logging‑manager with Copilot**.
+  - Plain Java → “Live log‑level control works only for Spring Boot apps (Actuator
+    `/loggers`) or Quarkus apps (the `quarkus-logging-manager` extension).”
+
+### 6.4 Spring (`spring`)
+
+Active when the project is Spring Boot (independent of whether the app is running).
+Inactive → `renderSpringAdvisor` shows the “not a Spring Boot project” reason. When
+active, four stacked sections (`updateDevSetup`):
+
+1. **Version advisor** — detected Spring Boot version + support status (`current` /
+   `supported` / `eol` / `unknown` / `unreadable`) and an **Upgrade with Copilot** button
+   (`#btn-upgrade-spring`, styled `fix-copilot` to match the other Copilot buttons).
+
+2. **Actuator section** (`#spring-actuator-section`) — _hidden when BootUI is
+   configured_ (BootUI ⟹ Actuator). Otherwise:
+   - Actuator present → “Actuator is set up” confirmation.
+   - Actuator absent → **Add Actuator with Copilot**.
+
+3. **BootUI section** (`#spring-bootui-section`) — shown for every Spring Boot project:
+   - BootUI configured → “BootUI is configured — it includes Spring Boot Actuator.”
+   - BootUI absent → pitch + **Add BootUI with Copilot**.
+
+4. **DevTools section** — live‑reload toggle + manual reload (unchanged by the BootUI
+   work).
+
+Section visibility summary:
+
+| Project state     | Actuator section     | BootUI section                   |
+| ----------------- | -------------------- | -------------------------------- |
+| BootUI configured | hidden               | “BootUI configured” confirmation |
+| Actuator only     | “Actuator is set up” | pitch + **Add BootUI**           |
+| Neither           | **Add Actuator**     | pitch + **Add BootUI**           |
+
+### 6.5 Quarkus (`quarkus`)
+
+Active when `caps.quarkus`. Inactive → `#quarkus-empty` shows the “not a Quarkus app”
+reason. When active: Quarkus MCP register panel + (in the Live JVM/Logs inactive bodies)
+the Micrometer / logging‑manager CTAs described above.
+
+### 6.6 BootUI / advisor scans (`scans`)
+
+Active only at metrics tier `bootui` (app running). Pane shows scan controls
+(`Scan all` + per‑panel scans).
+
+- Title is followed by `#bootui-configured` (“BootUI is configured”, shown when BootUI is
+  on the classpath) or `#bootui-desc` (the “add the starter” description, shown
+  otherwise).
+- **Inactive** (`scansInactiveHtml(appDown)`), consistent with Live JVM/Logs:
+  - Lead: app down → “The app isn’t running.” Otherwise → “The running app has no BootUI
+    endpoint.”
+  - Spring Boot + BootUI → ✓ BootUI is set up — _{next}_.
+  - Spring Boot, no BootUI → “Advisor scans need BootUI — add it above, then run the app.”
+  - Not Spring Boot → “Advisor scans need a BootUI‑enabled Spring Boot app.”
+  - Greyed placeholder scan buttons render so the pane isn’t empty.
+
+### 6.7 Dependencies (`deps`) — always active
+
+OSIV check + outdated‑library list with “Direct dependencies only” filter and per‑finding
+**Fix with Copilot**. (Specified in `PLAN.md`; behaviour rules to be folded in here as it
+lands.)
+
+---
+
+## 7. Runtime profile activation (BootUI dev profile)
+
+For Maven Spring Boot projects, BootUI is often only on the classpath under a `dev`
+profile. `pomCaps` reports `bootuiProfiles`; the Maven Spring runner merges them into the
+`-P` list (`withBootuiProfile`) so the BootUI tier actually comes up at runtime and Live
+JVM / Logs / BootUI go active.
+
+---
+
+## 8. Shared button conventions
+
+- Every Copilot fix/CTA button reads **“… with Copilot”** and uses the orange
+  **`fix fix-copilot`** style (Add Actuator, Add BootUI, Add logging‑manager, Add Quarkus
+  metrics, Upgrade Spring Boot, etc.).
+- After a fix is requested, the button disables and reads “Asked Copilot ✓”.
+
+---
+
+## 9. Open questions / desired changes
+
+_List here what should differ from the “as‑implemented” rules above. For each item, note
+the tab, the scenario, the current behaviour, and the desired behaviour._
+
+- [ ] _(example)_ Logs tab should NOT be active for a Quarkus app lacking
+      `logging-manager` (see §3 note) — desired: gate `loggers` on the actual logger
+      backend, not just the metrics tier.
+- [ ]
+- [ ]

--- a/extension.mjs
+++ b/extension.mjs
@@ -5541,6 +5541,20 @@ async function actuatorMetrics(base) {
 // Micrometer output, so we normalize them into the same shape as the BootUI /
 // Actuator tiers.
 
+// A Spring Boot app behind Spring Security redirects unknown paths (including
+// /q/health and /q/metrics) to its login page, and fetch() follows the redirect
+// to a 200 HTML body. Validate the response shapes so that login page is never
+// mistaken for the Quarkus tier: SmallRye Health is JSON with a string `status`
+// (Spring's error JSON uses a numeric status, so it's rejected), and Micrometer's
+// exposition carries `# HELP`/`# TYPE` comments or at least one parseable sample.
+export function looksLikeSmallryeHealth(health) {
+  return !!health && typeof health === "object" && typeof health.status === "string";
+}
+
+export function looksLikePrometheus(text) {
+  return typeof text === "string" && (/^#\s*(HELP|TYPE)\s/m.test(text) || parsePrometheus(text).size > 0);
+}
+
 /**
  * Normalize SmallRye Health (/q/health) into { status, checks }, where each check
  * is a MicroProfile Health entry ({ name, status }) — e.g. the datasource, Kafka or
@@ -5623,8 +5637,12 @@ async function refreshMetrics() {
     return finishMetrics();
   }
 
-  // Tier 3 — Quarkus: SmallRye Health + Micrometer/Prometheus under /q/*.
-  const [qHealth, qMetrics] = await Promise.all([fetchJson(base, "/q/health"), fetchText(base, "/q/metrics")]);
+  // Tier 3 — Quarkus: SmallRye Health + Micrometer/Prometheus under /q/*. Only
+  // accept responses that actually look like SmallRye Health / Micrometer output,
+  // so a Spring Security login page served from /q/* isn't read as Quarkus.
+  const [qHealthRaw, qMetricsRaw] = await Promise.all([fetchJson(base, "/q/health"), fetchText(base, "/q/metrics")]);
+  const qHealth = looksLikeSmallryeHealth(qHealthRaw) ? qHealthRaw : null;
+  const qMetrics = looksLikePrometheus(qMetricsRaw) ? qMetricsRaw : null;
   if (qHealth || qMetrics) {
     lastMetrics = quarkusMetrics(qMetrics, qHealth);
     return finishMetrics();

--- a/extension.mjs
+++ b/extension.mjs
@@ -1515,6 +1515,28 @@ function pomMainClass(xml) {
   return null;
 }
 
+// Matches the BootUI Spring Boot starter dependency (any of its group/artifact
+// spellings). Shared by the per-pom capability flag and the dev-profile probe.
+const BOOTUI_DEP_RE = /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/;
+
+// Maven profile id(s) whose <profile> block declares the BootUI starter. The
+// install-bootui fix scopes BootUI to a dev-only Maven profile, so when the
+// dependency lives only there, running the app must activate that profile (-P)
+// or the starter never reaches the classpath (and the BootUI metrics tier — the
+// Live JVM / Loggers panes — never comes up).
+function mavenBootuiProfiles(xml) {
+  const ids = [];
+  // Greedy outer match spans the whole top-level <profiles> section even when a
+  // profile nests a plugin-config <profiles> block (mirrors listMavenProfiles).
+  const block = (xml.match(/<profiles>([\s\S]*)<\/profiles>/) || [, ""])[1];
+  for (const p of block.matchAll(/<profile>([\s\S]*?)<\/profile>/g)) {
+    if (!BOOTUI_DEP_RE.test(p[1])) continue;
+    const id = (p[1].match(/<id>\s*([^<]+?)\s*<\/id>/) || [])[1];
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
 // Per-pom capability flags, derived purely from the pom text (cheap + offline).
 export function pomCaps(xml, name) {
   const quarkus = /quarkus-maven-plugin|io\.quarkus/.test(xml);
@@ -1529,7 +1551,8 @@ export function pomCaps(xml, name) {
     devtools: xml.includes("spring-boot-devtools"),
     quarkusMetrics: /quarkus-micrometer/.test(xml),
     loggingManager: /quarkus-logging-manager/.test(xml),
-    bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(xml),
+    bootui: BOOTUI_DEP_RE.test(xml),
+    bootuiProfiles: mavenBootuiProfiles(xml),
     mainClass: pomMainClass(xml),
   };
 }
@@ -3272,6 +3295,22 @@ function withMavenProfiles(args, mavenProfiles) {
   return p ? [...args, "-P", p] : args;
 }
 
+// Merge the user-selected Maven profiles with the dev-only profile(s) that carry
+// the module's BootUI starter, so running a BootUI app activates its starter (and
+// with it the BootUI metrics tier) without the user having to remember -Pdev.
+// Returns a comma-separated, de-duplicated profile list (empty string for none).
+function withBootuiProfile(mavenProfiles, mod) {
+  const ids = new Set();
+  for (const p of String(mavenProfiles || "").split(",")) {
+    const t = p.trim();
+    if (t) ids.add(t);
+  }
+  if (mod && mod.bootui && Array.isArray(mod.bootuiProfiles)) {
+    for (const id of mod.bootuiProfiles) ids.add(id);
+  }
+  return [...ids].join(",");
+}
+
 // ---------------------------------------------------------------------------
 // Affected-test selection
 //
@@ -4098,7 +4137,17 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
 
     const args = ["-ntp"];
     if (module) args.push("-pl", module);
-    if (mavenProfiles && mavenProfiles.trim()) args.push("-P", mavenProfiles.trim());
+    // Activate any user-selected Maven profiles plus the dev-only profile that
+    // carries BootUI, so a profile-scoped BootUI starter reaches the classpath and
+    // its metrics tier (Live JVM / Loggers) comes up while running.
+    const runProfiles = withBootuiProfile(mavenProfiles, mod);
+    if (runProfiles) {
+      args.push("-P", runProfiles);
+      if (runProfiles !== (mavenProfiles || "").trim() && mod && mod.bootuiProfiles && mod.bootuiProfiles.length) {
+        pushConsole(`[coffilot] activating Maven profile(s) ${runProfiles} to enable BootUI.`, "stdout", op);
+      }
+    }
+    app.mavenProfiles = runProfiles || null;
     args.push("-Dmaven.test.skip=true", "spring-boot:run");
     if (profiles) args.push(`-Dspring-boot.run.profiles=${profiles}`);
     // Pass the native-access flag to the forked app JVM so its FFM-using
@@ -4129,7 +4178,7 @@ async function startApp({ module, profiles, mavenProfiles, mode, dbg = null } = 
     // and recompile on save to drive that loop automatically (off while debugging).
     if (!dbg && settings.devtools && mod && mod.devtools) {
       const lr = resolveRunner(true);
-      startLiveReload({ module: module || "", mavenProfiles, bin: lr.bin, label: lr.label });
+      startLiveReload({ module: module || "", mavenProfiles: runProfiles, bin: lr.bin, label: lr.label });
     }
     return { ok: true, started: true, mode: "spring", command: `${baseRunner().label} ${args.join(" ")}` };
   }

--- a/extension.mjs
+++ b/extension.mjs
@@ -6486,35 +6486,36 @@ function buildFixPrompt(kind, extra = {}) {
         .filter(Boolean)
         .join("\n\n");
     }
-    case "install-actuator-loggers": {
+    case "install-actuator": {
       const moduleName = extra.module || "";
       const resDir = moduleName ? `${moduleName}/src/main/resources` : "src/main/resources";
+      const expose = "management.endpoints.web.exposure.include=health,info,metrics,prometheus,loggers";
       if (buildTool === "gradle") {
         const { rel, kts } = gradleModuleBuildFile(moduleName);
         const dep = kts
           ? `implementation("org.springframework.boot:spring-boot-starter-actuator")`
           : `implementation 'org.springframework.boot:spring-boot-starter-actuator'`;
         return [
-          "This is a Spring Boot application whose runtime log-level endpoint isn't reachable, so the canvas can't read or change loggers live. Add Spring Boot Actuator and expose its `/loggers` endpoint.",
+          "This is a Spring Boot application that doesn't use Spring Boot Actuator, so the canvas can't read live JVM metrics or change log levels at runtime. Add the Actuator starter and expose its HTTP endpoints.",
           `1. Edit \`${rel}\` and add the Actuator starter inside \`dependencies { }\`:`,
           codeBlock(`dependencies {\n  ${dep}\n}`, kts ? "kotlin" : "groovy"),
           "   Omit the version so it inherits from the Spring Boot plugin's dependency management. Don't duplicate the line if it's already present.",
-          `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the loggers endpoint over HTTP:`,
-          codeBlock("management.endpoints.web.exposure.include=health,loggers", "properties"),
-          "   If an `exposure.include` line already exists, add `loggers` to it rather than replacing it. The `/loggers` endpoint serves both reads and live level changes — no extra config needed.",
-          "After editing, tell me to run the app again (e.g. `./gradlew bootRun`); the Loggers tab then lists every logger and lets you change levels live.",
+          `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the endpoints the canvas reads:`,
+          codeBlock(expose, "properties"),
+          "   If an `exposure.include` line already exists, merge these endpoint ids into it rather than replacing it. (`/metrics` and `/prometheus` back the Live JVM tab; `/loggers` reads and changes levels live.)",
+          "After editing, tell me to run the app again (e.g. `./gradlew bootRun`); the Live JVM tab then shows heap/threads/health and the Loggers tab lists every logger.",
         ]
           .filter(Boolean)
           .join("\n\n");
       }
       const pomRel = moduleName ? `${moduleName}/pom.xml` : "pom.xml";
       return [
-        "This is a Spring Boot application whose runtime log-level endpoint isn't reachable, so the canvas can't read or change loggers live. Add Spring Boot Actuator and expose its `/loggers` endpoint.",
+        "This is a Spring Boot application that doesn't use Spring Boot Actuator, so the canvas can't read live JVM metrics or change log levels at runtime. Add the Actuator starter and expose its HTTP endpoints.",
         `1. Edit \`${pomRel}\` and add a dependency on \`org.springframework.boot:spring-boot-starter-actuator\` inside the \`<dependencies>\` block (omit the \`<version>\` so it inherits from the Spring Boot parent/BOM). Don't duplicate it if it's already present.`,
-        `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the loggers endpoint over HTTP:`,
-        codeBlock("management.endpoints.web.exposure.include=health,loggers", "properties"),
-        "   If an `exposure.include` line already exists, add `loggers` to it rather than replacing it. The `/loggers` endpoint serves both reads and live level changes — no extra config needed.",
-        "After editing, tell me to run the app again (e.g. `./mvnw spring-boot:run`); the Loggers tab then lists every logger and lets you change levels live.",
+        `2. In \`${resDir}/application.properties\` (create it if it doesn't exist), expose the endpoints the canvas reads:`,
+        codeBlock(expose, "properties"),
+        "   If an `exposure.include` line already exists, merge these endpoint ids into it rather than replacing it. (`/metrics` and `/prometheus` back the Live JVM tab; `/loggers` reads and changes levels live.)",
+        "After editing, tell me to run the app again (e.g. `./mvnw spring-boot:run`); the Live JVM tab then shows heap/threads/health and the Loggers tab lists every logger.",
       ]
         .filter(Boolean)
         .join("\n\n");

--- a/extension.mjs
+++ b/extension.mjs
@@ -6836,7 +6836,7 @@ async function runScanRest(key) {
 // pick up a different plugin major on a fresh machine.
 const DEP_TREE_PLUGIN = "org.apache.maven.plugins:maven-dependency-plugin:3.7.1";
 const VERSIONS_PLUGIN = "org.codehaus.mojo:versions-maven-plugin:2.18.0";
-const GRADLE_VERSIONS_PLUGIN = "com.github.ben-manes:gradle-versions-plugin:0.51.0";
+const GRADLE_VERSIONS_PLUGIN = "com.github.ben-manes:gradle-versions-plugin:0.54.0";
 
 let lastDependencyReport = null;
 
@@ -7118,9 +7118,12 @@ export function mavenDepUpdatesArgs() {
 export function gradleDepTreeArgs() {
   return ["dependencies", "--configuration", "runtimeClasspath", "-q"];
 }
-/** Gradle: the ben-manes `dependencyUpdates` task, injected via an init script. */
+/** Gradle: the ben-manes `dependencyUpdates` task, injected via an init script.
+ * `--no-parallel` is required on Gradle 9+ (the task fails under parallel project
+ * execution there) and is a harmless no-op on Gradle 7/8, where parallel builds
+ * are opt-in. */
 export function gradleDepUpdatesArgs(initScript) {
-  return ["--init-script", initScript, "dependencyUpdates", "-q"];
+  return ["--init-script", initScript, "dependencyUpdates", "-q", "--no-parallel"];
 }
 
 /** Maven outdated-libraries scan: dependency:tree + display-dependency-updates. */

--- a/extension.mjs
+++ b/extension.mjs
@@ -7504,12 +7504,30 @@ async function appPostCsrf(base, seedPath, postPath, body) {
 async function loggersStatus() {
   const base = appBase();
   if (!base) return { available: false };
-  // The framework is already known from how the app was launched (app.runMode), so go
-  // straight to the matching backend instead of probing both: Quarkus serves
-  // logging-manager under /q, everything else (Spring Boot or the generic runner) uses
-  // Actuator /loggers.
-  const status = app.runMode === "quarkus" ? await quarkusLoggersStatus(base) : await actuatorLoggersStatus(base);
+  // The framework is already known from how the app was launched (app.runMode): Quarkus
+  // serves logging-manager under /q. Everything else (Spring Boot or the generic runner)
+  // prefers BootUI's /bootui/api/loggers — it bundles Actuator's LoggersEndpoint, so it's
+  // the top tier whenever BootUI is on the classpath — then falls back to Actuator /loggers.
+  if (app.runMode === "quarkus") {
+    return (await quarkusLoggersStatus(base)) || { available: false };
+  }
+  const status = (await bootuiLoggersStatus(base)) || (await actuatorLoggersStatus(base));
   return status || { available: false };
+}
+
+/**
+ * Read loggers from BootUI's /bootui/api/loggers. BootUI bundles Spring Boot Actuator's
+ * LoggersEndpoint and re-exposes it (as availableLevels + a loggers array), so it's the
+ * preferred source whenever BootUI is on the classpath. Returns the normalized status, or
+ * null when BootUI isn't present.
+ */
+async function bootuiLoggersStatus(base) {
+  const report = await fetchJson(base, "/bootui/api/loggers");
+  const status = normalizeBootuiLoggers(report);
+  if (!status) return null;
+  app.loggersSource = "bootui";
+  app.loggersPrefix = "/bootui/api/loggers";
+  return status;
 }
 
 /**
@@ -7575,6 +7593,30 @@ export function normalizeQuarkusLoggers(list, levelsRaw) {
 }
 
 /**
+ * Normalize BootUI's /bootui/api/loggers report into the shared loggers shape (ROOT first,
+ * then alphabetical). BootUI returns { availableLevels, loggers: [{ name, configuredLevel,
+ * effectiveLevel }], page } — the levels and per-logger shape mirror Spring Boot Actuator
+ * (BootUI re-exposes Actuator's LoggersEndpoint). Returns null when the input isn't a BootUI
+ * loggers report (i.e. BootUI isn't present).
+ */
+export function normalizeBootuiLoggers(report) {
+  if (!report || !Array.isArray(report.loggers)) return null;
+  const levels =
+    Array.isArray(report.availableLevels) && report.availableLevels.length
+      ? report.availableLevels
+      : DEFAULT_LOG_LEVELS;
+  const loggers = report.loggers
+    .filter((l) => l && typeof l.name === "string")
+    .map((l) => ({
+      name: l.name === "" ? "ROOT" : l.name,
+      configuredLevel: l.configuredLevel || null,
+      effectiveLevel: l.effectiveLevel || null,
+    }));
+  loggers.sort((a, b) => (a.name === "ROOT" ? -1 : b.name === "ROOT" ? 1 : a.name.localeCompare(b.name)));
+  return { available: true, source: "bootui", levels, loggers };
+}
+
+/**
  * Change one logger's level on the Quarkus logging-manager extension: a form-encoded
  * POST to /q/logging-manager (ROOT maps back to JBoss's empty-string root name, an empty
  * level resets the logger to its inherited level). Returns the raw response.
@@ -7610,18 +7652,24 @@ async function setLoggerLevel(name, level) {
     };
   }
   const quarkus = app.loggersSource === "quarkus";
+  const bootui = app.loggersSource === "bootui";
   const validLevels = quarkus ? QUARKUS_LOG_LEVELS : DEFAULT_LOG_LEVELS;
   if (lvl && !validLevels.includes(lvl)) return { ok: false, error: `Unknown level "${level}".` };
   const prefix = app.loggersPrefix;
   try {
+    // BootUI re-exposes Actuator's LoggersEndpoint at /bootui/api/loggers/{name} with a
+    // { level } body (its prefix already ends in /loggers), so it has its own write path
+    // distinct from Actuator's ${prefix}/loggers/{name} + { configuredLevel }.
     const res = quarkus
       ? await quarkusSetLevel(base, name, lvl)
-      : await appPostCsrf(base, `${prefix}/loggers`, `${prefix}/loggers/${encodeURIComponent(name)}`, {
-          configuredLevel: lvl,
-        });
+      : bootui
+        ? await appPostCsrf(base, prefix, `${prefix}/${encodeURIComponent(name)}`, { level: lvl })
+        : await appPostCsrf(base, `${prefix}/loggers`, `${prefix}/loggers/${encodeURIComponent(name)}`, {
+            configuredLevel: lvl,
+          });
     await res.text().catch(() => null);
     if (!res.ok) {
-      const backend = quarkus ? "Logging Manager" : "Actuator";
+      const backend = quarkus ? "Logging Manager" : bootui ? "BootUI" : "Actuator";
       const why =
         res.status === 404
           ? "The app's logger endpoint isn't exposed (or is read-only)."

--- a/extension.mjs
+++ b/extension.mjs
@@ -1284,6 +1284,9 @@ const SETTINGS_KEYS = [
   "jdkHome",
   "asideTab",
   "asideOpen",
+  "depsDirectOnly",
+  "testFailuresOnly",
+  "debugSuspend",
 ];
 
 // Live-metrics polling cadence bounds (ms). Kept conservative so the UI stays
@@ -1341,6 +1344,12 @@ function defaultSettings() {
     // opened, then remembers whatever the user last did.
     asideTab: "settings",
     asideOpen: false,
+    // View/preference toggles restored across reloads/sessions: the Dependencies
+    // "Direct only" filter, the Tests "Failures only" filter, and the Debug
+    // "Suspend until debugger attaches" option. All off by default.
+    depsDirectOnly: false,
+    testFailuresOnly: false,
+    debugSuspend: false,
   };
 }
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -6910,29 +6910,55 @@ function gradleScopeLabel(config) {
 }
 
 /**
+ * Whether a Gradle configuration name represents a real user dependency classpath
+ * (compile / runtime / test / annotation-processor / development) rather than an
+ * internal plugin, metadata or publication configuration — e.g. the `kotlin*`
+ * compiler classpaths, `*DependenciesMetadata`, or `*Elements`. The `dependencies`
+ * report lists all of these, but only the former describe what the project actually
+ * declares, so direct/transitive classification is restricted to them. Pure
+ * (exported for tests). */
+export function gradleDepConfigFilter(name) {
+  const n = String(name || "");
+  if (/^kotlin/i.test(n)) return false; // kotlinCompilerPluginClasspath, kotlinBuildToolsApiClasspath, …
+  if (/(?:compile|runtime)classpath$/i.test(n)) return true; // compile/runtime/test (+ custom source set) classpaths
+  return /^(?:annotationProcessor|testAnnotationProcessor|developmentOnly|testAndDevelopmentOnly)$/.test(n);
+}
+
+/**
  * Parse `gradle dependencies` report output into a deduplicated list of nodes with
  * the same shape as parseDependencyTree. Gradle indents 5 characters per level
  * (`|    ` or five spaces), so depth 0 is a direct dependency and anything deeper
  * is transitive; `via` records the direct dependency that pulls a transitive one
  * in. Version coercion (`a:b:1 -> 2`) resolves to the right-hand side, and the
- * `(*)`/`(c)`/`(n)`/`FAILED` annotations are stripped. Pure (exported for tests).
+ * `(*)`/`(c)`/`(n)`/`FAILED` annotations are stripped. When `configFilter` is
+ * supplied, only rows under configurations it accepts are counted (used to skip
+ * internal plugin/metadata configs); without it every configuration is parsed.
+ * Pure (exported for tests).
  */
-export function parseGradleDependencyTree(out) {
+export function parseGradleDependencyTree(out, { configFilter = null } = {}) {
   const byKey = new Map();
   const stack = []; // stack[depth] = "group:artifact"
   let scope = "";
+  let included = !configFilter; // whether the current configuration's rows count
   for (const rawLine of String(out || "").split(/\r?\n/)) {
     const m = rawLine.match(/^([\s|]*)[+\\]--- (.+)$/);
     if (!m) {
       // Any non-connector line ends the current subtree: reset the ancestor stack
       // so the next configuration/project is depth-counted independently. A
       // configuration header ("runtimeClasspath - Runtime classpath …") also
-      // records the scope applied to its rows.
+      // records the scope applied to its rows and, with a configFilter, whether the
+      // configuration counts toward direct/transitive classification at all.
       stack.length = 0;
       const header = rawLine.match(/^([A-Za-z][A-Za-z0-9]*)\s+-\s+/);
-      if (header) scope = gradleScopeLabel(header[1]);
+      if (header) {
+        scope = gradleScopeLabel(header[1]);
+        included = configFilter ? !!configFilter(header[1]) : true;
+      } else if (configFilter) {
+        included = false;
+      }
       continue;
     }
+    if (!included) continue;
     const depth = Math.floor(m[1].length / 5);
     let coord = m[2].trim();
     coord = coord
@@ -7114,9 +7140,13 @@ export function mavenDepTreeArgs() {
 export function mavenDepUpdatesArgs() {
   return ["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`];
 }
-/** Gradle: the built-in `dependencies` report for the runtime classpath. */
+/** Gradle: the built-in `dependencies` report. All configurations are requested
+ * (the task only accepts one `--configuration` at a time, so we resolve them all in
+ * a single pass) and `parseGradleDependencyTree` is given a filter that keeps only
+ * the real compile/runtime/test classpaths, so direct/transitive classification
+ * reflects what the project declares rather than internal plugin classpaths. */
 export function gradleDepTreeArgs() {
-  return ["dependencies", "--configuration", "runtimeClasspath", "-q"];
+  return ["dependencies", "-q"];
 }
 /** Gradle: the ben-manes `dependencyUpdates` task, injected via an init script.
  * `--no-parallel` is required on Gradle 9+ (the task fails under parallel project
@@ -7178,7 +7208,7 @@ async function runGradleDependencyScan() {
     writeFileSync(initScript, gradleDependencyUpdatesInitBody(outDir));
     const treeRes = await captureBuildTool(gradleDepTreeArgs());
     const updRes = await captureBuildTool(gradleDepUpdatesArgs(initScript));
-    const nodes = parseGradleDependencyTree(treeRes.out || "");
+    const nodes = parseGradleDependencyTree(treeRes.out || "", { configFilter: gradleDepConfigFilter });
     const updMap = new Map();
     try {
       for (const f of readdirSync(outDir)) {
@@ -7189,13 +7219,15 @@ async function runGradleDependencyScan() {
     } catch {
       /* no report file written */
     }
-    // The runtimeClasspath tree omits test/compileOnly deps; surface any outdated
-    // dependency missing from the tree as a direct one so nothing is dropped.
+    // Any outdated dependency missing from the project's compile/runtime/test
+    // classpaths comes from the buildscript or a plugin (a Gradle plugin marker, a
+    // Kotlin compiler artifact, …), not something the project declares directly, so
+    // surface it as transitive — "Direct only" then hides this plugin/build noise.
     const known = new Set(nodes.map((n) => n.key));
     for (const [key, upd] of updMap) {
       if (known.has(key)) continue;
       const [group, artifact] = key.split(":");
-      nodes.push({ key, group, artifact, version: upd.current, scope: "", depth: 0, direct: true, via: null });
+      nodes.push({ key, group, artifact, version: upd.current, scope: "", depth: 1, direct: false, via: null });
     }
     const updates = mergeDependencyUpdates(nodes, updMap);
     const error = !updMap.size && updRes.ok === false ? updRes.error || "Could not resolve dependency updates." : null;

--- a/extension.mjs
+++ b/extension.mjs
@@ -35,6 +35,7 @@ import {
   mkdirSync,
   writeFileSync,
   unlinkSync,
+  rmSync,
   watch as fsWatch,
 } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
@@ -6825,13 +6826,17 @@ async function runScanRest(key) {
 // out to the build tool (the same loopback-only "shell out and parse" model the
 // rest of Coffilot uses) and lets the build tool's own plugins resolve the latest
 // available versions, so we never add a direct HTTP client to a package registry.
-// Maven is wired here; Gradle outdated-scanning is not yet implemented.
+// Both Maven and Gradle are wired here: Maven uses the dependency + versions
+// plugins; Gradle uses its built-in `dependencies` report plus the ben-manes
+// gradle-versions-plugin, injected through a throwaway `--init-script` so the
+// target project's own build files are never touched.
 // ---------------------------------------------------------------------------
 
 // Pinned plugin coordinates so the scan is reproducible and doesn't silently
 // pick up a different plugin major on a fresh machine.
 const DEP_TREE_PLUGIN = "org.apache.maven.plugins:maven-dependency-plugin:3.7.1";
 const VERSIONS_PLUGIN = "org.codehaus.mojo:versions-maven-plugin:2.18.0";
+const GRADLE_VERSIONS_PLUGIN = "com.github.ben-manes:gradle-versions-plugin:0.51.0";
 
 let lastDependencyReport = null;
 
@@ -6890,6 +6895,102 @@ export function parseDependencyUpdates(out) {
     const m = line.match(/^\s*([\w.\-]+:[\w.\-]+)\s+\.{2,}\s+(\S+)\s+->\s+(\S+)\s*$/);
     if (!m) continue;
     map.set(m[1], { current: m[2], latest: m[3] });
+  }
+  return map;
+}
+
+/** Normalise a Gradle configuration name to a Maven-like scope word for display. */
+function gradleScopeLabel(config) {
+  const c = String(config || "");
+  if (/test/i.test(c)) return "test";
+  if (/annotationProcessor/i.test(c)) return "annotationProcessor";
+  if (/compileOnly|compileClasspath/i.test(c)) return "compile";
+  if (/runtime/i.test(c)) return "runtime";
+  return c;
+}
+
+/**
+ * Parse `gradle dependencies` report output into a deduplicated list of nodes with
+ * the same shape as parseDependencyTree. Gradle indents 5 characters per level
+ * (`|    ` or five spaces), so depth 0 is a direct dependency and anything deeper
+ * is transitive; `via` records the direct dependency that pulls a transitive one
+ * in. Version coercion (`a:b:1 -> 2`) resolves to the right-hand side, and the
+ * `(*)`/`(c)`/`(n)`/`FAILED` annotations are stripped. Pure (exported for tests).
+ */
+export function parseGradleDependencyTree(out) {
+  const byKey = new Map();
+  const stack = []; // stack[depth] = "group:artifact"
+  let scope = "";
+  for (const rawLine of String(out || "").split(/\r?\n/)) {
+    const m = rawLine.match(/^([\s|]*)[+\\]--- (.+)$/);
+    if (!m) {
+      // Any non-connector line ends the current subtree: reset the ancestor stack
+      // so the next configuration/project is depth-counted independently. A
+      // configuration header ("runtimeClasspath - Runtime classpath …") also
+      // records the scope applied to its rows.
+      stack.length = 0;
+      const header = rawLine.match(/^([A-Za-z][A-Za-z0-9]*)\s+-\s+/);
+      if (header) scope = gradleScopeLabel(header[1]);
+      continue;
+    }
+    const depth = Math.floor(m[1].length / 5);
+    let coord = m[2].trim();
+    coord = coord
+      .replace(/\s+\((?:\*|c|n)\)\s*$/, "")
+      .replace(/\s+FAILED\s*$/, "")
+      .trim();
+    let resolved = null;
+    const arrow = coord.indexOf(" -> ");
+    if (arrow !== -1) {
+      resolved = coord.slice(arrow + 4).trim();
+      coord = coord.slice(0, arrow).trim();
+    }
+    const parts = coord.split(":");
+    let group, artifact, version;
+    if (parts.length >= 3) {
+      [group, artifact] = parts;
+      version = resolved || parts[2];
+    } else if (parts.length === 2) {
+      [group, artifact] = parts;
+      version = resolved; // constraint/platform line with no requested version
+    } else {
+      continue;
+    }
+    if (!group || !artifact || !version) continue;
+    const key = `${group}:${artifact}`;
+    stack[depth] = key;
+    stack.length = depth + 1;
+    const via = depth > 0 ? stack[0] || null : null;
+    const node = { key, group, artifact, version, scope, depth, direct: depth === 0, via };
+    const prev = byKey.get(key);
+    // Keep the shallowest occurrence so a dependency that is both direct and
+    // transitive is classified as direct.
+    if (!prev || node.depth < prev.depth) byKey.set(key, node);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Parse a ben-manes gradle-versions-plugin JSON report into a map of
+ * "group:name" -> { current, latest }. The plugin lists only outdated
+ * dependencies under `outdated.dependencies`, each exposing the newest available
+ * release/milestone/integration version. Pure (exported for tests).
+ */
+export function parseGradleDependencyUpdates(jsonText) {
+  const map = new Map();
+  let data;
+  try {
+    data = JSON.parse(jsonText);
+  } catch {
+    return map;
+  }
+  const deps = data && data.outdated && Array.isArray(data.outdated.dependencies) ? data.outdated.dependencies : [];
+  for (const d of deps) {
+    if (!d || !d.group || !d.name) continue;
+    const avail = d.available || {};
+    const latest = avail.release || avail.milestone || avail.integration;
+    if (!latest) continue;
+    map.set(`${d.group}:${d.name}`, { current: d.version, latest });
   }
   return map;
 }
@@ -6998,10 +7099,99 @@ function captureBuildTool(args, timeoutMs = 180000) {
 
 const emptyDepCounts = () => ({ total: 0, direct: 0, transitive: 0 });
 
+/** Whether the active build tool can run an outdated-libraries scan. */
+function updatesSupportedFor(tool) {
+  return tool === "maven" || tool === "gradle";
+}
+
+/** Maven outdated-libraries scan: dependency:tree + display-dependency-updates. */
+async function runMavenDependencyScan() {
+  const treeRes = await captureBuildTool(["-ntp", "-B", `${DEP_TREE_PLUGIN}:tree`, "-DoutputType=text"]);
+  const updRes = await captureBuildTool(["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`]);
+  const nodes = parseDependencyTree(treeRes.out || "");
+  const updMap = parseDependencyUpdates(updRes.out || "");
+  const updates = mergeDependencyUpdates(nodes, updMap);
+  // Distinguish "everything is up to date" from a command that actually failed
+  // (offline, missing plugin, broken pom): only the latter sets an error.
+  let error = null;
+  if (!nodes.length && treeRes.ok === false) error = treeRes.error || "dependency:tree failed.";
+  else if (!updMap.size && updRes.ok === false) error = updRes.error || "Could not resolve dependency updates.";
+  return { updates, error };
+}
+
+/** Body of the throwaway Gradle init script that injects the ben-manes
+ * gradle-versions-plugin and points its JSON report at our temp dir, one file per
+ * project so subprojects don't overwrite each other. */
+function gradleDependencyUpdatesInitBody(outDir) {
+  const dir = outDir.replace(/\\/g, "/"); // forward slashes are safe in a Groovy string on every OS
+  return [
+    "// Coffilot: inject the ben-manes versions plugin to list outdated libraries (read-only).",
+    "initscript {",
+    "  repositories { gradlePluginPortal() }",
+    `  dependencies { classpath '${GRADLE_VERSIONS_PLUGIN}' }`,
+    "}",
+    "allprojects {",
+    "  apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin",
+    "  tasks.named('dependencyUpdates') {",
+    "    outputFormatter = 'json'",
+    `    outputDir = '${dir}'`,
+    "    reportfileName = 'coffilot-deps-' + project.path.replaceAll(':', '_')",
+    "    checkForGradleUpdate = false",
+    "    revision = 'release'",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}
+
+/** Gradle outdated-libraries scan: the built-in `dependencies` report (for the
+ * direct/transitive tree) plus the ben-manes plugin's JSON report (for the latest
+ * available versions), injected through a throwaway init script. */
+async function runGradleDependencyScan() {
+  const stamp = `${process.pid}-${Date.now()}`;
+  const outDir = path.join(os.tmpdir(), `coffilot-deps-${stamp}`);
+  const initScript = path.join(os.tmpdir(), `coffilot-deps-${stamp}.gradle`);
+  try {
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(initScript, gradleDependencyUpdatesInitBody(outDir));
+    const treeRes = await captureBuildTool(["dependencies", "--configuration", "runtimeClasspath", "-q"]);
+    const updRes = await captureBuildTool(["--init-script", initScript, "dependencyUpdates", "-q"]);
+    const nodes = parseGradleDependencyTree(treeRes.out || "");
+    const updMap = new Map();
+    try {
+      for (const f of readdirSync(outDir)) {
+        if (!f.endsWith(".json")) continue;
+        const part = parseGradleDependencyUpdates(readFileSync(path.join(outDir, f), "utf8"));
+        for (const [k, v] of part) if (!updMap.has(k)) updMap.set(k, v);
+      }
+    } catch {
+      /* no report file written */
+    }
+    // The runtimeClasspath tree omits test/compileOnly deps; surface any outdated
+    // dependency missing from the tree as a direct one so nothing is dropped.
+    const known = new Set(nodes.map((n) => n.key));
+    for (const [key, upd] of updMap) {
+      if (known.has(key)) continue;
+      const [group, artifact] = key.split(":");
+      nodes.push({ key, group, artifact, version: upd.current, scope: "", depth: 0, direct: true, via: null });
+    }
+    const updates = mergeDependencyUpdates(nodes, updMap);
+    const error = !updMap.size && updRes.ok === false ? updRes.error || "Could not resolve dependency updates." : null;
+    return { updates, error };
+  } finally {
+    try {
+      if (existsSync(initScript)) unlinkSync(initScript);
+      rmSync(outDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
 /**
- * On-demand scan: for Maven, the list of outdated libraries (direct + transitive).
- * Caches the result so the panel can re-render it after a tab switch or reload
- * without re-running the build tool.
+ * On-demand scan: the list of outdated libraries (direct + transitive) for Maven
+ * or Gradle. Caches the result so the panel can re-render it after a tab switch or
+ * reload without re-running the build tool.
  */
 async function runDependencyScan() {
   const startedAt = Date.now();
@@ -7021,17 +7211,11 @@ async function runDependencyScan() {
   }
   let updates = [];
   let error = null;
-  const updatesSupported = buildTool === "maven";
+  const updatesSupported = updatesSupportedFor(buildTool);
   if (updatesSupported) {
-    const treeRes = await captureBuildTool(["-ntp", "-B", `${DEP_TREE_PLUGIN}:tree`, "-DoutputType=text"]);
-    const updRes = await captureBuildTool(["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`]);
-    const nodes = parseDependencyTree(treeRes.out || "");
-    const updMap = parseDependencyUpdates(updRes.out || "");
-    updates = mergeDependencyUpdates(nodes, updMap);
-    // Distinguish "everything is up to date" from a command that actually failed
-    // (offline, missing plugin, broken pom): only the latter sets an error.
-    if (!nodes.length && treeRes.ok === false) error = treeRes.error || "dependency:tree failed.";
-    else if (!updMap.size && updRes.ok === false) error = updRes.error || "Could not resolve dependency updates.";
+    const res = buildTool === "gradle" ? await runGradleDependencyScan() : await runMavenDependencyScan();
+    updates = res.updates;
+    error = res.error;
   }
   lastDependencyReport = {
     ran: true,
@@ -7058,7 +7242,7 @@ function dependencySnapshot() {
     ran: false,
     buildTool,
     available: toolAvailable(),
-    updatesSupported: buildTool === "maven",
+    updatesSupported: updatesSupportedFor(buildTool),
     updates: [],
     counts: emptyDepCounts(),
     ranAt: null,
@@ -8364,7 +8548,7 @@ function makeCanvas() {
       {
         name: "check_dependencies",
         description:
-          "Scan the project for outdated libraries. Shells out to the build tool to resolve the latest available versions and returns the findings (current → latest, direct vs transitive, version-jump size). Maven only for now. Findings can be handed to fix_issue with kind 'fix-dependency'.",
+          "Scan the project for outdated libraries (Maven or Gradle). Shells out to the build tool to resolve the latest available versions and returns the findings (current → latest, direct vs transitive, version-jump size). Findings can be handed to fix_issue with kind 'fix-dependency'.",
         inputSchema: { type: "object", properties: {} },
         handler: async () => runDependencyScan(),
       },

--- a/extension.mjs
+++ b/extension.mjs
@@ -6617,6 +6617,20 @@ function buildFixPrompt(kind, extra = {}) {
         .filter(Boolean)
         .join("\n\n");
     }
+    case "fix-dependency": {
+      const coord = `${extra.group}:${extra.artifact}`;
+      const transitive = extra.direct === false || extra.scope === "transitive";
+      const scopeNote = transitive
+        ? `\`${coord}\` is a **transitive** dependency${extra.via ? ` pulled in by \`${extra.via}\`` : ""}, so you usually can't bump it directly: prefer upgrading the dependency that brings it in, or — if that isn't possible — pin the newer version explicitly (Maven: a \`<dependency>\` or a \`<dependencyManagement>\` entry; Gradle: a dependency constraint).`
+        : `\`${coord}\` is a **direct** dependency declared in the build.`;
+      return [
+        `Upgrade the ${TOOL_LABEL} dependency \`${coord}\` from \`${extra.current}\` to \`${extra.latest}\` in this project.`,
+        scopeNote,
+        `Find where it is declared or managed, update the version, then verify the build still compiles and the tests pass. If the upgrade introduces breaking API changes, fix the affected code. Check the release notes for \`${coord}\` ${extra.current} → ${extra.latest} for any required migration.`,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
     case "quarkus-skills":
       return [
         `Use the \`quarkus-agent\` MCP server's \`quarkus_skills\` tool (projectDir = \`${workspacePath}\`) to load the coding patterns, testing guidelines, and common pitfalls for this project's Quarkus extensions.`,
@@ -6632,9 +6646,10 @@ function buildFixPrompt(kind, extra = {}) {
         `Use the \`quarkus-agent\` MCP server's \`devui-exceptions_getLastException\` tool (projectDir = \`${workspacePath}\`) to fetch the last compilation, deployment, or runtime exception from the running Quarkus dev-mode app — the structured class, message, stack trace, and offending user-code location.`,
         "Then diagnose the root cause and fix it in the codebase. Use `quarkus_logs` for broader context if needed. If the `quarkus-agent` MCP server isn't registered, or the app isn't running in dev mode, tell me what's missing.",
       ].join("\n\n");
+    default:
+      return null;
   }
 }
-
 async function sendFix(kind, extra) {
   const raw = buildFixPrompt(kind, extra);
   if (!raw) return { ok: false, error: `Unknown fix kind: ${kind}` };
@@ -6803,6 +6818,252 @@ async function runScanRest(key) {
   } catch (e) {
     return { ok: false, tool: scan.tool, error: e.message };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies — an on-demand "outdated libraries" scan. Read-only: it shells
+// out to the build tool (the same loopback-only "shell out and parse" model the
+// rest of Coffilot uses) and lets the build tool's own plugins resolve the latest
+// available versions, so we never add a direct HTTP client to a package registry.
+// Maven is wired here; Gradle outdated-scanning is not yet implemented.
+// ---------------------------------------------------------------------------
+
+// Pinned plugin coordinates so the scan is reproducible and doesn't silently
+// pick up a different plugin major on a fresh machine.
+const DEP_TREE_PLUGIN = "org.apache.maven.plugins:maven-dependency-plugin:3.7.1";
+const VERSIONS_PLUGIN = "org.codehaus.mojo:versions-maven-plugin:2.18.0";
+
+let lastDependencyReport = null;
+
+/**
+ * Parse `mvn dependency:tree -DoutputType=text` output into a deduplicated list
+ * of dependency nodes. The leading tree art encodes depth (3 chars per level), so
+ * depth 1 is a direct dependency and anything deeper is transitive; `via` records
+ * the direct dependency that pulls a transitive one in. Pure (exported for tests).
+ */
+export function parseDependencyTree(out) {
+  const byKey = new Map();
+  const stack = []; // stack[depth] = "group:artifact"
+  for (const rawLine of String(out || "").split(/\r?\n/)) {
+    // Strip the Maven log prefix ("[INFO] ", "[WARNING] ", …).
+    const line = rawLine.replace(/^\[[A-Z]+\]\s?/, "");
+    const m = line.match(/^([| ]*)([+\\]-) (.+)$/);
+    if (!m) {
+      // A bare coordinate with no tree connector is a reactor root; reset the
+      // ancestor stack so the next module's tree is depth-counted independently.
+      if (/^[\w.\-]+:[\w.\-]+:[\w.\-]+:/.test(line.trim())) stack.length = 0;
+      continue;
+    }
+    const depth = m[1].length / 3 + 1;
+    // The coordinate is the first whitespace-delimited token (drop trailing
+    // annotations like "(optional)").
+    const coord = m[3].trim().split(/\s+/)[0];
+    const parts = coord.split(":");
+    if (parts.length < 4) continue;
+    // group:artifact:type:version:scope  OR  group:artifact:type:classifier:version:scope
+    const group = parts[0];
+    const artifact = parts[1];
+    const version = parts.length >= 6 ? parts[4] : parts[3];
+    const scope = parts.length >= 6 ? parts[5] : parts[4] || "compile";
+    const key = `${group}:${artifact}`;
+    stack[depth] = key;
+    stack.length = depth + 1;
+    const via = depth > 1 ? stack[1] || null : null;
+    const node = { key, group, artifact, version, scope, depth, direct: depth === 1, via };
+    const prev = byKey.get(key);
+    // Keep the shallowest occurrence so a dependency that is both direct and
+    // transitive is classified as direct.
+    if (!prev || node.depth < prev.depth) byKey.set(key, node);
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * Parse `versions:display-dependency-updates` output into a map of
+ * "group:artifact" -> { current, latest }. Pure (exported for tests).
+ */
+export function parseDependencyUpdates(out) {
+  const map = new Map();
+  for (const rawLine of String(out || "").split(/\r?\n/)) {
+    const line = rawLine.replace(/^\[[A-Z]+\]\s?/, "");
+    // e.g. "  com.google.guava:guava ........... 19.0 -> 33.6.0-jre"
+    const m = line.match(/^\s*([\w.\-]+:[\w.\-]+)\s+\.{2,}\s+(\S+)\s+->\s+(\S+)\s*$/);
+    if (!m) continue;
+    map.set(m[1], { current: m[2], latest: m[3] });
+  }
+  return map;
+}
+
+/** Whether a version string looks like a pre-release (alpha/beta/rc/milestone/…). */
+export function isPrerelease(v) {
+  return /[-._](alpha|beta|rc|m\d+|cr\d+|snapshot|milestone|preview|ea|dev|pre)\d*/i.test(String(v || ""));
+}
+
+/** Numeric [major, minor, patch] prefix of a version, ignoring any qualifier. */
+function versionParts(v) {
+  const m = String(v || "").match(/^\d+(?:\.\d+){0,3}/);
+  return m ? m[0].split(".").map(Number) : null;
+}
+
+/** Classify the size of an upgrade as major / minor / patch (else "other"). */
+export function classifyVersionJump(current, latest) {
+  const a = versionParts(current);
+  const b = versionParts(latest);
+  if (!a || !b) return "other";
+  if ((a[0] || 0) !== (b[0] || 0)) return "major";
+  if ((a[1] || 0) !== (b[1] || 0)) return "minor";
+  if ((a[2] || 0) !== (b[2] || 0)) return "patch";
+  return "other";
+}
+
+const JUMP_RANK = { major: 0, minor: 1, patch: 2, other: 3 };
+
+/**
+ * Merge a parsed dependency tree with the available-updates map into a sorted
+ * list of outdated libraries. The tree is authoritative for the resolved (current)
+ * version and for direct/transitive classification; the updates map supplies the
+ * latest available version. Pure (exported for tests).
+ */
+export function mergeDependencyUpdates(treeNodes, updatesMap) {
+  const out = [];
+  for (const node of treeNodes) {
+    const upd = updatesMap.get(node.key);
+    if (!upd) continue;
+    const current = node.version || upd.current;
+    const latest = upd.latest;
+    if (!latest || current === latest) continue;
+    out.push({
+      group: node.group,
+      artifact: node.artifact,
+      current,
+      latest,
+      scope: node.scope,
+      direct: node.direct,
+      via: node.via,
+      prerelease: isPrerelease(latest) && !isPrerelease(current),
+      jump: classifyVersionJump(current, latest),
+    });
+  }
+  out.sort(
+    (a, b) =>
+      Number(b.direct) - Number(a.direct) ||
+      JUMP_RANK[a.jump] - JUMP_RANK[b.jump] ||
+      `${a.group}:${a.artifact}`.localeCompare(`${b.group}:${b.artifact}`),
+  );
+  return out;
+}
+
+/**
+ * Run a build-tool command and capture its combined output without blocking the
+ * event loop. Mirrors spawnTool's spawn config (cwd / env / Windows shell) but is
+ * a one-shot capture rather than a streamed lane.
+ */
+function captureBuildTool(args, timeoutMs = 180000) {
+  const base = baseRunner();
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(base.bin, quoteWinShellArgs(withJLineDumbFlag(args, base.bin)), {
+        cwd: workspacePath,
+        env: toolEnv(),
+        shell: isWindows,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (e) {
+      resolve({ ok: false, error: e.message, out: "" });
+      return;
+    }
+    let out = "";
+    let done = false;
+    const finish = (val) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(val);
+    };
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      finish({ ok: false, error: "Timed out", out });
+    }, timeoutMs);
+    child.stdout.on("data", (c) => (out += c.toString()));
+    child.stderr.on("data", (c) => (out += c.toString()));
+    child.on("error", (e) => finish({ ok: false, error: e.message, out }));
+    child.on("close", (code) => finish({ ok: code === 0, code, out }));
+  });
+}
+
+const emptyDepCounts = () => ({ total: 0, direct: 0, transitive: 0 });
+
+/**
+ * On-demand scan: for Maven, the list of outdated libraries (direct + transitive).
+ * Caches the result so the panel can re-render it after a tab switch or reload
+ * without re-running the build tool.
+ */
+async function runDependencyScan() {
+  const startedAt = Date.now();
+  if (!toolAvailable()) {
+    lastDependencyReport = {
+      ran: true,
+      buildTool,
+      available: false,
+      updatesSupported: false,
+      updates: [],
+      counts: emptyDepCounts(),
+      ranAt: startedAt,
+      durationMs: 0,
+      error: `No ${TOOL_LABEL || "build"} tool is available.`,
+    };
+    return lastDependencyReport;
+  }
+  let updates = [];
+  let error = null;
+  const updatesSupported = buildTool === "maven";
+  if (updatesSupported) {
+    const treeRes = await captureBuildTool(["-ntp", "-B", `${DEP_TREE_PLUGIN}:tree`, "-DoutputType=text"]);
+    const updRes = await captureBuildTool(["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`]);
+    const nodes = parseDependencyTree(treeRes.out || "");
+    const updMap = parseDependencyUpdates(updRes.out || "");
+    updates = mergeDependencyUpdates(nodes, updMap);
+    // Distinguish "everything is up to date" from a command that actually failed
+    // (offline, missing plugin, broken pom): only the latter sets an error.
+    if (!nodes.length && treeRes.ok === false) error = treeRes.error || "dependency:tree failed.";
+    else if (!updMap.size && updRes.ok === false) error = updRes.error || "Could not resolve dependency updates.";
+  }
+  lastDependencyReport = {
+    ran: true,
+    buildTool,
+    available: true,
+    updatesSupported,
+    updates,
+    counts: {
+      total: updates.length,
+      direct: updates.filter((u) => u.direct).length,
+      transitive: updates.filter((u) => !u.direct).length,
+    },
+    ranAt: startedAt,
+    durationMs: Date.now() - startedAt,
+    error,
+  };
+  return lastDependencyReport;
+}
+
+/** GET /api/deps payload: the cached scan if any, else an idle snapshot. */
+function dependencySnapshot() {
+  if (lastDependencyReport) return lastDependencyReport;
+  return {
+    ran: false,
+    buildTool,
+    available: toolAvailable(),
+    updatesSupported: buildTool === "maven",
+    updates: [],
+    counts: emptyDepCounts(),
+    ranAt: null,
+    error: null,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -7600,6 +7861,17 @@ async function handleRequest(req, res) {
     return;
   }
 
+  if (req.method === "GET" && url.pathname === "/api/deps") {
+    await workspaceReady;
+    sendJson(res, 200, dependencySnapshot());
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/deps/scan") {
+    await workspaceReady;
+    sendJson(res, 200, await runDependencyScan());
+    return;
+  }
+
   if (req.method === "GET" && url.pathname === "/api/loggers") {
     const status = await loggersStatus();
     // runMode lets the UI tailor the "no logger endpoint" hint (and its fix button)
@@ -8088,6 +8360,13 @@ function makeCanvas() {
           required: ["tool"],
         },
         handler: async (ctx) => runScanRest(ctx.input?.tool),
+      },
+      {
+        name: "check_dependencies",
+        description:
+          "Scan the project for outdated libraries. Shells out to the build tool to resolve the latest available versions and returns the findings (current → latest, direct vs transitive, version-jump size). Maven only for now. Findings can be handed to fix_issue with kind 'fix-dependency'.",
+        inputSchema: { type: "object", properties: {} },
+        handler: async () => runDependencyScan(),
       },
       {
         name: "set_log_level",

--- a/extension.mjs
+++ b/extension.mjs
@@ -1527,6 +1527,7 @@ export function pomCaps(xml, name) {
     quarkus,
     actuator: xml.includes("spring-boot-starter-actuator"),
     devtools: xml.includes("spring-boot-devtools"),
+    quarkusMetrics: /quarkus-micrometer/.test(xml),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(xml),
     mainClass: pomMainClass(xml),
   };
@@ -1570,6 +1571,7 @@ export function gradleCaps(text, name) {
     quarkus,
     actuator: text.includes("spring-boot-starter-actuator"),
     devtools: text.includes("spring-boot-devtools"),
+    quarkusMetrics: /quarkus-micrometer/.test(text),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(text),
     application: gradleHasApplicationPlugin(text),
     mainClass: gradleMainClass(text),
@@ -1940,6 +1942,7 @@ function capabilitiesSnapshot() {
     runnable: mods.some((m) => m.runnable),
     actuator: mods.some((m) => m.actuator),
     devtools: mods.some((m) => m.devtools),
+    quarkusMetrics: mods.some((m) => m.quarkusMetrics),
     bootui: mods.some((m) => m.bootui),
     quarkusAgentMcp: mods.some((m) => m.quarkus) ? detectQuarkusAgentMcp() : { available: false, runner: null },
   };
@@ -6553,6 +6556,41 @@ function buildFixPrompt(kind, extra = {}) {
           "- Use the latest released version of `io.quarkiverse.loggingmanager:quarkus-logging-manager` from Maven Central; pin a concrete version rather than a range (replace `VERSION`).",
         ].join("\n"),
         "After editing, tell me to run the app again (e.g. `./mvnw quarkus:dev`); the Loggers tab then lists every logger and lets you change levels live.",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+    }
+    case "install-quarkus-metrics": {
+      const moduleName = extra.module || "";
+      const expose =
+        "By default Quarkus serves Prometheus metrics at `/q/metrics`; the canvas reads that endpoint, so no extra configuration is needed once the extension is present.";
+      if (buildTool === "gradle") {
+        const { rel, kts } = gradleModuleBuildFile(moduleName);
+        const dep = kts
+          ? `implementation("io.quarkus:quarkus-micrometer-registry-prometheus")`
+          : `implementation 'io.quarkus:quarkus-micrometer-registry-prometheus'`;
+        return [
+          "This is a Quarkus application that doesn't expose JVM metrics, so the canvas can't read live heap, threads and uptime. Add the Quarkus Micrometer Prometheus extension, which serves `/q/metrics`.",
+          `Edit \`${rel}\` and add the extension inside \`dependencies { }\`:`,
+          codeBlock(`dependencies {\n  ${dep}\n}`, kts ? "kotlin" : "groovy"),
+          "   Omit the version so it inherits from the Quarkus platform BOM. Don't duplicate the line if it's already present.",
+          expose,
+          "After editing, tell me to run the app again (e.g. `./gradlew quarkusDev`); the Live JVM tab then shows heap, threads and health.",
+        ]
+          .filter(Boolean)
+          .join("\n\n");
+      }
+      const pomRel = moduleName ? `${moduleName}/pom.xml` : "pom.xml";
+      return [
+        "This is a Quarkus application that doesn't expose JVM metrics, so the canvas can't read live heap, threads and uptime. Add the Quarkus Micrometer Prometheus extension, which serves `/q/metrics`.",
+        `Edit \`${pomRel}\` and add this dependency inside the \`<dependencies>\` block (omit the \`<version>\` so it inherits from the Quarkus platform BOM):`,
+        codeBlock(
+          "<dependency>\n  <groupId>io.quarkus</groupId>\n  <artifactId>quarkus-micrometer-registry-prometheus</artifactId>\n</dependency>",
+          "xml",
+        ),
+        "   Don't duplicate it if it's already present.",
+        expose,
+        "After editing, tell me to run the app again (e.g. `./mvnw quarkus:dev`); the Live JVM tab then shows heap, threads and health.",
       ]
         .filter(Boolean)
         .join("\n\n");

--- a/extension.mjs
+++ b/extension.mjs
@@ -7104,10 +7104,29 @@ function updatesSupportedFor(tool) {
   return tool === "maven" || tool === "gradle";
 }
 
+// Dependency-scan command vectors, exported so the e2e harness drives exactly
+// what the scan runs (no hand-maintained copy), mirroring testArgsFor/buildArgsFor.
+/** Maven: `dependency:tree` in text form (current versions + direct/transitive). */
+export function mavenDepTreeArgs() {
+  return ["-ntp", "-B", `${DEP_TREE_PLUGIN}:tree`, "-DoutputType=text"];
+}
+/** Maven: `versions:display-dependency-updates` (latest available versions). */
+export function mavenDepUpdatesArgs() {
+  return ["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`];
+}
+/** Gradle: the built-in `dependencies` report for the runtime classpath. */
+export function gradleDepTreeArgs() {
+  return ["dependencies", "--configuration", "runtimeClasspath", "-q"];
+}
+/** Gradle: the ben-manes `dependencyUpdates` task, injected via an init script. */
+export function gradleDepUpdatesArgs(initScript) {
+  return ["--init-script", initScript, "dependencyUpdates", "-q"];
+}
+
 /** Maven outdated-libraries scan: dependency:tree + display-dependency-updates. */
 async function runMavenDependencyScan() {
-  const treeRes = await captureBuildTool(["-ntp", "-B", `${DEP_TREE_PLUGIN}:tree`, "-DoutputType=text"]);
-  const updRes = await captureBuildTool(["-ntp", "-B", `${VERSIONS_PLUGIN}:display-dependency-updates`]);
+  const treeRes = await captureBuildTool(mavenDepTreeArgs());
+  const updRes = await captureBuildTool(mavenDepUpdatesArgs());
   const nodes = parseDependencyTree(treeRes.out || "");
   const updMap = parseDependencyUpdates(updRes.out || "");
   const updates = mergeDependencyUpdates(nodes, updMap);
@@ -7121,8 +7140,8 @@ async function runMavenDependencyScan() {
 
 /** Body of the throwaway Gradle init script that injects the ben-manes
  * gradle-versions-plugin and points its JSON report at our temp dir, one file per
- * project so subprojects don't overwrite each other. */
-function gradleDependencyUpdatesInitBody(outDir) {
+ * project so subprojects don't overwrite each other. Exported for the e2e harness. */
+export function gradleDependencyUpdatesInitBody(outDir) {
   const dir = outDir.replace(/\\/g, "/"); // forward slashes are safe in a Groovy string on every OS
   return [
     "// Coffilot: inject the ben-manes versions plugin to list outdated libraries (read-only).",
@@ -7154,8 +7173,8 @@ async function runGradleDependencyScan() {
   try {
     mkdirSync(outDir, { recursive: true });
     writeFileSync(initScript, gradleDependencyUpdatesInitBody(outDir));
-    const treeRes = await captureBuildTool(["dependencies", "--configuration", "runtimeClasspath", "-q"]);
-    const updRes = await captureBuildTool(["--init-script", initScript, "dependencyUpdates", "-q"]);
+    const treeRes = await captureBuildTool(gradleDepTreeArgs());
+    const updRes = await captureBuildTool(gradleDepUpdatesArgs(initScript));
     const nodes = parseGradleDependencyTree(treeRes.out || "");
     const updMap = new Map();
     try {

--- a/extension.mjs
+++ b/extension.mjs
@@ -1528,6 +1528,7 @@ export function pomCaps(xml, name) {
     actuator: xml.includes("spring-boot-starter-actuator"),
     devtools: xml.includes("spring-boot-devtools"),
     quarkusMetrics: /quarkus-micrometer/.test(xml),
+    loggingManager: /quarkus-logging-manager/.test(xml),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(xml),
     mainClass: pomMainClass(xml),
   };
@@ -1572,6 +1573,7 @@ export function gradleCaps(text, name) {
     actuator: text.includes("spring-boot-starter-actuator"),
     devtools: text.includes("spring-boot-devtools"),
     quarkusMetrics: /quarkus-micrometer/.test(text),
+    loggingManager: /quarkus-logging-manager/.test(text),
     bootui: /bootui-spring-boot-starter|julien-dubois\.bootui|jdubois\.bootui/.test(text),
     application: gradleHasApplicationPlugin(text),
     mainClass: gradleMainClass(text),
@@ -1943,6 +1945,7 @@ function capabilitiesSnapshot() {
     actuator: mods.some((m) => m.actuator),
     devtools: mods.some((m) => m.devtools),
     quarkusMetrics: mods.some((m) => m.quarkusMetrics),
+    loggingManager: mods.some((m) => m.loggingManager),
     bootui: mods.some((m) => m.bootui),
     quarkusAgentMcp: mods.some((m) => m.quarkus) ? detectQuarkusAgentMcp() : { available: false, runner: null },
   };

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -10,8 +10,8 @@ rung of that ladder:
 
 | Project | What it is | Coffilot tier exercised |
 | ------- | ---------- | ----------------------- |
-| [`hello-world`](hello-world) | Plain Maven project (no Spring), one JUnit 5 test | **Plain Java** — Build / Test / Package only |
-| [`gradle-hello-world`](gradle-hello-world) | Plain Gradle project (no Spring), one JUnit 5 test | **Plain Java (Gradle)** — Build / Test / Package via `./gradlew` |
+| [`hello-world`](hello-world) | Plain Maven project (no Spring), one JUnit 5 test, plus a deliberately ancient `guava:19.0` for the upgrades scan | **Plain Java** — Build / Test / Package + outdated-library scan |
+| [`gradle-hello-world`](gradle-hello-world) | Plain Gradle project (no Spring), one JUnit 5 test, plus a deliberately ancient `guava:19.0` for the upgrades scan | **Plain Java (Gradle)** — Build / Test / Package + outdated-library scan via `./gradlew` |
 | [`spring-mvc`](spring-mvc) | Spring Boot MVC app (`web`), from start.spring.io | **Spring Boot** — Run lane + process-level JVM metrics |
 | [`spring-mvc-actuator-devtools`](spring-mvc-actuator-devtools) | Same app + Actuator + DevTools | **Actuator** — richer live metrics via `/actuator` |
 | [`spring-mvc-bootui`](spring-mvc-bootui) | Same app with BootUI in a `dev` Maven profile | **BootUI** — richest metrics + advisor scan |
@@ -136,8 +136,12 @@ Coffilot's own test suite drives these projects on two levels (see `test/`):
   then feed the JUnit reports the build produced through Coffilot's own report
   discovery + parser and assert the parsed results. `failing-tests` additionally
   covers the failure path: the build exits non-zero, yet the report still parses
-  with the right pass/fail/error split. They need a JDK 17 and network access, so
-  they are **skipped unless `COFFILOT_E2E=1`** is set:
+  with the right pass/fail/error split. They also drive the **Upgrades-tab
+  outdated-library scan** end to end for one Maven (`hello-world`) and one Gradle
+  (`gradle-hello-world`) project — running the real scan commands (for Gradle, the
+  ben-manes plugin injected through a throwaway `--init-script`) and asserting the
+  ancient `guava:19.0` is reported as an outdated, direct dependency. They need a
+  JDK 17 and network access, so they are **skipped unless `COFFILOT_E2E=1`** is set:
 
   ```bash
   COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs

--- a/integration-tests/gradle-hello-world/build.gradle
+++ b/integration-tests/gradle-hello-world/build.gradle
@@ -20,6 +20,13 @@ application {
     mainClass = 'com.example.helloworld.App'
 }
 
+dependencies {
+    // A deliberately ancient release (2015) so the Upgrades-tab outdated-library
+    // scan always has a guaranteed-outdated direct dependency to report. It is
+    // unused by the code; it only exercises the dependency scan.
+    implementation 'com.google.guava:guava:19.0'
+}
+
 testing {
     suites {
         test {

--- a/integration-tests/hello-world/pom.xml
+++ b/integration-tests/hello-world/pom.xml
@@ -19,6 +19,14 @@
     </properties>
 
     <dependencies>
+        <!-- A deliberately ancient release (2015) so the Upgrades-tab outdated-library
+             scan always has a guaranteed-outdated direct dependency to report. It is
+             unused by the code; it only exercises the dependency scan. -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/public/app.js
+++ b/public/app.js
@@ -1891,11 +1891,13 @@ function renderDeps(report) {
   depsState = report;
   depsResultEl.innerHTML = updatesSectionHtml(report);
 
-  // The "Direct only" toggle is meaningful only once a scan found transitive
-  // updates to hide.
-  const hasTransitive = !!(report.ran && report.counts && report.counts.transitive > 0);
-  if (depsDirectInput) depsDirectInput.disabled = !hasTransitive;
-  if (depsDirectToggle) depsDirectToggle.classList.toggle("disabled", !hasTransitive);
+  // "Direct only" is a view preference, not a scan parameter: keep it interactive
+  // whenever the project supports update scanning so it can be set before a scan
+  // and applies live to the list afterwards. Only disable it when this build tool
+  // can't scan for updates at all (nothing to filter).
+  const canFilter = report.updatesSupported !== false;
+  if (depsDirectInput) depsDirectInput.disabled = !canFilter;
+  if (depsDirectToggle) depsDirectToggle.classList.toggle("disabled", !canFilter);
 
   const outdated = report.counts ? report.counts.total : 0;
   if (depsSrc) {
@@ -1989,7 +1991,7 @@ async function fixDep(i, btn) {
 if (depsScanBtn) depsScanBtn.onclick = runDepsScan;
 if (depsDirectInput)
   depsDirectInput.onchange = () => {
-    renderDeps(depsState);
+    if (depsState) renderDeps(depsState);
     saveSettings();
   };
 

--- a/public/app.js
+++ b/public/app.js
@@ -94,6 +94,8 @@ const devtoolsToggle = document.getElementById("devtools-toggle");
 const devtoolsInput = document.getElementById("in-devtools");
 const devtoolsActions = document.getElementById("devtools-actions");
 const springVersionEl = document.getElementById("spring-version");
+const springActuatorSection = document.getElementById("spring-actuator-section");
+const springDevtoolsSection = document.getElementById("spring-devtools-section");
 const btnUpgradeSpring = document.getElementById("btn-upgrade-spring");
 const btnReload = document.getElementById("btn-reload");
 const btnRestartApp = document.getElementById("btn-restart-app");
@@ -192,6 +194,7 @@ const quarkusMcpState = document.getElementById("quarkus-mcp-state");
 const quarkusMcpScansEl = document.getElementById("quarkus-mcp-scans");
 const quarkusMcpRegisterBtn = document.getElementById("quarkus-mcp-register");
 const quarkusEmptyEl = document.getElementById("quarkus-empty");
+const quarkusDescEl = document.getElementById("quarkus-desc");
 const scansSrc = document.getElementById("scans-src");
 const scansHint = document.getElementById("scans-hint");
 const scansListEl = document.getElementById("scans-list");
@@ -1207,6 +1210,67 @@ async function refreshVars() {
 // on every SSE push, so we replay the previous fill width and bump it to the new
 // value on the next frame, letting the CSS width transition animate smoothly.
 let lastHeapPct = 0;
+// The Live JVM tab is greyed when the app is down or exposes no metrics endpoint.
+// Its pane then explains why and, when the project is a Spring Boot app without
+// Actuator (or a Quarkus app without Micrometer), offers a one-click Copilot fix to
+// add the dependency. metricsInactiveKey skips rebuilding an identical view on every
+// SSE push (which would otherwise reset a just-pressed button); metricsFixAsked
+// keeps the "Asked Copilot ✓" state until the app comes up with real metrics.
+let metricsInactiveKey = null;
+let metricsFixAsked = false;
+// Render the Live JVM pane's "why it's inactive" message (+ optional dependency
+// fix) for a down or metrics-less app. appDown distinguishes "not running" from
+// "running but no endpoint". Mirrors renderLoggersUnavailable's fix-button pattern.
+function renderMetricsInactive(appDown) {
+  const mod =
+    moduleList.find((m) => m.name === moduleSelect.value) ||
+    moduleList.find((m) => m.runnable) ||
+    moduleList[0] ||
+    null;
+  const springNoActuator = !!caps.springBoot && !(mod && mod.actuator);
+  const quarkusNoMetrics = !!caps.quarkus && !(mod && mod.quarkusMetrics);
+  let msg;
+  let fix = null;
+  let fixLabel = null;
+  if (springNoActuator) {
+    msg = appDown
+      ? "The app isn\u2019t running, and this Spring Boot app doesn\u2019t include Spring Boot Actuator \u2014 the Live JVM tab needs it to read metrics."
+      : "This Spring Boot app doesn\u2019t expose Spring Boot Actuator, so the Live JVM tab can\u2019t read metrics.";
+    fix = "install-actuator";
+    fixLabel = "Add Actuator with Copilot";
+  } else if (quarkusNoMetrics) {
+    msg = appDown
+      ? "The app isn\u2019t running, and this Quarkus app doesn\u2019t include Micrometer metrics \u2014 the Live JVM tab needs them."
+      : "This Quarkus app doesn\u2019t expose Micrometer metrics, so the Live JVM tab can\u2019t read metrics.";
+    fix = "install-quarkus-metrics";
+    fixLabel = "Add Quarkus metrics with Copilot";
+  } else if (appDown) {
+    msg = "The app isn\u2019t running. Run a module to see its live JVM metrics.";
+  } else {
+    msg = "The running app doesn\u2019t expose a metrics endpoint, so there are no live JVM metrics to show.";
+  }
+  const key = (appDown ? "down" : "noendpoint") + ":" + (fix || "none") + ":" + (metricsFixAsked ? "asked" : "open");
+  if (key === metricsInactiveKey) return;
+  metricsInactiveKey = key;
+  let html = `<p class="muted">${msg}</p>`;
+  if (fix) {
+    html += metricsFixAsked
+      ? '<button class="fix fix-copilot tiny" style="margin-top: 0.4rem" disabled>Asked Copilot \u2713</button>'
+      : `<button id="metrics-fix" class="fix fix-copilot tiny" style="margin-top: 0.4rem">${fixLabel}</button>`;
+  }
+  metricsEl.innerHTML = html;
+  metricsHint.hidden = true;
+  const btn = fix && document.getElementById("metrics-fix");
+  if (btn) {
+    btn.onclick = () => {
+      metricsFixAsked = true;
+      metricsInactiveKey = null;
+      btn.disabled = true;
+      btn.textContent = "Asked Copilot \u2713";
+      post("/api/fix", { kind: fix, module: moduleSelect.value });
+    };
+  }
+}
 function renderMetrics(m) {
   const nowUp = !!(m && m.appUp);
   // The metrics tier is the single source of truth for which tool panels are
@@ -1227,9 +1291,7 @@ function renderMetrics(m) {
     metricsSrc.hidden = true;
     renderMcp(null);
     renderScans(false);
-    metricsEl.innerHTML = '<p class="muted">Application isn\u2019t running or doesn\u2019t expose metrics.</p>';
-    metricsHint.innerHTML =
-      'To get metrics, add <strong>Spring Boot Actuator</strong> or <strong>Quarkus Micrometer/health</strong>. For even richer metrics with Spring Boot, add <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a>.';
+    renderMetricsInactive(true);
     return;
   }
   metricsSrc.hidden = false;
@@ -1239,14 +1301,17 @@ function renderMetrics(m) {
 
   if (tier === "process") {
     lastHeapPct = 0;
-    metricsEl.innerHTML =
-      '<p class="muted">App is running, but no <code>/bootui/api</code>, <code>/actuator</code> or <code>/q/metrics</code> endpoint answered, so live JVM metrics aren\u2019t available.</p>';
-    metricsHint.innerHTML =
-      "Add <code>spring-boot-starter-actuator</code> / BootUI (Spring) or <code>quarkus-micrometer-registry-prometheus</code> (Quarkus) to surface heap, threads and health here.";
     renderMcp(null);
     renderScans(false);
+    renderMetricsInactive(false);
     return;
   }
+
+  // Real metrics: the tab is active again, so clear the inactive-view guard and
+  // restore the contextual hint that the active tiers populate below.
+  metricsInactiveKey = null;
+  metricsFixAsked = false;
+  metricsHint.hidden = false;
 
   const o = m.overview || {};
   const heap = (m.memory && m.memory.heap) || {};
@@ -1664,6 +1729,7 @@ function renderQuarkusMcp() {
   updateAsideAvailability({ quarkus: isQuarkus });
   quarkusMcpPanel.hidden = !isQuarkus;
   quarkusEmptyEl.hidden = isQuarkus;
+  if (quarkusDescEl) quarkusDescEl.hidden = !isQuarkus;
   if (!isQuarkus) {
     quarkusMcpState.textContent = "";
     return;
@@ -1894,9 +1960,9 @@ function renderLoggers(data, force) {
     loggersSrc.hidden = true;
     loggersControls.hidden = true;
     loggersListEl.innerHTML =
-      '<p class="muted">Application isn\u2019t running or doesn\u2019t expose a runtime-logger endpoint.</p>' +
-      '<p class="hint">Live log levels need a running Spring Boot app (Actuator <code>/loggers</code>) or a Quarkus ' +
-      "app with the logging-manager extension. Click <strong>Run</strong> to start it.</p>";
+      '<p class="muted">The app isn\u2019t running.</p>' +
+      '<p class="hint">Run a Spring Boot app (Actuator <code>/loggers</code>) or a Quarkus app with the ' +
+      "logging-manager extension to change its log levels here live, no restart.</p>";
     loggersData = null;
     loggersFixAsked = false;
     loggersUnavailKey = null;
@@ -2316,6 +2382,13 @@ function updateDevSetup() {
   if (lblProfiles) lblProfiles.textContent = quarkus ? "Quarkus profile" : "Spring Boot profiles";
   profileItems = quarkus ? quarkusItems : springItems;
 
+  // The Spring Boot tab is greyed (inactive) when the project has no Spring Boot
+  // module at all; its Actuator/DevTools sections are meaningless then, so hide
+  // them and let renderSpringAdvisor show the "not a Spring Boot project" reason.
+  const springProject = !!(caps && caps.springBoot);
+  if (springActuatorSection) springActuatorSection.hidden = !springProject;
+  if (springDevtoolsSection) springDevtoolsSection.hidden = !springProject;
+
   // Activate-BootUI CTA: only available — shown and enabled — for a Spring Boot
   // module that doesn't depend on BootUI yet. Hidden for non-Spring apps and once
   // the module already has BootUI (since it's then active).
@@ -2380,7 +2453,7 @@ function renderSpringAdvisor(adv) {
   springAdvisor = adv || null;
   if (!springVersionEl) return;
   if (!adv || !adv.detected) {
-    springVersionEl.innerHTML = '<p class="muted">No Spring Boot module detected.</p>';
+    springVersionEl.innerHTML = '<p class="muted">This isn\u2019t a Spring Boot project.</p>';
     btnUpgradeSpring.hidden = true;
     return;
   }

--- a/public/app.js
+++ b/public/app.js
@@ -75,6 +75,8 @@ const warmCopied = document.getElementById("warm-copied");
 const warmDocs = document.getElementById("warm-docs");
 const btnAddBootui = document.getElementById("btn-add-bootui");
 const btnAddDevtools = document.getElementById("btn-add-devtools");
+const btnAddActuator = document.getElementById("btn-add-actuator");
+const actuatorStatus = document.getElementById("actuator-status");
 const setJdtls = document.getElementById("set-jdtls");
 const jdtlsDot = document.getElementById("jdtls-dot");
 const jdtlsStateEl = document.getElementById("jdtls-state");
@@ -1892,7 +1894,9 @@ function renderLoggers(data, force) {
     loggersSrc.hidden = true;
     loggersControls.hidden = true;
     loggersListEl.innerHTML =
-      '<p class="muted">App not running. Click <strong>Run</strong> to control its log levels.</p>';
+      '<p class="muted">Application isn\u2019t running or doesn\u2019t expose a runtime-logger endpoint.</p>' +
+      '<p class="hint">Live log levels need a running Spring Boot app (Actuator <code>/loggers</code>) or a Quarkus ' +
+      "app with the logging-manager extension. Click <strong>Run</strong> to start it.</p>";
     loggersData = null;
     loggersFixAsked = false;
     loggersUnavailKey = null;
@@ -1932,9 +1936,9 @@ function renderLoggersUnavailable(runMode) {
   if (runMode === "spring") {
     html =
       '<p class="muted">No Spring Boot Actuator <code>/loggers</code> endpoint is exposed on the running app, ' +
-      "so log levels can\u2019t be changed here. Add <code>spring-boot-starter-actuator</code> and expose it " +
-      "(<code>management.endpoints.web.exposure.include=loggers</code>).</p>";
-    fix = "install-actuator-loggers";
+      "so log levels can\u2019t be changed here.</p>" +
+      '<p class="hint">Add Spring Boot Actuator from the <strong>Spring</strong> tab, then expose it ' +
+      "(<code>management.endpoints.web.exposure.include=loggers</code>) and run the app again.</p>";
   } else if (runMode === "quarkus") {
     html =
       '<p class="muted">No Quarkus logging-manager endpoint is exposed on the running app, so log levels ' +
@@ -2322,6 +2326,18 @@ function updateDevSetup() {
   btnAddBootui.textContent = caps.gradle ? "Add BootUI (developmentOnly)" : "Add BootUI to dev profile";
   btnAddBootui.title =
     "Add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
+
+  // Actuator section (Spring Boot tab): offer to add Actuator for a Spring Boot
+  // module that doesn't depend on it yet (it backs both the Live JVM metrics and
+  // the Loggers tab); otherwise confirm it's already on the classpath.
+  const hasActuator = spring && !!mod.actuator;
+  const showAddActuator = spring && !mod.actuator;
+  if (actuatorStatus) actuatorStatus.hidden = !hasActuator;
+  btnAddActuator.hidden = !showAddActuator;
+  if (showAddActuator) {
+    btnAddActuator.disabled = false;
+    btnAddActuator.textContent = "Add Actuator";
+  }
 
   // DevTools section (Spring Boot tab): show the live-reload toggle + manual
   // actions once DevTools is on the classpath, otherwise offer to add it.
@@ -2982,6 +2998,11 @@ btnAddDevtools.onclick = async () => {
   btnAddDevtools.disabled = true;
   btnAddDevtools.textContent = "Asked Copilot \u2713";
   await post("/api/fix", { kind: "install-devtools", module: moduleSelect.value });
+};
+btnAddActuator.onclick = async () => {
+  btnAddActuator.disabled = true;
+  btnAddActuator.textContent = "Asked Copilot \u2713";
+  await post("/api/fix", { kind: "install-actuator", module: moduleSelect.value });
 };
 btnUpgradeSpring.onclick = async () => {
   btnUpgradeSpring.disabled = true;

--- a/public/app.js
+++ b/public/app.js
@@ -1984,7 +1984,11 @@ async function fixDep(i, btn) {
 }
 
 if (depsScanBtn) depsScanBtn.onclick = runDepsScan;
-if (depsDirectInput) depsDirectInput.onchange = () => renderDeps(depsState);
+if (depsDirectInput)
+  depsDirectInput.onchange = () => {
+    renderDeps(depsState);
+    saveSettings();
+  };
 
 // ---- Runtime log levels (Loggers aside tab) ----------------------------
 // Lists the running app's loggers from Spring Boot Actuator /loggers or the Quarkus
@@ -2656,6 +2660,23 @@ function applySettingsState(s) {
     // JDK doesn't leave the control on a phantom value.
     jdkSelect.value = [...jdkSelect.options].some((o) => o.value === want) ? want : "";
   }
+  // View/preference toggles: restore the saved checkbox state, then re-render the
+  // dependent view so the filter takes effect immediately.
+  if (dbgSuspendInput) dbgSuspendInput.checked = s.debugSuspend === true;
+  if (failuresOnlyInput) {
+    const want = s.testFailuresOnly === true;
+    if (failuresOnlyInput.checked !== want) {
+      failuresOnlyInput.checked = want;
+      rerenderTestFilter();
+    }
+  }
+  if (depsDirectInput) {
+    const want = s.depsDirectOnly === true;
+    if (depsDirectInput.checked !== want) {
+      depsDirectInput.checked = want;
+      if (depsState) renderDeps(depsState);
+    }
+  }
   applyAsideState(s);
 }
 
@@ -3204,6 +3225,9 @@ function saveSettings() {
     jdkHome: jdkSelect ? jdkSelect.value : "",
     asideTab: asideTabPref,
     asideOpen: asideOpenPref,
+    depsDirectOnly: !!(depsDirectInput && depsDirectInput.checked),
+    testFailuresOnly: !!(failuresOnlyInput && failuresOnlyInput.checked),
+    debugSuspend: !!(dbgSuspendInput && dbgSuspendInput.checked),
   });
 }
 warmInput.addEventListener("change", saveSettings);
@@ -3226,8 +3250,13 @@ if (flameDuration) flameDuration.addEventListener("change", saveSettings);
 function rerenderTestFilter() {
   if (lastTestReportData) renderTests(lastTestReportData, lastTestRenderOpts);
 }
-if (failuresOnlyInput) failuresOnlyInput.addEventListener("change", rerenderTestFilter);
+if (failuresOnlyInput)
+  failuresOnlyInput.addEventListener("change", () => {
+    rerenderTestFilter();
+    saveSettings();
+  });
 if (testSearchEl) testSearchEl.addEventListener("input", rerenderTestFilter);
+if (dbgSuspendInput) dbgSuspendInput.addEventListener("change", saveSettings);
 
 // "Full build" persists the affected-vs-full-suite preference for the Test button.
 fullbuildInput.addEventListener("change", () => {

--- a/public/app.js
+++ b/public/app.js
@@ -1210,66 +1210,125 @@ async function refreshVars() {
 // on every SSE push, so we replay the previous fill width and bump it to the new
 // value on the next frame, letting the CSS width transition animate smoothly.
 let lastHeapPct = 0;
-// The Live JVM tab is greyed when the app is down or exposes no metrics endpoint.
-// Its pane then explains why and, when the project is a Spring Boot app without
-// Actuator (or a Quarkus app without Micrometer), offers a one-click Copilot fix to
-// add the dependency. metricsInactiveKey skips rebuilding an identical view on every
-// SSE push (which would otherwise reset a just-pressed button); metricsFixAsked
-// keeps the "Asked Copilot ✓" state until the app comes up with real metrics.
+// The Live JVM and Loggers tabs are greyed when the app is down or exposes no
+// diagnostic endpoint. Both panes share diagnosticInactiveBody / paintDiagnosticInactive
+// so they tell one consistent story: for the selected module, either confirm the
+// required dependency is already in the build ("\u2026 is set up") or offer an orange
+// "Add \u2026 with Copilot" fix to add it. The *AskedKinds sets remember which fixes were
+// pressed so the SSE/poll re-render keeps them disabled, and the *InactiveKey guards
+// skip rebuilding an identical view (which would otherwise reset a just-pressed button).
 let metricsInactiveKey = null;
-let metricsFixAsked = false;
-// Render the Live JVM pane's "why it's inactive" message (+ optional dependency
-// fix) for a down or metrics-less app. appDown distinguishes "not running" from
-// "running but no endpoint". Mirrors renderLoggersUnavailable's fix-button pattern.
-function renderMetricsInactive(appDown) {
-  const mod =
-    moduleList.find((m) => m.name === moduleSelect.value) ||
-    moduleList.find((m) => m.runnable) ||
-    moduleList[0] ||
-    null;
-  const springNoActuator = !!caps.springBoot && !(mod && mod.actuator);
-  const quarkusNoMetrics = !!caps.quarkus && !(mod && mod.quarkusMetrics);
-  let msg;
-  let fix = null;
-  let fixLabel = null;
-  if (springNoActuator) {
-    msg = appDown
-      ? "The app isn\u2019t running, and this Spring Boot app doesn\u2019t include Spring Boot Actuator \u2014 the Live JVM tab needs it to read metrics."
-      : "This Spring Boot app doesn\u2019t expose Spring Boot Actuator, so the Live JVM tab can\u2019t read metrics.";
-    fix = "install-actuator";
-    fixLabel = "Add Actuator with Copilot";
-  } else if (quarkusNoMetrics) {
-    msg = appDown
-      ? "The app isn\u2019t running, and this Quarkus app doesn\u2019t include Micrometer metrics \u2014 the Live JVM tab needs them."
-      : "This Quarkus app doesn\u2019t expose Micrometer metrics, so the Live JVM tab can\u2019t read metrics.";
-    fix = "install-quarkus-metrics";
-    fixLabel = "Add Quarkus metrics with Copilot";
-  } else if (appDown) {
-    msg = "The app isn\u2019t running. Run a module to see its live JVM metrics.";
+const metricsAskedKinds = new Set();
+
+// The selected module the run lane would launch \u2014 its build file is where we read
+// which diagnostic dependencies (Actuator, BootUI, Micrometer, logging-manager) live.
+function selectedRunModule() {
+  return (
+    moduleList.find((m) => m.name === moduleSelect.value) || moduleList.find((m) => m.runnable) || moduleList[0] || null
+  );
+}
+
+// Build the dependency status/fix block for a diagnostic pane. Spring Boot is layered \u2014
+// Actuator is the base and BootUI the richer tier \u2014 so: BootUI present => just say it's
+// set up (no Actuator offer, since BootUI already includes it); Actuator present but no
+// BootUI => say Actuator is set up and still offer BootUI; neither => offer Add Actuator
+// then Add BootUI, in that order. Quarkus uses the feature-specific dependency
+// ("metrics" => Micrometer, "loggers" => logging-manager): present => say so, else offer
+// its fix. appDown tailors "run the app" vs. "expose its endpoints and restart". Returns
+// { lines, fixes } consumed by paintDiagnosticInactive.
+function diagnosticInactiveBody(feature, appDown) {
+  const mod = selectedRunModule();
+  const next = appDown ? "run the app to use this tab" : "expose its endpoints and restart to use this tab";
+  const lines = [];
+  const fixes = [];
+  if (mod && mod.springBoot) {
+    if (mod.bootui) {
+      lines.push(`<p class="muted ok">\u2713 BootUI is set up \u2014 ${next}.</p>`);
+    } else if (mod.actuator) {
+      lines.push(`<p class="muted ok">\u2713 Spring Boot Actuator is set up \u2014 ${next}.</p>`);
+      lines.push('<p class="hint">Add BootUI for its developer console, richer metrics and advisor scans.</p>');
+      fixes.push({ id: "diag-fix-bootui", kind: "install-bootui", label: "Add BootUI with Copilot" });
+    } else {
+      lines.push(
+        feature === "loggers"
+          ? '<p class="muted">This Spring Boot app doesn\u2019t include Spring Boot Actuator, so log levels can\u2019t be changed live.</p>'
+          : '<p class="muted">This Spring Boot app doesn\u2019t include Spring Boot Actuator, so the Live JVM tab can\u2019t read metrics.</p>',
+      );
+      fixes.push({ id: "diag-fix-actuator", kind: "install-actuator", label: "Add Actuator with Copilot" });
+      fixes.push({ id: "diag-fix-bootui", kind: "install-bootui", label: "Add BootUI with Copilot" });
+    }
+  } else if (mod && mod.quarkus) {
+    if (feature === "loggers") {
+      if (mod.loggingManager) {
+        lines.push(`<p class="muted ok">\u2713 Quarkus logging-manager is set up \u2014 ${next}.</p>`);
+      } else {
+        lines.push(
+          '<p class="muted">This Quarkus app doesn\u2019t include the logging-manager extension, so log levels can\u2019t be changed live.</p>',
+        );
+        fixes.push({ id: "diag-fix-lm", kind: "install-logging-manager", label: "Add logging-manager with Copilot" });
+      }
+    } else if (mod.quarkusMetrics) {
+      lines.push(`<p class="muted ok">\u2713 Quarkus Micrometer is set up \u2014 ${next}.</p>`);
+    } else {
+      lines.push(
+        '<p class="muted">This Quarkus app doesn\u2019t include Micrometer metrics, so the Live JVM tab can\u2019t read metrics.</p>',
+      );
+      fixes.push({ id: "diag-fix-qm", kind: "install-quarkus-metrics", label: "Add Quarkus metrics with Copilot" });
+    }
   } else {
-    msg = "The running app doesn\u2019t expose a metrics endpoint, so there are no live JVM metrics to show.";
+    lines.push(
+      feature === "loggers"
+        ? '<p class="hint">Live log-level control works only for Spring Boot apps (Actuator <code>/loggers</code>) or Quarkus apps (the <code>quarkus-logging-manager</code> extension).</p>'
+        : '<p class="hint">Live JVM metrics need a Spring Boot app (Actuator or BootUI) or a Quarkus app (Micrometer).</p>',
+    );
   }
-  const key = (appDown ? "down" : "noendpoint") + ":" + (fix || "none") + ":" + (metricsFixAsked ? "asked" : "open");
-  if (key === metricsInactiveKey) return;
-  metricsInactiveKey = key;
-  let html = `<p class="muted">${msg}</p>`;
-  if (fix) {
-    html += metricsFixAsked
-      ? '<button class="fix fix-copilot tiny" style="margin-top: 0.4rem" disabled>Asked Copilot \u2713</button>'
-      : `<button id="metrics-fix" class="fix fix-copilot tiny" style="margin-top: 0.4rem">${fixLabel}</button>`;
+  return { lines, fixes };
+}
+
+// Stable signature of an inactive view, so an identical re-render is skipped.
+function diagnosticInactiveKey(lead, body, asked) {
+  return [lead, body.lines.join("|"), body.fixes.map((f) => f.kind).join(","), [...asked].sort().join(",")].join("::");
+}
+
+// Paint an inactive diagnostic pane: a lead line (why it's greyed right now) then the
+// dependency status/fix block. Each pending fix becomes an orange button that posts its
+// Copilot fix and flips to "Asked Copilot \u2713"; already-asked fixes render disabled.
+function paintDiagnosticInactive(targetEl, lead, body, asked) {
+  let html = lead ? `<p class="muted">${lead}</p>` : "";
+  html += body.lines.join("");
+  if (body.fixes.length) {
+    html += '<div class="set-proposals" style="margin-top: 0.5rem">';
+    for (const f of body.fixes) {
+      html += asked.has(f.kind)
+        ? '<button class="fix fix-copilot tiny" disabled>Asked Copilot \u2713</button>'
+        : `<button id="${f.id}" class="fix fix-copilot tiny">${f.label}</button>`;
+    }
+    html += "</div>";
   }
-  metricsEl.innerHTML = html;
-  metricsHint.hidden = true;
-  const btn = fix && document.getElementById("metrics-fix");
-  if (btn) {
+  targetEl.innerHTML = html;
+  for (const f of body.fixes) {
+    if (asked.has(f.kind)) continue;
+    const btn = document.getElementById(f.id);
+    if (!btn) continue;
     btn.onclick = () => {
-      metricsFixAsked = true;
-      metricsInactiveKey = null;
+      asked.add(f.kind);
       btn.disabled = true;
       btn.textContent = "Asked Copilot \u2713";
-      post("/api/fix", { kind: fix, module: moduleSelect.value });
+      post("/api/fix", { kind: f.kind, module: moduleSelect.value });
     };
   }
+}
+
+// Render the Live JVM pane's inactive view (app down, or running without a metrics
+// endpoint).
+function renderMetricsInactive(appDown) {
+  const body = diagnosticInactiveBody("metrics", appDown);
+  const lead = appDown ? "The app isn\u2019t running." : "The running app exposes no metrics endpoint.";
+  const key = diagnosticInactiveKey(lead, body, metricsAskedKinds);
+  if (key === metricsInactiveKey) return;
+  metricsInactiveKey = key;
+  paintDiagnosticInactive(metricsEl, lead, body, metricsAskedKinds);
+  metricsHint.hidden = true;
 }
 function renderMetrics(m) {
   const nowUp = !!(m && m.appUp);
@@ -1310,7 +1369,7 @@ function renderMetrics(m) {
   // Real metrics: the tab is active again, so clear the inactive-view guard and
   // restore the contextual hint that the active tiers populate below.
   metricsInactiveKey = null;
-  metricsFixAsked = false;
+  metricsAskedKinds.clear();
   metricsHint.hidden = false;
 
   const o = m.overview || {};
@@ -1918,11 +1977,11 @@ const LOGGER_LEVELS = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 let appRunning = false;
 let loggersData = null;
 let loggersTimer = null;
-// Tracks whether the user already pressed "Fix with Copilot" on the current
-// no-endpoint view, so the 5s poll re-render doesn't reset the button. Cleared when
-// the app goes down or loggers become available. loggersUnavailKey guards against
-// rebuilding an identical unavailable view on every poll.
-let loggersFixAsked = false;
+// loggersAskedKinds remembers which "Add … with Copilot" fixes were pressed on the
+// current inactive view so the 5s poll re-render doesn't reset them; cleared when the
+// app goes down or loggers become available. loggersUnavailKey guards against
+// rebuilding an identical inactive view on every poll.
+const loggersAskedKinds = new Set();
 let loggersUnavailKey = null;
 
 function loggersTabActive() {
@@ -1957,23 +2016,15 @@ async function loadLoggers() {
 
 function renderLoggers(data, force) {
   if (!data || data.appDown) {
-    loggersSrc.hidden = true;
-    loggersControls.hidden = true;
-    loggersListEl.innerHTML =
-      '<p class="muted">The app isn\u2019t running.</p>' +
-      '<p class="hint">Run a Spring Boot app (Actuator <code>/loggers</code>) or a Quarkus app with the ' +
-      "logging-manager extension to change its log levels here live, no restart.</p>";
-    loggersData = null;
-    loggersFixAsked = false;
-    loggersUnavailKey = null;
+    renderLoggersInactive(true);
     return;
   }
   if (!data.available) {
-    renderLoggersUnavailable(data.runMode);
+    renderLoggersInactive(false);
     return;
   }
   loggersData = data;
-  loggersFixAsked = false;
+  loggersAskedKinds.clear();
   loggersUnavailKey = null;
   loggersSrc.hidden = false;
   const quarkus = data.source === "quarkus";
@@ -1986,51 +2037,19 @@ function renderLoggers(data, force) {
   renderLoggersList();
 }
 
-// The app is up but exposes no runtime-logger endpoint. Tailor the hint to the
-// framework: Spring Boot and Quarkus each get a one-click "Fix with Copilot" that
-// asks the agent to add the missing dependency; anything else just explains the
-// feature only works for those two.
-function renderLoggersUnavailable(runMode) {
+// Render the Loggers pane's inactive view (app down, or running without a runtime
+// logger endpoint), sharing the dependency status/fix block with Live JVM so the two
+// diagnostic panes stay consistent.
+function renderLoggersInactive(appDown) {
   loggersSrc.hidden = true;
   loggersControls.hidden = true;
   loggersData = null;
-  const key = (runMode || "other") + ":" + (loggersFixAsked ? "asked" : "open");
+  const body = diagnosticInactiveBody("loggers", appDown);
+  const lead = appDown ? "The app isn\u2019t running." : "The running app exposes no runtime-logger endpoint.";
+  const key = diagnosticInactiveKey(lead, body, loggersAskedKinds);
   if (key === loggersUnavailKey) return;
   loggersUnavailKey = key;
-  let html;
-  let fix = null;
-  if (runMode === "spring") {
-    html =
-      '<p class="muted">No Spring Boot Actuator <code>/loggers</code> endpoint is exposed on the running app, ' +
-      "so log levels can\u2019t be changed here.</p>" +
-      '<p class="hint">Add Spring Boot Actuator from the <strong>Spring</strong> tab, then expose it ' +
-      "(<code>management.endpoints.web.exposure.include=loggers</code>) and run the app again.</p>";
-  } else if (runMode === "quarkus") {
-    html =
-      '<p class="muted">No Quarkus logging-manager endpoint is exposed on the running app, so log levels ' +
-      "can\u2019t be changed here. Add the <code>quarkus-logging-manager</code> extension.</p>";
-    fix = "install-logging-manager";
-  } else {
-    html =
-      '<p class="muted">Live log-level control works only for Spring Boot apps (via the Actuator ' +
-      "<code>/loggers</code> endpoint) or Quarkus apps (via the <code>quarkus-logging-manager</code> extension).</p>";
-  }
-  if (fix) {
-    html += loggersFixAsked
-      ? '<button class="fix fix-copilot tiny" style="margin-top: 0.4rem" disabled>Asked Copilot \u2713</button>'
-      : '<button id="loggers-fix" class="fix fix-copilot tiny" style="margin-top: 0.4rem">Fix with Copilot</button>';
-  }
-  loggersListEl.innerHTML = html;
-  const btn = fix && document.getElementById("loggers-fix");
-  if (btn) {
-    btn.onclick = () => {
-      loggersFixAsked = true;
-      loggersUnavailKey = null;
-      btn.disabled = true;
-      btn.textContent = "Asked Copilot \u2713";
-      post("/api/fix", { kind: fix, module: moduleSelect.value });
-    };
-  }
+  paintDiagnosticInactive(loggersListEl, lead, body, loggersAskedKinds);
 }
 
 function renderLoggersList() {

--- a/public/app.js
+++ b/public/app.js
@@ -2056,9 +2056,9 @@ function renderLoggers(data, force) {
   loggersAskedKinds.clear();
   loggersUnavailKey = null;
   loggersSrc.hidden = false;
-  const quarkus = data.source === "quarkus";
-  loggersSrc.className = quarkus ? "src quarkus" : "src actuator";
-  loggersSrc.textContent = quarkus ? "Quarkus" : "Actuator";
+  loggersSrc.className =
+    "src " + (data.source === "quarkus" ? "quarkus" : data.source === "bootui" ? "bootui" : "actuator");
+  loggersSrc.textContent = data.source === "quarkus" ? "Quarkus" : data.source === "bootui" ? "BootUI" : "Actuator";
   loggersControls.hidden = false;
   // Don't rebuild the list out from under the user while they're using it
   // (an open select or focused search box) unless explicitly forced.

--- a/public/app.js
+++ b/public/app.js
@@ -1353,7 +1353,7 @@ function renderMetrics(m) {
     lastHeapPct = 0;
     metricsSrc.hidden = true;
     renderMcp(null);
-    renderScans(false);
+    renderScans(false, true);
     renderMetricsInactive(true);
     return;
   }
@@ -1365,7 +1365,7 @@ function renderMetrics(m) {
   if (tier === "process") {
     lastHeapPct = 0;
     renderMcp(null);
-    renderScans(false);
+    renderScans(false, false);
     renderMetricsInactive(false);
     return;
   }
@@ -1425,12 +1425,12 @@ function renderMetrics(m) {
       ? "Metrics read from Quarkus Micrometer (<code>/q/metrics</code>) and SmallRye Health (<code>/q/health</code>)."
       : "Health read from Quarkus SmallRye Health (<code>/q/health</code>). Add <code>quarkus-micrometer-registry-prometheus</code> to surface heap, threads and uptime here.";
     renderMcp(null);
-    renderScans(false);
+    renderScans(false, false);
   } else {
     metricsHint.innerHTML =
       "Metrics normalized from Spring Boot <code>/actuator/**</code>. Add BootUI for advisor scans and richer detail.";
     renderMcp(null);
-    renderScans(false);
+    renderScans(false, false);
   }
 }
 
@@ -1520,12 +1520,28 @@ function renderScanPlaceholders() {
     ).join("");
 }
 
-function renderScans(available) {
+// Inactive Advisor-scans message, consistent with the Live JVM / Loggers panes:
+// a lead line (why the tab is greyed right now) then the BootUI dependency story.
+// Advisor scans are BootUI-only, so when BootUI is set up we just say so; otherwise
+// we point at the "Add BootUI with Copilot" CTA above (Spring) or explain the gap.
+function scansInactiveHtml(appDown) {
+  const mod = selectedRunModule();
+  const lead = `<p class="muted">${appDown ? "The app isn\u2019t running." : "The running app has no BootUI endpoint."}</p>`;
+  if (mod && mod.springBoot) {
+    if (mod.bootui) {
+      const next = appDown ? "run the app to use this tab" : "expose its endpoints and restart to use this tab";
+      return `${lead}<p class="muted ok">\u2713 BootUI is set up \u2014 ${next}.</p>`;
+    }
+    return `${lead}<p class="hint">Advisor scans need BootUI \u2014 add it above, then run the app.</p>`;
+  }
+  return `${lead}<p class="hint">Advisor scans need a <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a>-enabled Spring Boot app.</p>`;
+}
+
+function renderScans(available, appDown = true) {
   if (!available) {
     scansLoaded = false;
     scansSrc.hidden = true;
-    scansHint.innerHTML =
-      'Start a <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a> app (dev profile) with <strong>Run</strong> to run its advisor scans against the live app.';
+    scansHint.innerHTML = scansInactiveHtml(appDown);
     renderScanPlaceholders();
     scansResultEl.innerHTML = "";
     markScanResults(false);

--- a/public/app.js
+++ b/public/app.js
@@ -194,6 +194,11 @@ const scansSrc = document.getElementById("scans-src");
 const scansHint = document.getElementById("scans-hint");
 const scansListEl = document.getElementById("scans-list");
 const scansResultEl = document.getElementById("scans-result");
+const depsScanBtn = document.getElementById("deps-scan");
+const depsDirectToggle = document.getElementById("deps-direct-toggle");
+const depsDirectInput = document.getElementById("deps-direct");
+const depsResultEl = document.getElementById("deps-result");
+const depsSrc = document.getElementById("deps-src");
 let caps = {};
 // Whether a Maven/Gradle build tool is present. When false the canvas runs
 // in degraded mode: Build/Test/Package/Run stay disabled.
@@ -387,18 +392,26 @@ function showAsideTab(name) {
   document.getElementById("atab-scans").classList.toggle("active", name === "scans");
   document.getElementById("atab-quarkus").classList.toggle("active", name === "quarkus");
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
+  document.getElementById("atab-deps").classList.toggle("active", name === "deps");
+  if (name === "deps") initDeps();
   syncLoggersPolling();
   syncAsideWide();
 }
-// BootUI scan reports can be wide (severity badges + expandable findings), so the
-// aside grows to a roomier width while scan results are on screen and snaps back
-// to its slim default on any other tab. The default stays the minimal width.
+// BootUI scan reports and the dependency/upgrade list can be wide (severity badges
+// + expandable findings), so the aside grows to a roomier width while either is on
+// screen and snaps back to its slim default on any other tab.
 let hasScanResults = false;
+let hasDepsResults = false;
 function syncAsideWide() {
-  workspaceEl.classList.toggle("aside-wide", activeAsideTab() === "scans" && hasScanResults);
+  const tab = activeAsideTab();
+  workspaceEl.classList.toggle("aside-wide", (tab === "scans" && hasScanResults) || (tab === "deps" && hasDepsResults));
 }
 function markScanResults(on) {
   hasScanResults = on;
+  syncAsideWide();
+}
+function markDepsResults(on) {
+  hasDepsResults = on;
   syncAsideWide();
 }
 // Capture the current panel state as the persisted preference and save it. The
@@ -414,7 +427,7 @@ function rememberAsideState() {
 function applyAsideState(s) {
   if (asideStateApplied || !s) return;
   asideStateApplied = true;
-  asideTabPref = ["metrics", "loggers", "spring", "scans", "quarkus", "settings"].includes(s.asideTab)
+  asideTabPref = ["metrics", "loggers", "spring", "scans", "quarkus", "settings", "deps"].includes(s.asideTab)
     ? s.asideTab
     : "settings";
   asideOpenPref = s.asideOpen === true;
@@ -472,11 +485,12 @@ syncAsideMode();
 // each group the tabs keep a fixed canonical order (ASIDE_ORDER) so they never
 // shuffle relative to one another. Clicking a greyed tab still opens it so its
 // in-panel text explains what's missing.
-const ASIDE_ALWAYS = new Set(["settings"]);
+const ASIDE_ALWAYS = new Set(["settings", "deps"]);
 // Canonical left-to-right order, applied within both the available and the
 // unavailable group. Settings always leads the available group (it's never
-// unavailable); "quarkus" takes the trailing slot for the Quarkus Agent MCP tab.
-const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "scans", "quarkus"];
+// unavailable); Upgrades (deps) is always available and trails the runtime tabs;
+// "quarkus" takes the trailing slot for the Quarkus Agent MCP tab.
+const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "scans", "deps", "quarkus"];
 const ASIDE_REASON = {
   metrics:
     "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
@@ -1638,6 +1652,139 @@ quarkusMcpRegisterBtn.onclick = async () => {
   quarkusMcpRegisterBtn.textContent = "Asked Copilot \u2713";
   await post("/api/fix", { kind: "register-quarkus-mcp", runner: quarkusMcpRegisterBtn.dataset.runner || "jbang" });
 };
+
+// ---- Dependencies & upgrades (Upgrades aside tab) ----------------------
+// The outdated-libraries scan shells out to the build tool on demand. We fetch
+// the cached snapshot when the tab is first opened, and only run the slow version
+// scan when the user clicks "Check dependencies".
+let depsState = null;
+let depsLoaded = false;
+
+async function initDeps() {
+  if (depsLoaded) return;
+  depsLoaded = true;
+  renderDeps(await getJson("/api/deps"));
+}
+
+async function runDepsScan() {
+  if (!depsScanBtn) return;
+  depsScanBtn.disabled = true;
+  const orig = depsScanBtn.textContent;
+  depsScanBtn.textContent = "Checking\u2026";
+  depsResultEl.innerHTML = `<div class="deps-section"><h3>Outdated libraries</h3><p class="muted">Scanning\u2026 resolving the latest available versions (this can take a while).</p></div>`;
+  markDepsResults(false);
+  const r = await postJson("/api/deps/scan", {});
+  depsScanBtn.disabled = false;
+  depsScanBtn.textContent = orig;
+  renderDeps(r);
+}
+
+function renderDeps(report) {
+  if (!report || !report.counts) {
+    // A genuine report always carries a counts block; a fetch failure returns { error }.
+    depsResultEl.innerHTML = `<p class="deps-error">Couldn't load the dependency report${report && report.error ? ": " + esc(report.error) : ""}.</p>`;
+    return;
+  }
+  depsState = report;
+  depsResultEl.innerHTML = updatesSectionHtml(report);
+
+  // The "Direct only" toggle is meaningful only once a scan found transitive
+  // updates to hide.
+  const hasTransitive = !!(report.ran && report.counts && report.counts.transitive > 0);
+  if (depsDirectInput) depsDirectInput.disabled = !hasTransitive;
+  if (depsDirectToggle) depsDirectToggle.classList.toggle("disabled", !hasTransitive);
+
+  const outdated = report.counts ? report.counts.total : 0;
+  if (depsSrc) {
+    if (report.ran && outdated > 0) {
+      depsSrc.textContent = `${outdated} outdated`;
+      depsSrc.hidden = false;
+    } else {
+      depsSrc.hidden = true;
+    }
+  }
+  markDepsResults(!!(report.ran && report.updates && report.updates.length));
+
+  depsResultEl
+    .querySelectorAll("button[data-dep-fix]")
+    .forEach((b) => (b.onclick = () => fixDep(Number(b.dataset.depFix), b)));
+}
+
+function updatesSectionHtml(report) {
+  const head = (extra = "") => `<div class="deps-section-head"><h3>Outdated libraries</h3>${extra}</div>`;
+  if (!report.updatesSupported) {
+    return (
+      `<div class="deps-section">${head()}` +
+      `<p class="hint">Outdated-library scanning currently supports Maven projects${report.buildTool ? ` (this is a ${esc(report.buildTool)} project)` : ""}.</p></div>`
+    );
+  }
+  if (!report.ran) {
+    return (
+      `<div class="deps-section">${head()}` +
+      `<p class="hint">Click <strong>Check dependencies</strong> to scan for newer library versions.</p></div>`
+    );
+  }
+  if (report.error && (!report.updates || !report.updates.length)) {
+    return `<div class="deps-section">${head()}<p class="deps-error">Scan failed: ${esc(report.error)}</p></div>`;
+  }
+  if (!report.updates.length) {
+    return `<div class="deps-section">${head()}<p class="deps-ok">\u2713 All libraries are up to date.</p></div>`;
+  }
+  const counts = `<span class="deps-counts">${report.counts.direct} direct \u00b7 ${report.counts.transitive} transitive</span>`;
+  const directOnly = !!(depsDirectInput && depsDirectInput.checked);
+  const rows = report.updates.map((u, i) => (directOnly && !u.direct ? "" : depRowHtml(u, i))).join("");
+  const body = rows
+    ? `<div class="dep-list">${rows}</div>`
+    : `<p class="hint">No direct dependencies are outdated. Untick \u201cDirect only\u201d to see transitive ones.</p>`;
+  return `<div class="deps-section">${head(counts)}${body}</div>`;
+}
+
+function depRowHtml(u, i) {
+  const scopeBadge = u.direct
+    ? `<span class="dep-scope direct">direct</span>`
+    : `<span class="dep-scope transitive">transitive</span>`;
+  const preBadge = u.prerelease
+    ? `<span class="dep-pre" title="The latest version is a pre-release">pre-release</span>`
+    : "";
+  const via =
+    !u.direct && u.via
+      ? `<div class="finding-kv"><span class="fk">Pulled in by</span><span class="fv"><code>${esc(u.via)}</code></span></div>`
+      : "";
+  return (
+    `<details class="dep-item" data-dep="${i}"><summary>` +
+    `<span class="jump-badge jump-${esc(u.jump)}" title="${esc(u.jump)} version change">${esc(u.jump)}</span>` +
+    `<span class="finding-title">${esc(u.artifact)}</span>` +
+    `<span class="dep-ver"><span class="ver-old">${esc(u.current)}</span><span class="ver-arrow">\u2192</span><span class="ver-new">${esc(u.latest)}</span></span>` +
+    scopeBadge +
+    `</summary><div class="finding-body">` +
+    `<div class="finding-kv"><span class="fk">Coordinates</span><span class="fv"><code>${esc(u.group)}:${esc(u.artifact)}</code></span></div>` +
+    `<div class="finding-kv"><span class="fk">Latest</span><span class="fv">${esc(u.latest)} ${preBadge}</span></div>` +
+    `<div class="finding-kv"><span class="fk">Scope</span><span class="fv">${esc(u.scope)}</span></div>` +
+    via +
+    `<button class="fix fix-copilot tiny" data-dep-fix="${i}">Fix with Copilot</button>` +
+    `</div></details>`
+  );
+}
+
+async function fixDep(i, btn) {
+  const u = depsState && depsState.updates && depsState.updates[i];
+  if (!u) return;
+  btn.disabled = true;
+  btn.textContent = "Sent to Copilot \u2713";
+  await post("/api/fix", {
+    kind: "fix-dependency",
+    group: u.group,
+    artifact: u.artifact,
+    current: u.current,
+    latest: u.latest,
+    direct: u.direct,
+    scope: u.direct ? "direct" : "transitive",
+    via: u.via,
+  });
+}
+
+if (depsScanBtn) depsScanBtn.onclick = runDepsScan;
+if (depsDirectInput) depsDirectInput.onchange = () => renderDeps(depsState);
 
 // ---- Runtime log levels (Loggers aside tab) ----------------------------
 // Lists the running app's loggers from Spring Boot Actuator /loggers or the Quarkus

--- a/public/app.js
+++ b/public/app.js
@@ -77,10 +77,11 @@ const btnAddBootui = document.getElementById("btn-add-bootui");
 const btnAddDevtools = document.getElementById("btn-add-devtools");
 const btnAddActuator = document.getElementById("btn-add-actuator");
 const actuatorStatus = document.getElementById("actuator-status");
-const actuatorHint = document.getElementById("actuator-hint");
-const actuatorBootuiStatus = document.getElementById("actuator-bootui-status");
 const bootuiDesc = document.getElementById("bootui-desc");
 const bootuiConfigured = document.getElementById("bootui-configured");
+const btnAddBootuiSpring = document.getElementById("btn-add-bootui-spring");
+const bootuiSpringHint = document.getElementById("bootui-spring-hint");
+const bootuiSpringStatus = document.getElementById("bootui-spring-status");
 const setJdtls = document.getElementById("set-jdtls");
 const jdtlsDot = document.getElementById("jdtls-dot");
 const jdtlsStateEl = document.getElementById("jdtls-state");
@@ -99,6 +100,7 @@ const devtoolsInput = document.getElementById("in-devtools");
 const devtoolsActions = document.getElementById("devtools-actions");
 const springVersionEl = document.getElementById("spring-version");
 const springActuatorSection = document.getElementById("spring-actuator-section");
+const springBootuiSection = document.getElementById("spring-bootui-section");
 const springDevtoolsSection = document.getElementById("spring-devtools-section");
 const btnUpgradeSpring = document.getElementById("btn-upgrade-spring");
 const btnReload = document.getElementById("btn-reload");
@@ -2422,40 +2424,21 @@ function updateDevSetup() {
   profileItems = quarkus ? quarkusItems : springItems;
 
   // The Spring Boot tab is greyed (inactive) when the project has no Spring Boot
-  // module at all; its Actuator/DevTools sections are meaningless then, so hide
-  // them and let renderSpringAdvisor show the "not a Spring Boot project" reason.
+  // module at all; its Actuator/BootUI/DevTools sections are meaningless then, so
+  // hide them and let renderSpringAdvisor show the "not a Spring Boot project" reason.
+  // BootUI bundles Actuator, so when BootUI is configured the Actuator part is hidden
+  // and the BootUI part below confirms the richer tier instead.
+  const hasBootui = !!(mod && mod.bootui);
+  const hasActuator = spring && !!mod.actuator;
   const springProject = !!(caps && caps.springBoot);
-  if (springActuatorSection) springActuatorSection.hidden = !springProject;
+  if (springActuatorSection) springActuatorSection.hidden = !springProject || hasBootui;
+  if (springBootuiSection) springBootuiSection.hidden = !springProject;
   if (springDevtoolsSection) springDevtoolsSection.hidden = !springProject;
 
-  // Activate-BootUI CTA: only available — shown and enabled — for a Spring Boot
-  // module that doesn't depend on BootUI yet. Hidden for non-Spring apps and once
-  // the module already has BootUI (since it's then active).
-  const hasBootui = !!(mod && mod.bootui);
-  const canAddBootui = spring && !hasBootui;
-  btnAddBootui.hidden = !canAddBootui;
-  btnAddBootui.disabled = !canAddBootui;
-  btnAddBootui.textContent = "Add BootUI with Copilot";
-  btnAddBootui.title = caps.gradle
-    ? "Ask Copilot to add the BootUI starter to this module's developmentOnly configuration to unlock its console, richer metrics and advisor scans."
-    : "Ask Copilot to add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
-  // BootUI panel (scans tab): once the module depends on BootUI, confirm it instead
-  // of pitching the "add the starter" description.
-  if (bootuiConfigured) bootuiConfigured.hidden = !hasBootui;
-  if (bootuiDesc) bootuiDesc.hidden = hasBootui;
-
-  // Actuator section (Spring Boot tab): offer to add Actuator for a Spring Boot
-  // module that doesn't depend on it yet (it backs both the Live JVM metrics and
-  // the Loggers tab); otherwise confirm it's already on the classpath. BootUI
-  // bundles Actuator, so when BootUI is configured we suppress the Actuator hint /
-  // add button entirely and confirm BootUI covers it instead.
-  const hasActuator = spring && !!mod.actuator;
-  const showActuatorBootui = spring && hasBootui;
-  const showActuatorStatus = hasActuator && !hasBootui;
-  const showAddActuator = spring && !mod.actuator && !hasBootui;
-  if (actuatorHint) actuatorHint.hidden = showActuatorBootui;
-  if (actuatorStatus) actuatorStatus.hidden = !showActuatorStatus;
-  if (actuatorBootuiStatus) actuatorBootuiStatus.hidden = !showActuatorBootui;
+  // Actuator section (shown only while BootUI is absent): confirm Actuator is on the
+  // classpath, or offer to add it (it backs the Live JVM metrics and Loggers tabs).
+  const showAddActuator = spring && !hasActuator && !hasBootui;
+  if (actuatorStatus) actuatorStatus.hidden = !(hasActuator && !hasBootui);
   btnAddActuator.hidden = !showAddActuator;
   if (showAddActuator) {
     btnAddActuator.disabled = false;
@@ -2463,6 +2446,31 @@ function updateDevSetup() {
     btnAddActuator.title =
       "Ask Copilot to add the Spring Boot Actuator starter and expose its endpoints so the Live JVM and Loggers tabs work.";
   }
+
+  // BootUI section (Spring Boot tab): confirm BootUI once configured, otherwise offer
+  // to add it — shown below the Actuator part so a Spring app without either gets both
+  // CTAs. The "richer metrics + advisor scans" pitch hides once it's set up.
+  const canAddBootui = spring && !hasBootui;
+  const bootuiTitle = caps.gradle
+    ? "Ask Copilot to add the BootUI starter to this module's developmentOnly configuration to unlock its console, richer metrics and advisor scans."
+    : "Ask Copilot to add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
+  if (bootuiSpringHint) bootuiSpringHint.hidden = hasBootui;
+  if (bootuiSpringStatus) bootuiSpringStatus.hidden = !hasBootui;
+  if (btnAddBootuiSpring) {
+    btnAddBootuiSpring.hidden = !canAddBootui;
+    btnAddBootuiSpring.disabled = !canAddBootui;
+    btnAddBootuiSpring.textContent = "Add BootUI with Copilot";
+    btnAddBootuiSpring.title = bootuiTitle;
+  }
+
+  // BootUI panel (scans tab): the same Add-BootUI CTA in its advisor-scans context,
+  // and a "configured" confirmation that replaces the "add the starter" description.
+  btnAddBootui.hidden = !canAddBootui;
+  btnAddBootui.disabled = !canAddBootui;
+  btnAddBootui.textContent = "Add BootUI with Copilot";
+  btnAddBootui.title = bootuiTitle;
+  if (bootuiConfigured) bootuiConfigured.hidden = !hasBootui;
+  if (bootuiDesc) bootuiDesc.hidden = hasBootui;
 
   // DevTools section (Spring Boot tab): show the live-reload toggle + manual
   // actions once DevTools is on the classpath, otherwise offer to add it.
@@ -3117,11 +3125,18 @@ btnOpenBrowser.onclick = () => post("/api/open-app", {});
 moduleSelect.addEventListener("change", () => {
   updateDevSetup();
 });
-btnAddBootui.onclick = async () => {
-  btnAddBootui.disabled = true;
-  btnAddBootui.textContent = "Asked Copilot \u2713";
+// Both BootUI CTAs (Spring tab + scans tab) trigger the same install-bootui fix, so
+// asking from either flips both to the asked state.
+async function askInstallBootui() {
+  for (const b of [btnAddBootui, btnAddBootuiSpring]) {
+    if (!b) continue;
+    b.disabled = true;
+    b.textContent = "Asked Copilot \u2713";
+  }
   await post("/api/fix", { kind: "install-bootui", module: moduleSelect.value });
-};
+}
+btnAddBootui.onclick = askInstallBootui;
+if (btnAddBootuiSpring) btnAddBootuiSpring.onclick = askInstallBootui;
 btnAddDevtools.onclick = async () => {
   btnAddDevtools.disabled = true;
   btnAddDevtools.textContent = "Asked Copilot \u2713";

--- a/public/app.js
+++ b/public/app.js
@@ -1526,15 +1526,16 @@ function renderScanPlaceholders() {
 
 // Inactive Advisor-scans message, consistent with the Live JVM / Loggers panes:
 // a lead line (why the tab is greyed right now) then the BootUI dependency story.
-// Advisor scans are BootUI-only, so when BootUI is set up we just say so; otherwise
-// we point at the "Add BootUI with Copilot" CTA above (Spring) or explain the gap.
+// When BootUI is set up the pane title already confirms it, so the inactive body
+// just gives the next step; otherwise we point at the "Add BootUI with Copilot"
+// CTA above (Spring) or explain the gap.
 function scansInactiveHtml(appDown) {
   const mod = selectedRunModule();
   const lead = `<p class="muted">${appDown ? "The app isn\u2019t running." : "The running app has no BootUI endpoint."}</p>`;
   if (mod && mod.springBoot) {
     if (mod.bootui) {
-      const next = appDown ? "run the app to use this tab" : "expose its endpoints and restart to use this tab";
-      return `${lead}<p class="muted ok">\u2713 BootUI is set up \u2014 ${next}.</p>`;
+      const next = appDown ? "Run the app to use this tab" : "Expose its endpoints and restart to use this tab";
+      return `${lead}<p class="muted">${next}.</p>`;
     }
     return `${lead}<p class="hint">Advisor scans need BootUI \u2014 add it above, then run the app.</p>`;
   }

--- a/public/app.js
+++ b/public/app.js
@@ -2323,9 +2323,10 @@ function updateDevSetup() {
   const canAddBootui = spring && !hasBootui;
   btnAddBootui.hidden = !canAddBootui;
   btnAddBootui.disabled = !canAddBootui;
-  btnAddBootui.textContent = caps.gradle ? "Add BootUI (developmentOnly)" : "Add BootUI to dev profile";
-  btnAddBootui.title =
-    "Add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
+  btnAddBootui.textContent = "Add BootUI with Copilot";
+  btnAddBootui.title = caps.gradle
+    ? "Ask Copilot to add the BootUI starter to this module's developmentOnly configuration to unlock its console, richer metrics and advisor scans."
+    : "Ask Copilot to add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
 
   // Actuator section (Spring Boot tab): offer to add Actuator for a Spring Boot
   // module that doesn't depend on it yet (it backs both the Live JVM metrics and
@@ -2336,7 +2337,9 @@ function updateDevSetup() {
   btnAddActuator.hidden = !showAddActuator;
   if (showAddActuator) {
     btnAddActuator.disabled = false;
-    btnAddActuator.textContent = "Add Actuator";
+    btnAddActuator.textContent = "Add Actuator with Copilot";
+    btnAddActuator.title =
+      "Ask Copilot to add the Spring Boot Actuator starter and expose its endpoints so the Live JVM and Loggers tabs work.";
   }
 
   // DevTools section (Spring Boot tab): show the live-reload toggle + manual
@@ -2350,7 +2353,10 @@ function updateDevSetup() {
   btnAddDevtools.hidden = !showAddDevtools;
   if (showAddDevtools) {
     btnAddDevtools.disabled = false;
-    btnAddDevtools.textContent = caps.gradle ? "Add DevTools (developmentOnly)" : "Add DevTools to dev profile";
+    btnAddDevtools.textContent = "Add DevTools with Copilot";
+    btnAddDevtools.title = caps.gradle
+      ? "Ask Copilot to add Spring Boot DevTools to this module's developmentOnly configuration and enable live reload."
+      : "Ask Copilot to add Spring Boot DevTools to a dev-only Maven profile and enable live reload.";
   }
 
   // Keep the Spring Boot tab's availability in step with the build files (it's

--- a/public/app.js
+++ b/public/app.js
@@ -397,10 +397,10 @@ function setAsideOpen(open) {
 }
 function showAsideTab(name) {
   document.querySelectorAll(".atab").forEach((t) => t.classList.toggle("active", t.dataset.atab === name));
-  document.getElementById("atab-metrics").classList.toggle("active", name === "metrics");
+  document.getElementById("atab-jvm").classList.toggle("active", name === "jvm");
   document.getElementById("atab-loggers").classList.toggle("active", name === "loggers");
   document.getElementById("atab-spring").classList.toggle("active", name === "spring");
-  document.getElementById("atab-scans").classList.toggle("active", name === "scans");
+  document.getElementById("atab-bootui").classList.toggle("active", name === "bootui");
   document.getElementById("atab-quarkus").classList.toggle("active", name === "quarkus");
   document.getElementById("atab-settings").classList.toggle("active", name === "settings");
   document.getElementById("atab-deps").classList.toggle("active", name === "deps");
@@ -415,7 +415,10 @@ let hasScanResults = false;
 let hasDepsResults = false;
 function syncAsideWide() {
   const tab = activeAsideTab();
-  workspaceEl.classList.toggle("aside-wide", (tab === "scans" && hasScanResults) || (tab === "deps" && hasDepsResults));
+  workspaceEl.classList.toggle(
+    "aside-wide",
+    (tab === "bootui" && hasScanResults) || (tab === "deps" && hasDepsResults),
+  );
 }
 function markScanResults(on) {
   hasScanResults = on;
@@ -438,7 +441,7 @@ function rememberAsideState() {
 function applyAsideState(s) {
   if (asideStateApplied || !s) return;
   asideStateApplied = true;
-  asideTabPref = ["metrics", "loggers", "spring", "scans", "quarkus", "settings", "deps"].includes(s.asideTab)
+  asideTabPref = ["jvm", "loggers", "spring", "bootui", "quarkus", "settings", "deps"].includes(s.asideTab)
     ? s.asideTab
     : "settings";
   asideOpenPref = s.asideOpen === true;
@@ -502,26 +505,25 @@ const ASIDE_ALWAYS = new Set(["settings", "deps"]);
 // never unavailable); Quarkus precedes BootUI and Upgrades (deps) trails. The same
 // sequence is used whether a tab is active or greyed — only the group it sits in
 // changes, with unavailable tabs pushed to the bottom.
-const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "quarkus", "scans", "deps"];
+const ASIDE_ORDER = ["settings", "jvm", "loggers", "spring", "quarkus", "bootui", "deps"];
 const ASIDE_REASON = {
-  metrics:
-    "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
+  jvm: "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
   loggers:
     "Live log levels need a running Spring Boot app (Actuator /loggers) or a Quarkus app with the logging-manager extension. Click to learn more.",
   spring:
     "The Spring Boot tab needs a Spring Boot module — version advisor and DevTools live reload. Click to learn more.",
-  scans: "The BootUI panel needs a running BootUI app — Run a module with the BootUI starter. Click to learn more.",
+  bootui: "The BootUI panel needs a running BootUI app — Run a module with the BootUI starter. Click to learn more.",
   quarkus:
     "The Quarkus panel needs a Quarkus module — open a Quarkus project to register its Agent MCP server with Copilot. Click to learn more.",
 };
-// metrics / loggers / scans are each gated on the running app exposing the right
-// capability (see updateAsideAvailability callers); the BootUI (scans) tab is
+// jvm / loggers / bootui are each gated on the running app exposing the right
+// capability (see updateAsideAvailability callers); the BootUI (bootui) tab is
 // available only while a BootUI app is actually up, exactly like the other two.
 // quarkus and spring are gated on the project (a Quarkus / Spring Boot module),
 // not the running app, so they come from caps rather than the metrics snapshot.
 // Each source updates only its own keys, so availabilities are merged rather than
 // replaced wholesale.
-const asideAvail = { metrics: false, loggers: false, scans: false, spring: false, quarkus: false };
+const asideAvail = { jvm: false, loggers: false, bootui: false, spring: false, quarkus: false };
 const asideTabsEl = document.querySelector(".aside-tabs");
 const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 // Skip the open animation: the first layout (and the test environment) should snap
@@ -1342,9 +1344,9 @@ function renderMetrics(m) {
   // reachable, so refresh the bar's availability on every snapshot.
   const tier = nowUp ? m.metricsTier || "process" : null;
   updateAsideAvailability({
-    metrics: nowUp && tier !== "process",
+    jvm: nowUp && tier !== "process",
     loggers: nowUp && (tier === "bootui" || tier === "actuator" || tier === "quarkus"),
-    scans: nowUp && tier === "bootui",
+    bootui: nowUp && tier === "bootui",
   });
   if (nowUp !== appRunning) {
     appRunning = nowUp;

--- a/public/app.js
+++ b/public/app.js
@@ -2503,7 +2503,7 @@ function updateDevSetup() {
 
 // --- Spring Boot version + EOL/upgrade advisor (Spring Boot tab) -------------
 // The backend (springBootAdvisor) reports the detected version, its release line
-// and a support status; we render it and gate the "Upgrade with Copilot" button.
+// and a support status; we render it and gate the "Update with Copilot" button.
 const SPRING_STATUS = {
   current: { label: "Latest release line", cls: "ok" },
   supported: { label: "Supported — a newer release line is available", cls: "warn" },
@@ -2545,8 +2545,8 @@ function renderSpringAdvisor(adv) {
   btnUpgradeSpring.hidden = !showUpgrade;
   if (showUpgrade) {
     btnUpgradeSpring.disabled = false;
-    btnUpgradeSpring.textContent = "Upgrade with Copilot";
-    btnUpgradeSpring.title = `Ask Copilot to upgrade from Spring Boot ${adv.version} to the latest stable release.`;
+    btnUpgradeSpring.textContent = "Update with Copilot";
+    btnUpgradeSpring.title = `Ask Copilot to update from Spring Boot ${adv.version} to the latest stable release.`;
   }
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -77,6 +77,10 @@ const btnAddBootui = document.getElementById("btn-add-bootui");
 const btnAddDevtools = document.getElementById("btn-add-devtools");
 const btnAddActuator = document.getElementById("btn-add-actuator");
 const actuatorStatus = document.getElementById("actuator-status");
+const actuatorHint = document.getElementById("actuator-hint");
+const actuatorBootuiStatus = document.getElementById("actuator-bootui-status");
+const bootuiDesc = document.getElementById("bootui-desc");
+const bootuiConfigured = document.getElementById("bootui-configured");
 const setJdtls = document.getElementById("set-jdtls");
 const jdtlsDot = document.getElementById("jdtls-dot");
 const jdtlsStateEl = document.getElementById("jdtls-state");
@@ -2419,13 +2423,23 @@ function updateDevSetup() {
   btnAddBootui.title = caps.gradle
     ? "Ask Copilot to add the BootUI starter to this module's developmentOnly configuration to unlock its console, richer metrics and advisor scans."
     : "Ask Copilot to add the BootUI starter to this module's dev profile to unlock its console, richer metrics and advisor scans.";
+  // BootUI panel (scans tab): once the module depends on BootUI, confirm it instead
+  // of pitching the "add the starter" description.
+  if (bootuiConfigured) bootuiConfigured.hidden = !hasBootui;
+  if (bootuiDesc) bootuiDesc.hidden = hasBootui;
 
   // Actuator section (Spring Boot tab): offer to add Actuator for a Spring Boot
   // module that doesn't depend on it yet (it backs both the Live JVM metrics and
-  // the Loggers tab); otherwise confirm it's already on the classpath.
+  // the Loggers tab); otherwise confirm it's already on the classpath. BootUI
+  // bundles Actuator, so when BootUI is configured we suppress the Actuator hint /
+  // add button entirely and confirm BootUI covers it instead.
   const hasActuator = spring && !!mod.actuator;
-  const showAddActuator = spring && !mod.actuator;
-  if (actuatorStatus) actuatorStatus.hidden = !hasActuator;
+  const showActuatorBootui = spring && hasBootui;
+  const showActuatorStatus = hasActuator && !hasBootui;
+  const showAddActuator = spring && !mod.actuator && !hasBootui;
+  if (actuatorHint) actuatorHint.hidden = showActuatorBootui;
+  if (actuatorStatus) actuatorStatus.hidden = !showActuatorStatus;
+  if (actuatorBootuiStatus) actuatorBootuiStatus.hidden = !showActuatorBootui;
   btnAddActuator.hidden = !showAddActuator;
   if (showAddActuator) {
     btnAddActuator.disabled = false;

--- a/public/app.js
+++ b/public/app.js
@@ -486,11 +486,12 @@ syncAsideMode();
 // shuffle relative to one another. Clicking a greyed tab still opens it so its
 // in-panel text explains what's missing.
 const ASIDE_ALWAYS = new Set(["settings", "deps"]);
-// Canonical left-to-right order, applied within both the available and the
-// unavailable group. Settings always leads the available group (it's never
-// unavailable); Upgrades (deps) is always available and trails the runtime tabs;
-// "quarkus" takes the trailing slot for the Quarkus Agent MCP tab.
-const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "scans", "deps", "quarkus"];
+// Canonical order, applied within both the available and the unavailable group so
+// the tabs never shuffle relative to one another. Settings always leads (it's
+// never unavailable); Quarkus precedes BootUI and Upgrades (deps) trails. The same
+// sequence is used whether a tab is active or greyed — only the group it sits in
+// changes, with unavailable tabs pushed to the bottom.
+const ASIDE_ORDER = ["settings", "metrics", "loggers", "spring", "quarkus", "scans", "deps"];
 const ASIDE_REASON = {
   metrics:
     "Live JVM metrics need a running app that exposes metrics — Spring Boot Actuator/BootUI or Quarkus Micrometer. Click to learn more.",
@@ -510,27 +511,77 @@ const ASIDE_REASON = {
 // Each source updates only its own keys, so availabilities are merged rather than
 // replaced wholesale.
 const asideAvail = { metrics: false, loggers: false, scans: false, spring: false, quarkus: false };
+const asideTabsEl = document.querySelector(".aside-tabs");
+const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+// Skip the open animation: the first layout (and the test environment) should snap
+// into place; only later availability changes glide.
+let asideOrderApplied = false;
+// The flex `order` for a tab: the available group (0+) sorts before the separator
+// (order 50), the unavailable group (100+) sinks below it. Within each group the
+// canonical ASIDE_ORDER index keeps the sequence fixed.
+function computeAsideOrder(name, ok) {
+  const rank = ASIDE_ORDER.indexOf(name);
+  return (ok ? 0 : 100) + (rank === -1 ? ASIDE_ORDER.length : rank);
+}
+// FLIP: flex `order` changes can't be CSS-animated, so when a tab crosses between
+// the available and unavailable group we measure its old slot, let it jump to the
+// new one, then translate it back and transition the translate away so it appears
+// to glide. `first` holds the pre-change rects in `tabs` order.
+function flipAsideTabs(tabs, first) {
+  const movers = [];
+  tabs.forEach((btn, i) => {
+    const last = btn.getBoundingClientRect();
+    const dx = first[i].left - last.left;
+    const dy = first[i].top - last.top;
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) return;
+    btn.style.transition = "none";
+    btn.style.transform = `translate(${dx}px, ${dy}px)`;
+    movers.push(btn);
+  });
+  if (!movers.length) return;
+  // Commit the inverted positions, then release them so each tab animates to its
+  // real slot (the forced reflow matches the pattern used elsewhere in this file).
+  if (asideTabsEl) void asideTabsEl.offsetWidth;
+  movers.forEach((btn) => {
+    btn.style.transition = "transform 200ms var(--ease-out)";
+    btn.style.transform = "";
+    const done = (e) => {
+      if (e.propertyName !== "transform") return;
+      btn.style.transition = "";
+      btn.removeEventListener("transitionend", done);
+    };
+    btn.addEventListener("transitionend", done);
+  });
+}
 function updateAsideAvailability(avail) {
   if (avail) Object.assign(asideAvail, avail);
-  let anyUnavailable = false;
-  document.querySelectorAll(".atab").forEach((btn) => {
+  const tabs = Array.from(document.querySelectorAll(".atab"));
+  const plan = tabs.map((btn) => {
     const name = btn.dataset.atab;
     const ok = ASIDE_ALWAYS.has(name) || !!asideAvail[name];
+    return { btn, name, ok, order: String(computeAsideOrder(name, ok)) };
+  });
+  // Only measure/animate when a tab actually moves group, and never on the first
+  // layout or when the user prefers reduced motion. Keeping the hot path (repeated
+  // metrics pushes with no change) free of layout reads avoids thrash.
+  const animate = asideOrderApplied && !reduceMotion.matches && plan.some((p) => p.btn.style.order !== p.order);
+  const first = animate ? tabs.map((b) => b.getBoundingClientRect()) : null;
+
+  let anyUnavailable = false;
+  plan.forEach(({ btn, name, ok, order }) => {
     if (!ok) anyUnavailable = true;
     btn.classList.toggle("unavailable", !ok);
     btn.setAttribute("aria-disabled", ok ? "false" : "true");
-    // Available group sorts before the unavailable group; the canonical index
-    // fixes the order within each group regardless of DOM order. The separator
-    // (.atab-sep, order 50) sits between the two ranges. Settings is first in
-    // ASIDE_ORDER, so it stays pinned to the top of the bar.
-    const rank = ASIDE_ORDER.indexOf(name);
-    btn.style.order = String((ok ? 0 : 100) + (rank === -1 ? ASIDE_ORDER.length : rank));
+    btn.style.order = order;
     if (!btn.dataset.titleAvail) btn.dataset.titleAvail = btn.getAttribute("title") || "";
     btn.title = ok ? btn.dataset.titleAvail : ASIDE_REASON[name] || btn.dataset.titleAvail;
   });
   // The divider only makes sense when there's actually a disabled group below it.
   const sep = document.querySelector(".atab-sep");
   if (sep) sep.hidden = !anyUnavailable;
+
+  if (first) flipAsideTabs(tabs, first);
+  asideOrderApplied = true;
 }
 // Nothing is reachable until the first metrics snapshot lands, so start with only
 // Settings enabled (renderMetrics refines this on every push).

--- a/public/app.js
+++ b/public/app.js
@@ -1715,7 +1715,7 @@ function updatesSectionHtml(report) {
   if (!report.updatesSupported) {
     return (
       `<div class="deps-section">${head()}` +
-      `<p class="hint">Outdated-library scanning currently supports Maven projects${report.buildTool ? ` (this is a ${esc(report.buildTool)} project)` : ""}.</p></div>`
+      `<p class="hint">Outdated-library scanning needs a Maven or Gradle project${report.buildTool ? ` (this is a ${esc(report.buildTool)} project)` : ""}.</p></div>`
     );
   }
   if (!report.ran) {

--- a/public/index.html
+++ b/public/index.html
@@ -865,11 +865,11 @@
             <div class="deps-controls">
               <button class="tiny" id="deps-scan">Check dependencies</button>
               <label
-                class="switch small disabled"
+                class="switch small"
                 id="deps-direct-toggle"
                 title="Hide transitive dependencies and show only the ones you declare."
               >
-                <input type="checkbox" id="deps-direct" disabled />
+                <input type="checkbox" id="deps-direct" />
                 <span class="track"><span class="thumb"></span></span>
                 <span class="switch-label">Direct only</span>
               </label>

--- a/public/index.html
+++ b/public/index.html
@@ -484,7 +484,7 @@
             </svg>
             <span class="atab-label">Settings</span>
           </button>
-          <button class="atab" data-atab="deps" title="Check for outdated libraries and upgrade them with Copilot">
+          <button class="atab" data-atab="deps" title="Check for outdated libraries and update them with Copilot">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
                 d="M7.47 1.22a.75.75 0 0 1 1.06 0l3 3a.75.75 0 0 1-1.06 1.06L8.75 3.56V10a.75.75 0 0 1-1.5 0V3.56L5.53 5.28a.75.75 0 0 1-1.06-1.06z"
@@ -860,7 +860,7 @@
           <div id="atab-deps" class="apane">
             <h2>Dependencies updates<span id="deps-src" class="src" hidden></span></h2>
             <p class="hint" id="deps-hint">
-              Scan for <strong>outdated libraries</strong> and upgrade them with Copilot.
+              Scan for <strong>outdated libraries</strong> and update them with Copilot.
             </p>
             <div class="deps-controls">
               <button class="tiny" id="deps-scan">Check dependencies</button>

--- a/public/index.html
+++ b/public/index.html
@@ -541,62 +541,66 @@
               <button id="btn-upgrade-spring" class="fix tiny" hidden>Upgrade with Copilot</button>
             </div>
 
-            <h2 class="spring-h2">Actuator</h2>
-            <p class="hint" id="actuator-hint">
-              Spring Boot Actuator exposes runtime endpoints — the canvas reads live JVM metrics in the Live JVM tab and
-              changes log levels without a restart in the Loggers tab.
-            </p>
-            <!-- Confirmation that Actuator is on the classpath (mirrors the DevTools
+            <div id="spring-actuator-section">
+              <h2 class="spring-h2">Actuator</h2>
+              <p class="hint" id="actuator-hint">
+                Spring Boot Actuator exposes runtime endpoints — the canvas reads live JVM metrics in the Live JVM tab
+                and changes log levels without a restart in the Loggers tab.
+              </p>
+              <!-- Confirmation that Actuator is on the classpath (mirrors the DevTools
                toggle row: a status line once the dependency is present). -->
-            <div class="set-row" id="actuator-status" hidden>
-              <span class="muted">Spring Boot Actuator is on the classpath.</span>
-            </div>
-            <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
+              <div class="set-row" id="actuator-status" hidden>
+                <span class="muted">Spring Boot Actuator is on the classpath.</span>
+              </div>
+              <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
                on Actuator yet. -->
-            <div class="set-row set-proposals">
-              <button id="btn-add-actuator" class="fix fix-copilot tiny" hidden>Add Actuator with Copilot</button>
+              <div class="set-row set-proposals">
+                <button id="btn-add-actuator" class="fix fix-copilot tiny" hidden>Add Actuator with Copilot</button>
+              </div>
             </div>
 
-            <h2 class="spring-h2">DevTools</h2>
-            <p class="hint" id="devtools-hint">
-              Spring Boot DevTools recompiles on save and restarts the app in place — the canvas plays the IDE's
-              recompile role, so the dev loop works without an editor.
-            </p>
-            <!-- DevTools live-reload toggle (only meaningful once DevTools is on the
+            <div id="spring-devtools-section">
+              <h2 class="spring-h2">DevTools</h2>
+              <p class="hint" id="devtools-hint">
+                Spring Boot DevTools recompiles on save and restarts the app in place — the canvas plays the IDE's
+                recompile role, so the dev loop works without an editor.
+              </p>
+              <!-- DevTools live-reload toggle (only meaningful once DevTools is on the
                classpath). Moved here from Settings so the whole DevTools story lives
                in one Spring-only place. -->
-            <div class="set-row switch-row" id="set-devtools" hidden>
-              <label class="switch" id="devtools-toggle">
-                <input type="checkbox" id="in-devtools" />
-                <span class="track"><span class="thumb"></span></span>
-                <span class="switch-label">Enable live reload</span>
-              </label>
-              <span
-                class="info"
-                id="devtools-info"
-                tabindex="0"
-                data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
-                >&#9432;</span
-              >
-            </div>
-            <!-- Manual dev-loop actions, enabled while the app is running. -->
-            <div class="spring-actions" id="devtools-actions" hidden>
-              <button
-                id="btn-reload"
-                class="fix tiny"
-                disabled
-                title="Recompile now so DevTools restarts the running app in place."
-              >
-                Live reload
-              </button>
-              <button id="btn-restart-app" class="fix tiny" disabled title="Stop and relaunch the running app.">
-                Restart app
-              </button>
-            </div>
-            <!-- Add DevTools (dev profile): shown only for a Spring Boot module that
+              <div class="set-row switch-row" id="set-devtools" hidden>
+                <label class="switch" id="devtools-toggle">
+                  <input type="checkbox" id="in-devtools" />
+                  <span class="track"><span class="thumb"></span></span>
+                  <span class="switch-label">Enable live reload</span>
+                </label>
+                <span
+                  class="info"
+                  id="devtools-info"
+                  tabindex="0"
+                  data-tip="Watch the running module's sources and recompile on save so DevTools restarts the app in place."
+                  >&#9432;</span
+                >
+              </div>
+              <!-- Manual dev-loop actions, enabled while the app is running. -->
+              <div class="spring-actions" id="devtools-actions" hidden>
+                <button
+                  id="btn-reload"
+                  class="fix tiny"
+                  disabled
+                  title="Recompile now so DevTools restarts the running app in place."
+                >
+                  Live reload
+                </button>
+                <button id="btn-restart-app" class="fix tiny" disabled title="Stop and relaunch the running app.">
+                  Restart app
+                </button>
+              </div>
+              <!-- Add DevTools (dev profile): shown only for a Spring Boot module that
                doesn't depend on DevTools yet. -->
-            <div class="set-row set-proposals">
-              <button id="btn-add-devtools" class="fix fix-copilot tiny" hidden>Add DevTools with Copilot</button>
+              <div class="set-row set-proposals">
+                <button id="btn-add-devtools" class="fix fix-copilot tiny" hidden>Add DevTools with Copilot</button>
+              </div>
             </div>
           </div>
 
@@ -653,6 +657,11 @@
 
           <div id="atab-quarkus" class="apane">
             <h2>Quarkus Agent MCP<span id="quarkus-mcp-state" class="mcp-state"></span></h2>
+            <!-- Inactive-tab reason: shown right after the title when the project
+               has no Quarkus module (the rail tab is greyed in that case). -->
+            <p class="hint" id="quarkus-empty" hidden>
+              This isn&rsquo;t a Quarkus app. Open a Quarkus project to register its Agent MCP server with Copilot.
+            </p>
             <p class="hint" id="quarkus-desc">
               Register the standalone
               <a href="https://github.com/quarkusio/quarkus-agent-mcp" target="_blank" rel="noopener"
@@ -675,9 +684,6 @@
               </div>
               <div id="quarkus-mcp-scans" class="scans"></div>
             </div>
-            <p class="hint" id="quarkus-empty" hidden>
-              No Quarkus module detected. Open a Quarkus project to register its Agent MCP server with Copilot.
-            </p>
           </div>
 
           <div id="atab-settings" class="apane active">

--- a/public/index.html
+++ b/public/index.html
@@ -552,8 +552,13 @@
               <div class="set-row" id="actuator-status" hidden>
                 <span class="muted">Spring Boot Actuator is on the classpath.</span>
               </div>
+              <!-- BootUI bundles Actuator, so when BootUI is configured we confirm that
+               instead of offering (or explaining) Actuator. -->
+              <div class="set-row" id="actuator-bootui-status" hidden>
+                <span class="muted">BootUI is configured — it includes Spring Boot Actuator.</span>
+              </div>
               <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
-               on Actuator yet. -->
+               on Actuator yet (and isn't already covered by BootUI). -->
               <div class="set-row set-proposals">
                 <button id="btn-add-actuator" class="fix fix-copilot tiny" hidden>Add Actuator with Copilot</button>
               </div>
@@ -606,6 +611,9 @@
 
           <div id="atab-scans" class="apane">
             <h2>BootUI Spring Boot Starter<span id="scans-src" class="src bootui" hidden>live</span></h2>
+            <p class="hint" id="bootui-configured" hidden>
+              BootUI is configured for this module — its advisor scans and richer live metrics are available.
+            </p>
             <p class="hint" id="bootui-desc">
               An embedded, local-only developer console for Spring Boot. Add the starter to a Spring Boot module to
               unlock richer live metrics and its advisor scans (architecture, security, Hibernate, …), then push

--- a/public/index.html
+++ b/public/index.html
@@ -484,6 +484,17 @@
             </svg>
             <span class="atab-label">Settings</span>
           </button>
+          <button class="atab" data-atab="deps" title="Check for outdated libraries and upgrade them with Copilot">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                d="M8 1a2.5 2.5 0 0 1 2.5 2.5V4h-5V3.5A2.5 2.5 0 0 1 8 1m3.5 3v-.5a3.5 3.5 0 1 0-7 0V4H1.5a.5.5 0 0 0-.5.5v8A2.5 2.5 0 0 0 3.5 15h9a2.5 2.5 0 0 0 2.5-2.5v-8a.5.5 0 0 0-.5-.5zm-1 1H14v7.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5V5h2v.5a.5.5 0 0 0 1 0V5h6v.5a.5.5 0 0 0 1 0z"
+              />
+              <path
+                d="M7.5 8.5a.5.5 0 0 1 1 0v1.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 10.293z"
+              />
+            </svg>
+            <span class="atab-label">Upgrades</span>
+          </button>
           <div class="atab-sep" role="separator" aria-hidden="true" hidden></div>
           <button id="aside-toggle" class="aside-toggle" type="button" aria-label="Hide panel" title="Hide panel">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
@@ -799,6 +810,26 @@
                 title="How often the Live JVM panel refreshes metrics from the running app (500–30000 ms)."
               />
             </div>
+          </div>
+
+          <div id="atab-deps" class="apane">
+            <h2>Dependencies &amp; upgrades<span id="deps-src" class="src" hidden></span></h2>
+            <p class="hint" id="deps-hint">
+              Scan for <strong>outdated libraries</strong> and upgrade them with Copilot.
+            </p>
+            <div class="deps-controls">
+              <button class="tiny" id="deps-scan">Check dependencies</button>
+              <label
+                class="switch small disabled"
+                id="deps-direct-toggle"
+                title="Hide transitive dependencies and show only the ones you declare."
+              >
+                <input type="checkbox" id="deps-direct" disabled />
+                <span class="track"><span class="thumb"></span></span>
+                <span class="switch-label">Direct only</span>
+              </label>
+            </div>
+            <div id="deps-result"></div>
           </div>
         </div>
       </aside>

--- a/public/index.html
+++ b/public/index.html
@@ -655,10 +655,10 @@
             </div>
 
             <h2>Advisor scans</h2>
-            <p class="hint" id="scans-hint">
+            <div class="hint" id="scans-hint">
               Start a <a href="https://github.com/jdubois/boot-ui" target="_blank" rel="noopener">BootUI</a> app (dev
               profile) with <strong>Run</strong> to run its advisor scans against the live app.
-            </p>
+            </div>
             <div id="scans-list" class="scans"></div>
             <div id="scans-result"></div>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -554,7 +554,7 @@
             <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
                on Actuator yet. -->
             <div class="set-row set-proposals">
-              <button id="btn-add-actuator" class="fix tiny" hidden>Add Actuator</button>
+              <button id="btn-add-actuator" class="fix fix-copilot tiny" hidden>Add Actuator with Copilot</button>
             </div>
 
             <h2 class="spring-h2">DevTools</h2>
@@ -596,7 +596,7 @@
             <!-- Add DevTools (dev profile): shown only for a Spring Boot module that
                doesn't depend on DevTools yet. -->
             <div class="set-row set-proposals">
-              <button id="btn-add-devtools" class="fix tiny" hidden>Add DevTools to dev profile</button>
+              <button id="btn-add-devtools" class="fix fix-copilot tiny" hidden>Add DevTools with Copilot</button>
             </div>
           </div>
 
@@ -612,7 +612,7 @@
                module without BootUI, shown disabled elsewhere, and hidden once the
                module already depends on BootUI (then it's active). -->
             <button id="btn-add-bootui" class="fix fix-copilot tiny" style="margin-top: 0.4rem" hidden>
-              Add BootUI to dev profile
+              Add BootUI with Copilot
             </button>
 
             <!-- BootUI MCP server: optional bridge that exposes the running app's

--- a/public/index.html
+++ b/public/index.html
@@ -407,7 +407,7 @@
       </div>
       <aside id="aside">
         <div class="aside-tabs">
-          <button class="atab" data-atab="metrics" title="Live JVM metrics of the running app">
+          <button class="atab" data-atab="jvm" title="Live JVM metrics of the running app">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
                 d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4M3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707M2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10m9.5 0a.5.5 0 0 1 .5-.5H14a.5.5 0 0 1 0 1h-2a.5.5 0 0 1-.5-.5m.754-4.246a.39.39 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.39.39 0 0 0-.029-.518z"
@@ -443,7 +443,7 @@
           </button>
           <button
             class="atab"
-            data-atab="scans"
+            data-atab="bootui"
             title="BootUI: add it to your project, run advisor scans against the live app, and bridge its MCP server to Copilot"
           >
             <!-- BootUI brand mark (the "hot cup"), drawn monochrome via
@@ -506,7 +506,7 @@
         </div>
 
         <div class="aside-body">
-          <div id="atab-metrics" class="apane">
+          <div id="atab-jvm" class="apane">
             <h2>Live JVM metrics<span id="metrics-src" class="src" hidden></span></h2>
             <div id="metrics">
               <p class="muted">Application isn&rsquo;t running or doesn&rsquo;t expose metrics.</p>
@@ -622,7 +622,7 @@
             </div>
           </div>
 
-          <div id="atab-scans" class="apane">
+          <div id="atab-bootui" class="apane">
             <h2>BootUI Spring Boot Starter<span id="scans-src" class="src bootui" hidden>live</span></h2>
             <p class="hint" id="bootui-configured" hidden>
               BootUI is configured for this module — its advisor scans and richer live metrics are available.

--- a/public/index.html
+++ b/public/index.html
@@ -624,8 +624,8 @@
 
           <div id="atab-bootui" class="apane">
             <h2>BootUI Spring Boot Starter<span id="scans-src" class="src bootui" hidden>live</span></h2>
-            <p class="hint" id="bootui-configured" hidden>
-              BootUI is configured for this module — its advisor scans and richer live metrics are available.
+            <p class="hint ok" id="bootui-configured" hidden>
+              &#10003; BootUI is set up for this module — its advisor scans and richer live metrics are available.
             </p>
             <p class="hint" id="bootui-desc">
               An embedded, local-only developer console for Spring Boot. Add the starter to a Spring Boot module to
@@ -692,6 +692,11 @@
               proxy and structured exceptions. Coffilot only detects and registers it &mdash; the server runs as a
               separate process. Needs JBang or Java 21+; docs search also needs Docker/Podman.
             </p>
+            <!-- Register CTA: the primary action for this tab, placed above the
+               "Quarkus Agent MCP server" subtitle to match the BootUI tab layout. -->
+            <button id="quarkus-mcp-register" class="fix fix-copilot tiny" style="margin-top: 0.4rem" hidden>
+              Register with Copilot
+            </button>
             <!-- Quarkus Agent MCP: register the standalone quarkus-agent MCP
                server with the Copilot CLI and trigger its capabilities. The
                server is external (JBang / java), so this panel doesn't depend on
@@ -699,9 +704,6 @@
             <div id="quarkus-mcp" class="mcp-settings">
               <div class="switch-row">
                 <span class="switch-label">Quarkus Agent MCP server</span>
-                <button id="quarkus-mcp-register" class="fix fix-copilot tiny" style="margin-left: auto" hidden>
-                  Register with Copilot
-                </button>
               </div>
               <div id="quarkus-mcp-scans" class="scans"></div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -487,13 +487,13 @@
           <button class="atab" data-atab="deps" title="Check for outdated libraries and upgrade them with Copilot">
             <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
               <path
-                d="M8 1a2.5 2.5 0 0 1 2.5 2.5V4h-5V3.5A2.5 2.5 0 0 1 8 1m3.5 3v-.5a3.5 3.5 0 1 0-7 0V4H1.5a.5.5 0 0 0-.5.5v8A2.5 2.5 0 0 0 3.5 15h9a2.5 2.5 0 0 0 2.5-2.5v-8a.5.5 0 0 0-.5-.5zm-1 1H14v7.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 12.5V5h2v.5a.5.5 0 0 0 1 0V5h6v.5a.5.5 0 0 0 1 0z"
+                d="M7.47 1.22a.75.75 0 0 1 1.06 0l3 3a.75.75 0 0 1-1.06 1.06L8.75 3.56V10a.75.75 0 0 1-1.5 0V3.56L5.53 5.28a.75.75 0 0 1-1.06-1.06z"
               />
               <path
-                d="M7.5 8.5a.5.5 0 0 1 1 0v1.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 10.293z"
+                d="M2.75 9a.75.75 0 0 1 .75.75v2.5c0 .69.56 1.25 1.25 1.25h6.5c.69 0 1.25-.56 1.25-1.25v-2.5a.75.75 0 0 1 1.5 0v2.5A2.75 2.75 0 0 1 11.25 15h-6.5A2.75 2.75 0 0 1 2 12.25v-2.5A.75.75 0 0 1 2.75 9"
               />
             </svg>
-            <span class="atab-label">Upgrades</span>
+            <span class="atab-label">Updates</span>
           </button>
           <div class="atab-sep" role="separator" aria-hidden="true" hidden></div>
           <button id="aside-toggle" class="aside-toggle" type="button" aria-label="Hide panel" title="Hide panel">
@@ -538,7 +538,7 @@
               <p class="muted">Detecting the Spring Boot version…</p>
             </div>
             <div class="set-row set-proposals">
-              <button id="btn-upgrade-spring" class="fix fix-copilot tiny" hidden>Upgrade with Copilot</button>
+              <button id="btn-upgrade-spring" class="fix fix-copilot tiny" hidden>Update with Copilot</button>
             </div>
 
             <div id="spring-actuator-section">
@@ -858,7 +858,7 @@
           </div>
 
           <div id="atab-deps" class="apane">
-            <h2>Dependencies &amp; upgrades<span id="deps-src" class="src" hidden></span></h2>
+            <h2>Dependencies updates<span id="deps-src" class="src" hidden></span></h2>
             <p class="hint" id="deps-hint">
               Scan for <strong>outdated libraries</strong> and upgrade them with Copilot.
             </p>

--- a/public/index.html
+++ b/public/index.html
@@ -538,7 +538,7 @@
               <p class="muted">Detecting the Spring Boot version…</p>
             </div>
             <div class="set-row set-proposals">
-              <button id="btn-upgrade-spring" class="fix tiny" hidden>Upgrade with Copilot</button>
+              <button id="btn-upgrade-spring" class="fix fix-copilot tiny" hidden>Upgrade with Copilot</button>
             </div>
 
             <div id="spring-actuator-section">
@@ -552,15 +552,28 @@
               <div class="set-row" id="actuator-status" hidden>
                 <span class="muted">Spring Boot Actuator is on the classpath.</span>
               </div>
-              <!-- BootUI bundles Actuator, so when BootUI is configured we confirm that
-               instead of offering (or explaining) Actuator. -->
-              <div class="set-row" id="actuator-bootui-status" hidden>
-                <span class="muted">BootUI is configured — it includes Spring Boot Actuator.</span>
-              </div>
               <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
                on Actuator yet (and isn't already covered by BootUI). -->
               <div class="set-row set-proposals">
                 <button id="btn-add-actuator" class="fix fix-copilot tiny" hidden>Add Actuator with Copilot</button>
+              </div>
+            </div>
+
+            <!-- BootUI section: the richer tier layered on top of Actuator. Confirms
+             BootUI once configured, otherwise offers to add it (shown below the
+             Actuator part so a Spring app without either gets both CTAs). When BootUI
+             is configured the Actuator part above is hidden, since BootUI includes it. -->
+            <div id="spring-bootui-section">
+              <h2 class="spring-h2">BootUI</h2>
+              <p class="hint" id="bootui-spring-hint">
+                BootUI is an embedded, local-only developer console — it layers richer live JVM metrics and advisor
+                scans (architecture, security, Hibernate, …) on top of Actuator.
+              </p>
+              <div class="set-row" id="bootui-spring-status" hidden>
+                <span class="muted">BootUI is configured — it includes Spring Boot Actuator.</span>
+              </div>
+              <div class="set-row set-proposals">
+                <button id="btn-add-bootui-spring" class="fix fix-copilot tiny" hidden>Add BootUI with Copilot</button>
               </div>
             </div>
 

--- a/public/index.html
+++ b/public/index.html
@@ -541,6 +541,22 @@
               <button id="btn-upgrade-spring" class="fix tiny" hidden>Upgrade with Copilot</button>
             </div>
 
+            <h2 class="spring-h2">Actuator</h2>
+            <p class="hint" id="actuator-hint">
+              Spring Boot Actuator exposes runtime endpoints — the canvas reads live JVM metrics in the Live JVM tab and
+              changes log levels without a restart in the Loggers tab.
+            </p>
+            <!-- Confirmation that Actuator is on the classpath (mirrors the DevTools
+               toggle row: a status line once the dependency is present). -->
+            <div class="set-row" id="actuator-status" hidden>
+              <span class="muted">Spring Boot Actuator is on the classpath.</span>
+            </div>
+            <!-- Add Actuator: shown only for a Spring Boot module that doesn't depend
+               on Actuator yet. -->
+            <div class="set-row set-proposals">
+              <button id="btn-add-actuator" class="fix tiny" hidden>Add Actuator</button>
+            </div>
+
             <h2 class="spring-h2">DevTools</h2>
             <p class="hint" id="devtools-hint">
               Spring Boot DevTools recompiles on save and restarts the app in place — the canvas plays the IDE's

--- a/public/styles.css
+++ b/public/styles.css
@@ -1048,7 +1048,7 @@ aside h2 {
 }
 /* Caret that rotates when the row is open. */
 .scan-finding > summary::before {
-  content: "\u203A";
+  content: "\203A";
   flex: 0 0 auto;
   color: var(--text-color-muted, #656d76);
   transition: transform var(--dur-fast, 0.12s) var(--ease-out, ease);
@@ -1193,7 +1193,7 @@ aside h2 {
   display: none;
 }
 .dep-item > summary::before {
-  content: "\u203A";
+  content: "\203A";
   flex: 0 0 auto;
   color: var(--text-color-muted, #656d76);
   transition: transform var(--dur-fast, 0.12s) var(--ease-out, ease);

--- a/public/styles.css
+++ b/public/styles.css
@@ -2354,7 +2354,8 @@ button.fix.cof-pop-in {
   color: var(--text-color-muted, #656d76);
   gap: 0.35rem;
 }
-.muted.ok {
+.muted.ok,
+.hint.ok {
   color: var(--true-color-green, #1a7f37);
 }
 .muted.err {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1125,6 +1125,160 @@ aside h2 {
   color: var(--text-color-muted, #656d76);
 }
 
+/* ---- Dependencies & upgrades (Upgrades aside tab) -------------------- */
+.deps-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 0.6rem;
+}
+.switch.small {
+  font-size: 12px;
+}
+.deps-section + .deps-section {
+  margin-top: 0.9rem;
+}
+.deps-section > h3,
+.deps-section-head h3 {
+  margin: 0 0 0.4rem;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-color-muted, #656d76);
+}
+.deps-section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+.deps-section-head h3 {
+  margin: 0;
+}
+.deps-counts {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-color-muted, #656d76);
+}
+.deps-ok {
+  margin: 0.2rem 0 0;
+  color: var(--true-color-green, #1a7f37);
+}
+.deps-error {
+  margin: 0.2rem 0 0;
+  color: var(--true-color-red, #cf222e);
+}
+.dep-list {
+  border: 1px solid var(--border-color-muted, #d8dee4);
+  border-radius: 6px;
+  overflow: hidden;
+}
+/* A dependency row reuses the scan-finding interaction (caret + summary). */
+.dep-item {
+  border-top: 1px solid var(--border-color-muted, #d8dee4);
+}
+.dep-item:first-child {
+  border-top: none;
+}
+.dep-item > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  cursor: pointer;
+  list-style: none;
+}
+.dep-item > summary::-webkit-details-marker {
+  display: none;
+}
+.dep-item > summary::before {
+  content: "\u203A";
+  flex: 0 0 auto;
+  color: var(--text-color-muted, #656d76);
+  transition: transform var(--dur-fast, 0.12s) var(--ease-out, ease);
+}
+.dep-item[open] > summary::before {
+  transform: rotate(90deg);
+}
+.dep-item > summary:hover {
+  background: var(--background-color-muted, #f6f8fa);
+}
+.dep-item .finding-title {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.dep-ver {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-left: auto;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.dep-ver .ver-old {
+  color: var(--text-color-muted, #656d76);
+  text-decoration: line-through;
+}
+.dep-ver .ver-arrow {
+  color: var(--text-color-muted, #656d76);
+}
+.dep-ver .ver-new {
+  color: var(--true-color-green, #1a7f37);
+  font-weight: 600;
+}
+/* Upgrade size badge (major / minor / patch). */
+.jump-badge {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  line-height: 1.5;
+  color: var(--text-color-muted, #656d76);
+}
+.jump-badge.jump-major {
+  color: var(--true-color-red, #cf222e);
+}
+.jump-badge.jump-minor {
+  color: var(--true-color-orange, #bc4c00);
+}
+.jump-badge.jump-patch {
+  color: var(--true-color-blue, #0969da);
+}
+/* Direct / transitive pill. */
+.dep-scope {
+  flex: 0 0 auto;
+  font-size: 10px;
+  padding: 0.05rem 0.3rem;
+  border-radius: 999px;
+  background: var(--background-color-muted, #f6f8fa);
+  border: 1px solid var(--border-color-muted, #d8dee4);
+  color: var(--text-color-muted, #656d76);
+}
+.dep-scope.direct {
+  color: var(--text-color-default, #1f2328);
+}
+.dep-pre {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--true-color-yellow, #9a6700);
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 0 0.3rem;
+  margin-left: 0.3rem;
+}
+
 /* Install hint banner (shown only when mvnd is missing) */
 .banner {
   display: flex;

--- a/specifications/RIGHT-PANEL-SPEC.md
+++ b/specifications/RIGHT-PANEL-SPEC.md
@@ -233,9 +233,15 @@ Active only at metrics tier `bootui` (app running). Pane shows scan controls
 
 ### 7.7 Updates (`deps`) — always active
 
-Outdated library list (heading **“Dependencies updates”**) with “Direct dependencies
-only” filter and per‑finding **Fix with Copilot**. (Specified in `PLAN.md`; behaviour
+Outdated library list (heading **“Dependencies updates”**) with a **“Direct only”**
+filter and per‑finding **Fix with Copilot**. (Specified in `PLAN.md`; behaviour
 rules to be folded in here as it lands.). This needs to work both with Maven and Gradle.
+
+The **“Direct only”** toggle is a view preference, not a scan parameter: it stays
+interactive whenever the build tool supports update scanning (`updatesSupported`), so it
+can be set before a scan and applies live to the rendered list afterwards (transitive
+findings are hidden client‑side). It is disabled only when the project can't scan for
+updates at all. Its state persists via settings (`depsDirectOnly`).
 
 ---
 

--- a/specifications/RIGHT-PANEL-SPEC.md
+++ b/specifications/RIGHT-PANEL-SPEC.md
@@ -1,17 +1,15 @@
 # Right‑panel (aside rail) specification
 
-> **Status:** _draft — this captures the rules **as currently implemented** so we can
-> review and correct them._ Edit freely; the “Open questions / desired changes” section
-> at the bottom is the place to record what should be different.
-
 The **right panel** is the aside rail of the Coffilot canvas: a vertical list of tabs
 (`.atab`, each with a `data-atab` key) and their panes (`.apane`). This document
 specifies which tabs exist, how they are ordered, when each is active vs. inactive, and
 exactly what each pane shows in either state.
 
-Source of truth in code: `public/index.html` (markup), `public/app.js` (behaviour),
+This is implemented in the code: `public/index.html` (markup), `public/app.js` (behaviour),
 `public/styles.css` (styling), with capability/metrics data coming from
 `extension.mjs`.
+
+This implementation MUST follow this specification.
 
 ---
 
@@ -22,26 +20,40 @@ Internal `data-atab` keys vs. the labels users see:
 | Order | `data-atab` | User‑facing label | Pane purpose                                                     |
 | ----: | ----------- | ----------------- | ---------------------------------------------------------------- |
 |     1 | `settings`  | **Settings**      | Project/run settings                                             |
-|     2 | `metrics`   | **Live JVM**      | Live heap / threads / uptime                                     |
+|     2 | `jvm`       | **Live JVM**      | Live heap / threads / uptime                                     |
 |     3 | `loggers`   | **Logs**          | Live log‑level control                                           |
 |     4 | `spring`    | **Spring**        | Spring Boot version advisor + Actuator / BootUI / DevTools setup |
 |     5 | `quarkus`   | **Quarkus**       | Quarkus MCP register + metrics/logging setup                     |
-|     6 | `scans`     | **BootUI**        | BootUI advisor scans                                             |
-|     7 | `deps`      | **Dependencies**  | OSIV check + outdated‑library upgrades                           |
+|     6 | `bootui`    | **BootUI**        | BootUI advisor scans                                             |
+|     7 | `deps`      | **Dependencies**  | Outdated libraries upgrades                                      |
 
-Canonical order is `ASIDE_ORDER = ["settings", "metrics", "loggers", "spring",
-"quarkus", "scans", "deps"]` (`public/app.js`).
+Canonical order is `ASIDE_ORDER = ["settings", "jvm", "loggers", "spring",
+"quarkus", "bootui", "deps"]` (`public/app.js`).
 
 ---
 
-## 2. Ordering & active/inactive grouping
+## 2. First opening and persistence
+
+On first opening of the canvas, the Settings tab is opened.
+
+Then, persist:
+
+- Which tab is opened, or if they are all closed
+- The status of each toggle
+
+When opening the canvas, if any of this data is already persisted -> use this to restore the panel in the way
+it was persisted.
+
+---
+
+## 3. Ordering & active/inactive grouping
 
 **Rule:** the canonical order above is _always_ preserved **within** each group, but the
 rail is split into two groups:
 
 1. **Active (available) tabs** float to the top, in canonical order.
-2. A separator (`.atab-sep`) divides the groups.
-3. **Inactive (unavailable) tabs** sink to the bottom, in canonical order.
+2. A separator (`.atab-sep`) divides the groups, it is at the bottom of the Active (available) tabs.
+3. **Inactive (unavailable) tabs** float at the bottom, in canonical order.
 
 Implementation: `computeAsideOrder(name, ok) = (ok ? 0 : 100) + rank`, where `rank` is
 the canonical index. Available → `0 + rank`; unavailable → `100 + rank`.
@@ -54,41 +66,36 @@ layout and when the user has `prefers-reduced-motion`.
 
 ---
 
-## 3. Availability (active vs. inactive) per tab
+## 4. Availability (active vs. inactive) per tab
 
 Two independent gates drive availability, merged per‑key in `updateAsideAvailability`:
 
 - **Project capabilities** (static, from `pomCaps` / `gradleCaps`): does the project use
   Spring Boot? Quarkus? etc. Drives `spring` and `quarkus`.
-- **Runtime metrics tier** (dynamic, from the running app — see §4): drives `metrics`,
-  `loggers`, `scans`.
+- **Runtime metrics tier** (dynamic, from the running app — see §5): drives `jvm`,
+  `loggers`, `bootui`.
 
-| Tab                   | Active when                                                                            | Gate source    |
-| --------------------- | -------------------------------------------------------------------------------------- | -------------- |
-| `settings`            | Always                                                                                 | `ASIDE_ALWAYS` |
-| `metrics` (Live JVM)  | App running **and** metrics tier ≠ `process` (i.e. tier ∈ {bootui, actuator, quarkus}) | runtime        |
-| `loggers` (Logs)      | App running **and** metrics tier ∈ {bootui, actuator, quarkus}                         | runtime        |
-| `scans` (BootUI)      | App running **and** metrics tier = `bootui`                                            | runtime        |
-| `spring`              | `caps.springBoot` is true                                                              | project caps   |
-| `quarkus`             | `caps.quarkus` is true                                                                 | project caps   |
-| `deps` (Dependencies) | Always                                                                                 | `ASIDE_ALWAYS` |
-
-> **Note (possible inconsistency):** `metrics` and `loggers` currently share the same
-> gate (tier ∈ {bootui, actuator, quarkus}). For a Quarkus app this marks **Logs**
-> active on the basis of the metrics tier even when the `logging-manager` extension is
-> absent; the pane content then explains the gap. Flag for review.
+| Tab        | Active when                                                    | Gate source    |
+| ---------- | -------------------------------------------------------------- | -------------- |
+| `settings` | Always                                                         | `ASIDE_ALWAYS` |
+| `jvm`      | App running **and** metrics tier ∈ {bootui, actuator, quarkus} | runtime        |
+| `loggers`  | App running **and** metrics tier ∈ {bootui, actuator, quarkus} | runtime        |
+| `spring`   | `caps.springBoot` is true                                      | project caps   |
+| `quarkus`  | `caps.quarkus` is true                                         | project caps   |
+| `bootui`   | App running **and** metrics tier = `bootui`                    | runtime        |
+| `deps`     | Always                                                         | `ASIDE_ALWAYS` |
 
 Each inactive tab also has a greyed‑tab tooltip from `ASIDE_REASON`.
 
 ---
 
-## 4. Metrics tiers (runtime detection)
+## 5. Metrics tiers (runtime detection)
 
 `refreshMetrics` (`extension.mjs`) probes the running app in precedence order and sets
 `metricsTier`:
 
-1. **`bootui`** — `/bootui/api/overview` answers. Richest tier (console + richer metrics
-   - advisor scans). _Implies Actuator._
+1. **`bootui`** — `/bootui/api/overview` answers. Richest tier (console, richer metrics
+   and advisor scans). _Implies Actuator._
 2. **`actuator`** — Spring Boot Actuator reachable at `/actuator` or `/management`.
 3. **`quarkus`** — Quarkus `/q/health` (+ optional `/q/metrics`) answers.
 4. **`process`** — nothing answered (or app down). Live JVM/Logs/BootUI all inactive.
@@ -97,7 +104,7 @@ When the app is down: `appUp = false`, `metricsTier = process`.
 
 ---
 
-## 5. Governing principle — **BootUI ⟹ Actuator**
+## 6. Governing principle — **BootUI ⟹ Actuator**
 
 BootUI bundles Spring Boot Actuator. Therefore, **everywhere**, when BootUI is
 configured:
@@ -107,18 +114,15 @@ configured:
   for it).
 - The BootUI tier covers all the metrics/loggers needs Actuator would.
 
-This is the rule that keeps biting; treat it as invariant unless we deliberately change
-it.
-
 ---
 
-## 6. Per‑tab content rules
+## 7. Per‑tab content rules
 
-### 6.1 Settings (`settings`) — always active
+### 7.1 Settings (`settings`) — always active
 
 Project + run configuration. No active/inactive story.
 
-### 6.2 Live JVM (`metrics`)
+### 7.2 Live JVM (`jvm`)
 
 **Active:** live heap / non‑heap / threads / uptime from the current tier.
 
@@ -143,7 +147,7 @@ restart to use this tab” (running but no endpoint)._
 Fix buttons use the orange **`fix fix-copilot`** style; once clicked they disable and
 read “Asked Copilot ✓” (tracked in `metricsAskedKinds`).
 
-### 6.3 Logs (`loggers`)
+### 7.3 Logs (`loggers`)
 
 **Active:** live logger list + level controls; source badge reads “Actuator” or
 “Quarkus”.
@@ -163,7 +167,7 @@ same structure as Live JVM, with logger‑specific wording:
   - Plain Java → “Live log‑level control works only for Spring Boot apps (Actuator
     `/loggers`) or Quarkus apps (the `quarkus-logging-manager` extension).”
 
-### 6.4 Spring (`spring`)
+### 7.4 Spring (`spring`)
 
 Active when the project is Spring Boot (independent of whether the app is running).
 Inactive → `renderSpringAdvisor` shows the “not a Spring Boot project” reason. When
@@ -193,13 +197,13 @@ Section visibility summary:
 | Actuator only     | “Actuator is set up” | pitch + **Add BootUI**           |
 | Neither           | **Add Actuator**     | pitch + **Add BootUI**           |
 
-### 6.5 Quarkus (`quarkus`)
+### 7.5 Quarkus (`quarkus`)
 
 Active when `caps.quarkus`. Inactive → `#quarkus-empty` shows the “not a Quarkus app”
 reason. When active: Quarkus MCP register panel + (in the Live JVM/Logs inactive bodies)
 the Micrometer / logging‑manager CTAs described above.
 
-### 6.6 BootUI / advisor scans (`scans`)
+### 7.6 BootUI / advisor scans (`bootui`)
 
 Active only at metrics tier `bootui` (app running). Pane shows scan controls
 (`Scan all` + per‑panel scans).
@@ -215,24 +219,26 @@ Active only at metrics tier `bootui` (app running). Pane shows scan controls
   - Not Spring Boot → “Advisor scans need a BootUI‑enabled Spring Boot app.”
   - Greyed placeholder scan buttons render so the pane isn’t empty.
 
-### 6.7 Dependencies (`deps`) — always active
+### 7.7 Dependencies (`deps`) — always active
 
-OSIV check + outdated‑library list with “Direct dependencies only” filter and per‑finding
+Outdated library list with “Direct dependencies only” filter and per‑finding
 **Fix with Copilot**. (Specified in `PLAN.md`; behaviour rules to be folded in here as it
-lands.)
+lands.). This needs to work both with Maven and Gradle.
 
 ---
 
-## 7. Runtime profile activation (BootUI dev profile)
+## 8. Runtime profile activation (BootUI dev profile)
 
 For Maven Spring Boot projects, BootUI is often only on the classpath under a `dev`
 profile. `pomCaps` reports `bootuiProfiles`; the Maven Spring runner merges them into the
 `-P` list (`withBootuiProfile`) so the BootUI tier actually comes up at runtime and Live
 JVM / Logs / BootUI go active.
 
+For Gradle Spring Boot projects, there is a similar mechanism.
+
 ---
 
-## 8. Shared button conventions
+## 9. Shared button conventions
 
 - Every Copilot fix/CTA button reads **“… with Copilot”** and uses the orange
   **`fix fix-copilot`** style (Add Actuator, Add BootUI, Add logging‑manager, Add Quarkus
@@ -241,13 +247,4 @@ JVM / Logs / BootUI go active.
 
 ---
 
-## 9. Open questions / desired changes
-
-_List here what should differ from the “as‑implemented” rules above. For each item, note
-the tab, the scenario, the current behaviour, and the desired behaviour._
-
-- [ ] _(example)_ Logs tab should NOT be active for a Quarkus app lacking
-      `logging-manager` (see §3 note) — desired: gate `loggers` on the actual logger
-      backend, not just the metrics tier.
-- [ ]
-- [ ]
+## 10. Open questions / desired changes

--- a/specifications/RIGHT-PANEL-SPEC.md
+++ b/specifications/RIGHT-PANEL-SPEC.md
@@ -149,8 +149,16 @@ read “Asked Copilot ✓” (tracked in `metricsAskedKinds`).
 
 ### 7.3 Logs (`loggers`)
 
-**Active:** live logger list + level controls; source badge reads “Actuator” or
+**Active:** live logger list + level controls; source badge reads “BootUI”, “Actuator” or
 “Quarkus”.
+
+- Spring Boot + **BootUI** (whether Actuator is also present or not) → reads/writes via
+  BootUI’s `/bootui/api/loggers` (it bundles Actuator’s `LoggersEndpoint`, so it is the top
+  tier). Badge reads “BootUI”.
+- Spring Boot + **Actuator** (no BootUI) → reads/writes via Actuator’s `/loggers`. Badge
+  reads “Actuator”.
+- Quarkus + **logging‑manager** → reads/writes via the Quarkus logging‑manager endpoint.
+  Badge reads “Quarkus”.
 
 **Inactive** (`renderLoggersInactive` → `diagnosticInactiveBody("loggers", appDown)`):
 same structure as Live JVM, with logger‑specific wording:
@@ -209,7 +217,8 @@ above the "Quarkus Agent MCP server" subtitle.
 ### 7.6 BootUI / advisor scans (`bootui`)
 
 Active only at metrics tier `bootui` (app running). Pane shows scan controls
-(`Scan all` + per‑panel scans).
+(`Scan all` + per‑panel scans). Inactive handling is described below
+(`scansInactiveHtml`), including the “not a Spring Boot project” case.
 
 - Title is followed by `#bootui-configured` (“✓ BootUI is set up”, shown when BootUI is
   on the classpath) or `#bootui-desc` (the “add the starter” description, shown

--- a/specifications/RIGHT-PANEL-SPEC.md
+++ b/specifications/RIGHT-PANEL-SPEC.md
@@ -203,18 +203,21 @@ Active when `caps.quarkus`. Inactive → `#quarkus-empty` shows the “not a Qua
 reason. When active: Quarkus MCP register panel + (in the Live JVM/Logs inactive bodies)
 the Micrometer / logging‑manager CTAs described above.
 
+The "Register with Copilot" button is just after Quarkus Agent MCP register panel, and
+above the "Quarkus Agent MCP server" subtitle.
+
 ### 7.6 BootUI / advisor scans (`bootui`)
 
 Active only at metrics tier `bootui` (app running). Pane shows scan controls
 (`Scan all` + per‑panel scans).
 
-- Title is followed by `#bootui-configured` (“BootUI is configured”, shown when BootUI is
+- Title is followed by `#bootui-configured` (“✓ BootUI is set up”, shown when BootUI is
   on the classpath) or `#bootui-desc` (the “add the starter” description, shown
   otherwise).
 - **Inactive** (`scansInactiveHtml(appDown)`), consistent with Live JVM/Logs:
   - Lead: app down → “The app isn’t running.” Otherwise → “The running app has no BootUI
     endpoint.”
-  - Spring Boot + BootUI → ✓ BootUI is set up — _{next}_.
+  - Spring Boot + BootUI → _{next}_.
   - Spring Boot, no BootUI → “Advisor scans need BootUI — add it above, then run the app.”
   - Not Spring Boot → “Advisor scans need a BootUI‑enabled Spring Boot app.”
   - Greyed placeholder scan buttons render so the pane isn’t empty.

--- a/specifications/RIGHT-PANEL-SPEC.md
+++ b/specifications/RIGHT-PANEL-SPEC.md
@@ -25,7 +25,7 @@ Internal `data-atab` keys vs. the labels users see:
 |     4 | `spring`    | **Spring**        | Spring Boot version advisor + Actuator / BootUI / DevTools setup |
 |     5 | `quarkus`   | **Quarkus**       | Quarkus MCP register + metrics/logging setup                     |
 |     6 | `bootui`    | **BootUI**        | BootUI advisor scans                                             |
-|     7 | `deps`      | **Dependencies**  | Outdated libraries upgrades                                      |
+|     7 | `deps`      | **Updates**       | Outdated library updates                                         |
 
 Canonical order is `ASIDE_ORDER = ["settings", "jvm", "loggers", "spring",
 "quarkus", "bootui", "deps"]` (`public/app.js`).
@@ -182,7 +182,7 @@ Inactive → `renderSpringAdvisor` shows the “not a Spring Boot project” rea
 active, four stacked sections (`updateDevSetup`):
 
 1. **Version advisor** — detected Spring Boot version + support status (`current` /
-   `supported` / `eol` / `unknown` / `unreadable`) and an **Upgrade with Copilot** button
+   `supported` / `eol` / `unknown` / `unreadable`) and an **Update with Copilot** button
    (`#btn-upgrade-spring`, styled `fix-copilot` to match the other Copilot buttons).
 
 2. **Actuator section** (`#spring-actuator-section`) — _hidden when BootUI is
@@ -231,11 +231,11 @@ Active only at metrics tier `bootui` (app running). Pane shows scan controls
   - Not Spring Boot → “Advisor scans need a BootUI‑enabled Spring Boot app.”
   - Greyed placeholder scan buttons render so the pane isn’t empty.
 
-### 7.7 Dependencies (`deps`) — always active
+### 7.7 Updates (`deps`) — always active
 
-Outdated library list with “Direct dependencies only” filter and per‑finding
-**Fix with Copilot**. (Specified in `PLAN.md`; behaviour rules to be folded in here as it
-lands.). This needs to work both with Maven and Gradle.
+Outdated library list (heading **“Dependencies updates”**) with “Direct dependencies
+only” filter and per‑finding **Fix with Copilot**. (Specified in `PLAN.md`; behaviour
+rules to be folded in here as it lands.). This needs to work both with Maven and Gradle.
 
 ---
 
@@ -254,7 +254,7 @@ For Gradle Spring Boot projects, there is a similar mechanism.
 
 - Every Copilot fix/CTA button reads **“… with Copilot”** and uses the orange
   **`fix fix-copilot`** style (Add Actuator, Add BootUI, Add logging‑manager, Add Quarkus
-  metrics, Upgrade Spring Boot, etc.).
+  metrics, Update Spring Boot, etc.).
 - After a fix is requested, the button disables and reads “Asked Copilot ✓”.
 
 ---

--- a/test/e2e-projects.test.mjs
+++ b/test/e2e-projects.test.mjs
@@ -14,14 +14,30 @@
 //   COFFILOT_E2E=1 node --test test/e2e-projects.test.mjs
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { spawn } from "node:child_process";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 process.env.COFFILOT_TEST = "1";
 
-const { collectSurefireReport, testArgsFor, buildArgsFor, packageArgsFor } = await import("../extension.mjs");
+const {
+  collectSurefireReport,
+  testArgsFor,
+  buildArgsFor,
+  packageArgsFor,
+  parseDependencyTree,
+  parseDependencyUpdates,
+  parseGradleDependencyTree,
+  parseGradleDependencyUpdates,
+  mergeDependencyUpdates,
+  mavenDepTreeArgs,
+  mavenDepUpdatesArgs,
+  gradleDepTreeArgs,
+  gradleDepUpdatesArgs,
+  gradleDependencyUpdatesInitBody,
+} = await import("../extension.mjs");
 
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const projectsDir = path.join(repoRoot, "integration-tests");
@@ -207,6 +223,79 @@ for (const l of LIFECYCLE) {
       const pkg = await runWrapper(dir, l.tool, packageArgsFor(l.tool, false, true, false));
       assert.equal(pkg.code, 0, `${l.project} package lane failed (exit ${pkg.code}):\n${pkg.out.slice(-4000)}`);
       assert.ok(hasJar(dir, l.tool), `${l.project}: Package lane produced no jar in ${artifactDir(l.tool)}/`);
+    },
+  );
+}
+
+// Upgrades-tab outdated-library scan, end to end: for one Maven and one Gradle
+// project, run the very command vectors the scan runs (mavenDep*Args /
+// gradleDep*Args + the injected init script), then feed the real output through
+// Coffilot's own parsers + merge — the same pipeline runDependencyScan uses. Each
+// project declares a deliberately ancient guava 19.0 (see its build file), so the
+// scan must always surface guava as an outdated, direct dependency. We assert the
+// shape (current/direct/jump) rather than the exact latest version, which drifts.
+const DEP_SCANS = [
+  { project: "hello-world", tool: "maven" },
+  { project: "gradle-hello-world", tool: "gradle" },
+];
+
+// Run the active tool's outdated-library scan in `dir` and return the merged
+// updates list, using exactly the exported command vectors + parsers.
+async function scanOutdated(dir, tool) {
+  if (tool === "maven") {
+    const tree = await runWrapper(dir, "maven", mavenDepTreeArgs());
+    assert.equal(tree.code, 0, `dependency:tree failed (exit ${tree.code}):\n${tree.out.slice(-4000)}`);
+    const upd = await runWrapper(dir, "maven", mavenDepUpdatesArgs());
+    assert.equal(upd.code, 0, `display-dependency-updates failed (exit ${upd.code}):\n${upd.out.slice(-4000)}`);
+    const nodes = parseDependencyTree(tree.out);
+    const updMap = parseDependencyUpdates(upd.out);
+    return mergeDependencyUpdates(nodes, updMap);
+  }
+  // Gradle: inject the ben-manes plugin via a throwaway init script that writes a
+  // JSON report into our temp dir, exactly like runGradleDependencyScan.
+  const outDir = mkdtempSync(path.join(os.tmpdir(), "coffilot-deps-e2e-"));
+  try {
+    const initScript = path.join(outDir, "deps-init.gradle");
+    writeFileSync(initScript, gradleDependencyUpdatesInitBody(outDir));
+    const tree = await runWrapper(dir, "gradle", gradleDepTreeArgs());
+    assert.equal(tree.code, 0, `gradle dependencies failed (exit ${tree.code}):\n${tree.out.slice(-4000)}`);
+    const upd = await runWrapper(dir, "gradle", gradleDepUpdatesArgs(initScript));
+    assert.equal(upd.code, 0, `dependencyUpdates failed (exit ${upd.code}):\n${upd.out.slice(-4000)}`);
+    const nodes = parseGradleDependencyTree(tree.out);
+    const updMap = new Map();
+    for (const f of readdirSync(outDir)) {
+      if (!f.endsWith(".json")) continue;
+      for (const [k, v] of parseGradleDependencyUpdates(readFileSync(path.join(outDir, f), "utf8"))) {
+        if (!updMap.has(k)) updMap.set(k, v);
+      }
+    }
+    return mergeDependencyUpdates(nodes, updMap);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
+for (const s of DEP_SCANS) {
+  const dir = path.join(projectsDir, s.project);
+
+  test(
+    `${s.project}: Upgrades scan flags the outdated guava dependency`,
+    { skip: SKIP, timeout: BUILD_TIMEOUT_MS },
+    async () => {
+      assert.ok(existsSync(dir), `missing integration project: ${dir}`);
+
+      const updates = await scanOutdated(dir, s.tool);
+      assert.ok(updates.length > 0, `${s.project}: expected at least one outdated library`);
+
+      const guava = updates.find((u) => u.group === "com.google.guava" && u.artifact === "guava");
+      assert.ok(
+        guava,
+        `${s.project}: expected guava in the outdated list, got ${updates.map((u) => u.artifact).join(", ")}`,
+      );
+      assert.equal(guava.current, "19.0", `${s.project}: guava current version`);
+      assert.notEqual(guava.latest, "19.0", `${s.project}: guava should have a newer latest version`);
+      assert.equal(guava.direct, true, `${s.project}: guava is a declared (direct) dependency`);
+      assert.ok(["major", "minor", "patch", "other"].includes(guava.jump), `${s.project}: guava jump classified`);
     },
   );
 }

--- a/test/e2e-projects.test.mjs
+++ b/test/e2e-projects.test.mjs
@@ -31,6 +31,7 @@ const {
   parseDependencyUpdates,
   parseGradleDependencyTree,
   parseGradleDependencyUpdates,
+  gradleDepConfigFilter,
   mergeDependencyUpdates,
   mavenDepTreeArgs,
   mavenDepUpdatesArgs,
@@ -261,7 +262,7 @@ async function scanOutdated(dir, tool) {
     assert.equal(tree.code, 0, `gradle dependencies failed (exit ${tree.code}):\n${tree.out.slice(-4000)}`);
     const upd = await runWrapper(dir, "gradle", gradleDepUpdatesArgs(initScript));
     assert.equal(upd.code, 0, `dependencyUpdates failed (exit ${upd.code}):\n${upd.out.slice(-4000)}`);
-    const nodes = parseGradleDependencyTree(tree.out);
+    const nodes = parseGradleDependencyTree(tree.out, { configFilter: gradleDepConfigFilter });
     const updMap = new Map();
     for (const f of readdirSync(outDir)) {
       if (!f.endsWith(".json")) continue;

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -313,6 +313,29 @@ test("pomCaps / gradleCaps detect the Quarkus logging-manager extension", () => 
   );
 });
 
+test("pomCaps reports the Maven profile id(s) carrying the BootUI starter", () => {
+  // BootUI scoped to a dev-only profile (the install-bootui layout): bootui is
+  // detected, and its carrying profile id is reported so the runner can -P it.
+  const devProfile =
+    "<project><profiles><profile><id>dev</id><dependencies><dependency>" +
+    "<groupId>com.julien-dubois.bootui</groupId><artifactId>bootui-spring-boot-starter</artifactId>" +
+    "</dependency></dependencies></profile></profiles></project>";
+  const caps = pomCaps(devProfile, "app");
+  assert.equal(caps.bootui, true, "BootUI detected when scoped to a profile");
+  assert.deepEqual(caps.bootuiProfiles, ["dev"], "the dev profile carrying BootUI is reported");
+
+  // BootUI as a top-level dependency: detected, but no profile to activate.
+  const topLevel =
+    "<project><dependencies><dependency><groupId>com.julien-dubois.bootui</groupId>" +
+    "<artifactId>bootui-spring-boot-starter</artifactId></dependency></dependencies></project>";
+  const caps2 = pomCaps(topLevel, "app");
+  assert.equal(caps2.bootui, true, "top-level BootUI detected");
+  assert.deepEqual(caps2.bootuiProfiles, [], "no profile to activate for a top-level dependency");
+
+  // No BootUI at all: empty profile list.
+  assert.deepEqual(pomCaps("<project/>", "app").bootuiProfiles, [], "no BootUI profiles when absent");
+});
+
 test("normalizeQuarkusLoggers maps the listing to the shared shape (ROOT first)", () => {
   const out = normalizeQuarkusLoggers(
     [

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -28,6 +28,11 @@ const {
   jdkSupportsNativeAccess,
   springBootVersionFromPom,
   springBootVersionFromGradle,
+  parseDependencyTree,
+  parseDependencyUpdates,
+  mergeDependencyUpdates,
+  classifyVersionJump,
+  isPrerelease,
 } = await import("../extension.mjs");
 
 // ---------------------------------------------------------------------------
@@ -581,4 +586,102 @@ test("springBootVersionFromGradle reads a buildscript classpath and skips variab
   assert.equal(springBootVersionFromGradle(classpath), "2.7.18");
   const variable = `plugins { id 'org.springframework.boot' version "$springBootVersion" }`;
   assert.equal(springBootVersionFromGradle(variable), null);
+});
+
+// ---------------------------------------------------------------------------
+// Dependencies — outdated-library parsers
+// ---------------------------------------------------------------------------
+
+test("parseDependencyTree classifies direct vs transitive by tree depth", () => {
+  const out = [
+    "[INFO] com.example:demo:jar:1.0.0",
+    "[INFO] +- org.springframework.boot:spring-boot-starter-webmvc:jar:4.0.0:compile",
+    "[INFO] |  +- org.springframework:spring-web:jar:7.0.0:compile",
+    "[INFO] |  \\- com.fasterxml.jackson.core:jackson-databind:jar:2.18.0:compile",
+    "[INFO] \\- com.google.guava:guava:jar:19.0:compile",
+  ].join("\n");
+  const nodes = parseDependencyTree(out);
+  const byKey = Object.fromEntries(nodes.map((n) => [n.key, n]));
+  assert.equal(byKey["org.springframework.boot:spring-boot-starter-webmvc"].direct, true);
+  assert.equal(byKey["com.google.guava:guava"].direct, true);
+  assert.equal(byKey["org.springframework:spring-web"].direct, false);
+  assert.equal(byKey["org.springframework:spring-web"].via, "org.springframework.boot:spring-boot-starter-webmvc");
+  assert.equal(byKey["com.fasterxml.jackson.core:jackson-databind"].version, "2.18.0");
+});
+
+test("parseDependencyTree handles a 6-part coordinate with a classifier", () => {
+  const out = "[INFO] +- org.example:native-lib:jar:linux-x86_64:1.2.3:runtime";
+  const nodes = parseDependencyTree(out);
+  assert.equal(nodes.length, 1);
+  assert.equal(nodes[0].version, "1.2.3");
+  assert.equal(nodes[0].scope, "runtime");
+  assert.equal(nodes[0].direct, true);
+});
+
+test("parseDependencyTree keeps the shallowest occurrence of a duplicate", () => {
+  const out = [
+    "[INFO] +- com.google.guava:guava:jar:19.0:compile",
+    "[INFO] \\- org.example:wrapper:jar:1.0:compile",
+    "[INFO]    \\- com.google.guava:guava:jar:19.0:compile",
+  ].join("\n");
+  const nodes = parseDependencyTree(out);
+  const guava = nodes.filter((n) => n.key === "com.google.guava:guava");
+  assert.equal(guava.length, 1);
+  assert.equal(guava[0].direct, true);
+});
+
+test("parseDependencyUpdates extracts current -> latest per coordinate", () => {
+  const out = [
+    "[INFO] The following dependencies in Dependencies have newer versions:",
+    "[INFO]   com.google.guava:guava ..................... 19.0 -> 33.6.0-jre",
+    "[INFO]   org.slf4j:slf4j-api ........................ 1.7.20 -> 2.1.0-alpha1",
+    "[INFO] ",
+  ].join("\n");
+  const map = parseDependencyUpdates(out);
+  assert.equal(map.get("com.google.guava:guava").latest, "33.6.0-jre");
+  assert.equal(map.get("org.slf4j:slf4j-api").current, "1.7.20");
+  assert.equal(map.size, 2);
+});
+
+test("mergeDependencyUpdates joins tree + updates, sorts direct-first by jump", () => {
+  const nodes = parseDependencyTree(
+    [
+      "[INFO] +- com.google.guava:guava:jar:19.0:compile",
+      "[INFO] \\- org.example:lib:jar:1.0.0:compile",
+      "[INFO]    \\- org.slf4j:slf4j-api:jar:1.7.20:compile",
+    ].join("\n"),
+  );
+  const updates = parseDependencyUpdates(
+    [
+      "[INFO]   com.google.guava:guava ... 19.0 -> 33.6.0-jre",
+      "[INFO]   org.slf4j:slf4j-api ...... 1.7.20 -> 2.1.0-alpha1",
+    ].join("\n"),
+  );
+  const merged = mergeDependencyUpdates(nodes, updates);
+  assert.equal(merged.length, 2);
+  // guava is direct so it sorts ahead of the transitive slf4j.
+  assert.equal(merged[0].artifact, "guava");
+  assert.equal(merged[0].direct, true);
+  assert.equal(merged[0].jump, "major");
+  assert.equal(merged[1].direct, false);
+  assert.equal(merged[1].via, "org.example:lib");
+  // slf4j's latest is a pre-release while the current isn't.
+  assert.equal(merged[1].prerelease, true);
+});
+
+test("classifyVersionJump distinguishes major / minor / patch", () => {
+  assert.equal(classifyVersionJump("1.0.0", "2.0.0"), "major");
+  assert.equal(classifyVersionJump("1.2.0", "1.5.0"), "minor");
+  assert.equal(classifyVersionJump("1.2.3", "1.2.9"), "patch");
+  assert.equal(classifyVersionJump("19.0", "33.6.0-jre"), "major");
+  assert.equal(classifyVersionJump("weird", "1.0"), "other");
+});
+
+test("isPrerelease detects alpha/beta/rc/milestone/snapshot qualifiers", () => {
+  assert.equal(isPrerelease("2.1.0-alpha1"), true);
+  assert.equal(isPrerelease("3.0.0-RC1"), true);
+  assert.equal(isPrerelease("1.0.0-M2"), true);
+  assert.equal(isPrerelease("5.2.0-SNAPSHOT"), true);
+  assert.equal(isPrerelease("33.6.0-jre"), false);
+  assert.equal(isPrerelease("3.20.0"), false);
 });

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -36,6 +36,8 @@ const {
   gradleDepConfigFilter,
   classifyVersionJump,
   isPrerelease,
+  pomCaps,
+  gradleCaps,
 } = await import("../extension.mjs");
 
 // ---------------------------------------------------------------------------
@@ -277,6 +279,22 @@ test("quarkusMetrics surfaces the SmallRye health checks breakdown", () => {
 test("quarkusMetrics defaults the health checks to an empty list", () => {
   const out = quarkusMetrics(null, { status: "UP" });
   assert.deepEqual(out.health, { status: "UP", checks: [] });
+});
+
+test("pomCaps / gradleCaps detect the Quarkus Micrometer metrics dependency", () => {
+  const withMetrics =
+    "<project><dependencies><dependency><groupId>io.quarkus</groupId>" +
+    "<artifactId>quarkus-micrometer-registry-prometheus</artifactId></dependency></dependencies></project>";
+  assert.equal(pomCaps(withMetrics, "app").quarkusMetrics, true, "Maven: micrometer registry detected");
+  assert.equal(pomCaps("<project/>", "app").quarkusMetrics, false, "Maven: absent when no micrometer dep");
+
+  const gradleWith = 'dependencies { implementation("io.quarkus:quarkus-micrometer-registry-prometheus") }';
+  assert.equal(gradleCaps(gradleWith, "app").quarkusMetrics, true, "Gradle: micrometer registry detected");
+  assert.equal(
+    gradleCaps("plugins { id 'java' }", "app").quarkusMetrics,
+    false,
+    "Gradle: absent when no micrometer dep",
+  );
 });
 
 test("normalizeQuarkusLoggers maps the listing to the shared shape (ROOT first)", () => {

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -18,6 +18,7 @@ const {
   promFirstLabel,
   quarkusMetrics,
   normalizeQuarkusLoggers,
+  normalizeBootuiLoggers,
   maskSecrets,
   buildHistoryEntry,
   clampHistory,
@@ -398,6 +399,34 @@ test("normalizeQuarkusLoggers falls back to JBoss levels and rejects non-arrays"
   const out = normalizeQuarkusLoggers([{ name: "ROOT", configuredLevel: "INFO", effectiveLevel: "INFO" }], null);
   assert.ok(out.levels.includes("TRACE") && out.levels.includes("FINEST"));
   assert.equal(normalizeQuarkusLoggers(null, ["INFO"]), null);
+});
+
+test("normalizeBootuiLoggers maps the /bootui/api/loggers report to the shared shape (ROOT first)", () => {
+  const out = normalizeBootuiLoggers({
+    availableLevels: ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"],
+    loggers: [
+      { name: "org.acme.Svc", configuredLevel: "DEBUG", effectiveLevel: "DEBUG" },
+      { name: "ROOT", configuredLevel: "INFO", effectiveLevel: "INFO" },
+      { name: "io.github", configuredLevel: null, effectiveLevel: "INFO" },
+    ],
+    page: { total: 3 },
+  });
+  assert.equal(out.available, true);
+  assert.equal(out.source, "bootui");
+  assert.deepEqual(
+    out.loggers.map((l) => l.name),
+    ["ROOT", "io.github", "org.acme.Svc"],
+  );
+  // A null configuredLevel normalizes to null (the UI's "inherit" state).
+  assert.equal(out.loggers[1].configuredLevel, null);
+  assert.deepEqual(out.levels, ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]);
+});
+
+test("normalizeBootuiLoggers falls back to default levels and rejects non-reports", () => {
+  const out = normalizeBootuiLoggers({ loggers: [{ name: "ROOT", configuredLevel: "INFO", effectiveLevel: "INFO" }] });
+  assert.deepEqual(out.levels, ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]);
+  assert.equal(normalizeBootuiLoggers(null), null, "no report");
+  assert.equal(normalizeBootuiLoggers({ availableLevels: ["INFO"] }), null, "a report without a loggers array");
 });
 
 // ---------------------------------------------------------------------------

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -31,6 +31,8 @@ const {
   parseDependencyTree,
   parseDependencyUpdates,
   mergeDependencyUpdates,
+  parseGradleDependencyTree,
+  parseGradleDependencyUpdates,
   classifyVersionJump,
   isPrerelease,
 } = await import("../extension.mjs");
@@ -684,4 +686,122 @@ test("isPrerelease detects alpha/beta/rc/milestone/snapshot qualifiers", () => {
   assert.equal(isPrerelease("5.2.0-SNAPSHOT"), true);
   assert.equal(isPrerelease("33.6.0-jre"), false);
   assert.equal(isPrerelease("3.20.0"), false);
+});
+
+// Real `gradle dependencies --configuration runtimeClasspath` output (5-char
+// indent per level, with a repeated-subtree (*) marker).
+const GRADLE_TREE = [
+  "",
+  "------------------------------------------------------------",
+  "Root project 'gradledep'",
+  "------------------------------------------------------------",
+  "",
+  "runtimeClasspath - Runtime classpath of source set 'main'.",
+  "+--- com.google.guava:guava:19.0",
+  "+--- org.apache.commons:commons-lang3:3.4",
+  "+--- org.slf4j:slf4j-api:1.7.20",
+  "+--- com.fasterxml.jackson.core:jackson-databind:2.9.0",
+  "|    +--- com.fasterxml.jackson.core:jackson-annotations:2.9.0",
+  "|    \\--- com.fasterxml.jackson.core:jackson-core:2.9.0",
+  "\\--- org.springframework:spring-web:5.2.0.RELEASE",
+  "     +--- org.springframework:spring-beans:5.2.0.RELEASE",
+  "     |    \\--- org.springframework:spring-core:5.2.0.RELEASE",
+  "     |         \\--- org.springframework:spring-jcl:5.2.0.RELEASE",
+  "     \\--- org.springframework:spring-core:5.2.0.RELEASE (*)",
+  "",
+  "(*) - Indicates repeated occurrences of a transitive dependency subtree.",
+].join("\n");
+
+test("parseGradleDependencyTree classifies direct vs transitive by indent depth", () => {
+  const nodes = parseGradleDependencyTree(GRADLE_TREE);
+  const byKey = Object.fromEntries(nodes.map((n) => [n.key, n]));
+  assert.equal(byKey["com.google.guava:guava"].direct, true);
+  assert.equal(byKey["com.google.guava:guava"].version, "19.0");
+  assert.equal(byKey["com.google.guava:guava"].scope, "runtime");
+  // jackson-core is a transitive dep pulled in by jackson-databind.
+  assert.equal(byKey["com.fasterxml.jackson.core:jackson-core"].direct, false);
+  assert.equal(byKey["com.fasterxml.jackson.core:jackson-core"].via, "com.fasterxml.jackson.core:jackson-databind");
+  // spring-jcl is several levels deep but its `via` is still the direct ancestor.
+  assert.equal(byKey["org.springframework:spring-jcl"].direct, false);
+  assert.equal(byKey["org.springframework:spring-jcl"].via, "org.springframework:spring-web");
+});
+
+test("parseGradleDependencyTree keeps the shallowest occurrence and ignores (*)", () => {
+  const nodes = parseGradleDependencyTree(GRADLE_TREE);
+  const core = nodes.filter((n) => n.key === "org.springframework:spring-core");
+  // The (*) repeat at depth 1 wins over the depth-2 first occurrence, but it is
+  // still transitive, and deduped to a single node.
+  assert.equal(core.length, 1);
+  assert.equal(core[0].direct, false);
+});
+
+test("parseGradleDependencyTree resolves version coercion (a -> b)", () => {
+  const nodes = parseGradleDependencyTree(
+    [
+      "runtimeClasspath - Runtime classpath.",
+      "+--- org.slf4j:slf4j-api:1.7.20 -> 2.0.13",
+      "\\--- com.example:lib -> 3.1.0",
+    ].join("\n"),
+  );
+  const byKey = Object.fromEntries(nodes.map((n) => [n.key, n]));
+  assert.equal(byKey["org.slf4j:slf4j-api"].version, "2.0.13");
+  // A constraint-only line (no requested version) still resolves via the arrow.
+  assert.equal(byKey["com.example:lib"].version, "3.1.0");
+});
+
+test("parseGradleDependencyUpdates reads the ben-manes JSON outdated list", () => {
+  const json = JSON.stringify({
+    outdated: {
+      dependencies: [
+        { group: "com.google.guava", name: "guava", version: "19.0", available: { release: "33.6.0-jre" } },
+        {
+          group: "org.slf4j",
+          name: "slf4j-api",
+          version: "1.7.20",
+          available: { release: "2.1.0-alpha1", milestone: null },
+        },
+        {
+          group: "no.latest",
+          name: "lib",
+          version: "1.0",
+          available: { release: null, milestone: null, integration: null },
+        },
+      ],
+    },
+  });
+  const map = parseGradleDependencyUpdates(json);
+  assert.equal(map.get("com.google.guava:guava").latest, "33.6.0-jre");
+  assert.equal(map.get("org.slf4j:slf4j-api").latest, "2.1.0-alpha1");
+  // A dependency with no available version is dropped.
+  assert.equal(map.has("no.latest:lib"), false);
+});
+
+test("parseGradleDependencyUpdates returns an empty map on malformed JSON", () => {
+  assert.equal(parseGradleDependencyUpdates("not json").size, 0);
+  assert.equal(parseGradleDependencyUpdates("{}").size, 0);
+});
+
+test("mergeDependencyUpdates joins a Gradle tree + ben-manes report", () => {
+  const nodes = parseGradleDependencyTree(GRADLE_TREE);
+  const updMap = parseGradleDependencyUpdates(
+    JSON.stringify({
+      outdated: {
+        dependencies: [
+          { group: "com.google.guava", name: "guava", version: "19.0", available: { release: "33.6.0-jre" } },
+          {
+            group: "org.springframework",
+            name: "spring-core",
+            version: "5.2.0.RELEASE",
+            available: { release: "6.1.0" },
+          },
+        ],
+      },
+    }),
+  );
+  const merged = mergeDependencyUpdates(nodes, updMap);
+  const byKey = Object.fromEntries(merged.map((m) => [`${m.group}:${m.artifact}`, m]));
+  assert.equal(byKey["com.google.guava:guava"].direct, true);
+  assert.equal(byKey["com.google.guava:guava"].jump, "major");
+  assert.equal(byKey["org.springframework:spring-core"].direct, false);
+  assert.equal(byKey["org.springframework:spring-core"].via, "org.springframework:spring-web");
 });

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -33,6 +33,7 @@ const {
   mergeDependencyUpdates,
   parseGradleDependencyTree,
   parseGradleDependencyUpdates,
+  gradleDepConfigFilter,
   classifyVersionJump,
   isPrerelease,
 } = await import("../extension.mjs");
@@ -747,6 +748,66 @@ test("parseGradleDependencyTree resolves version coercion (a -> b)", () => {
   assert.equal(byKey["org.slf4j:slf4j-api"].version, "2.0.13");
   // A constraint-only line (no requested version) still resolves via the arrow.
   assert.equal(byKey["com.example:lib"].version, "3.1.0");
+});
+
+test("gradleDepConfigFilter keeps real dependency classpaths and drops internal configs", () => {
+  for (const ok of [
+    "compileClasspath",
+    "runtimeClasspath",
+    "testCompileClasspath",
+    "testRuntimeClasspath",
+    "productionRuntimeClasspath",
+    "integrationTestRuntimeClasspath",
+    "annotationProcessor",
+    "testAnnotationProcessor",
+    "developmentOnly",
+    "testAndDevelopmentOnly",
+  ]) {
+    assert.equal(gradleDepConfigFilter(ok), true, `${ok} should be a dependency classpath`);
+  }
+  for (const no of [
+    "kotlinCompilerPluginClasspathMain",
+    "kotlinBuildToolsApiClasspath",
+    "kotlinCompilerClasspath",
+    "apiElements",
+    "runtimeElements",
+    "mainSourceElements",
+    "implementationDependenciesMetadata",
+    "default",
+    "archives",
+  ]) {
+    assert.equal(gradleDepConfigFilter(no), false, `${no} should be excluded`);
+  }
+});
+
+test("parseGradleDependencyTree with a configFilter ignores internal plugin configs", () => {
+  // A real-world multi-config report: a plugin/compiler classpath that the user
+  // does not declare, plus the compile/test classpaths that they do.
+  const tree = [
+    "kotlinCompilerPluginClasspathMain - Kotlin compiler plugins for compilation",
+    "\\--- org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable:2.2.0",
+    "",
+    "compileClasspath - Compile classpath for source set 'main'.",
+    "+--- com.example:app-lib:1.0",
+    "|    \\--- com.example:shared:1.0",
+    "",
+    "testRuntimeClasspath - Runtime classpath of source set 'test'.",
+    "\\--- org.junit.jupiter:junit-jupiter:5.10.0",
+    "     \\--- org.junit.jupiter:junit-jupiter-api:5.10.0",
+    "",
+  ].join("\n");
+  const nodes = parseGradleDependencyTree(tree, { configFilter: gradleDepConfigFilter });
+  const byKey = Object.fromEntries(nodes.map((n) => [n.key, n]));
+  // The compiler-plugin artifact lives only in a kotlin* config and is dropped.
+  assert.equal(byKey["org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable"], undefined);
+  // Declared deps are direct; their transitive children are transitive.
+  assert.equal(byKey["com.example:app-lib"].direct, true);
+  assert.equal(byKey["com.example:shared"].direct, false);
+  assert.equal(byKey["org.junit.jupiter:junit-jupiter"].direct, true);
+  assert.equal(byKey["org.junit.jupiter:junit-jupiter-api"].direct, false);
+  // Without the filter every configuration is parsed, including the kotlin one.
+  const all = parseGradleDependencyTree(tree);
+  assert.ok(all.some((n) => n.key === "org.jetbrains.kotlin:kotlin-allopen-compiler-plugin-embeddable"));
 });
 
 test("parseGradleDependencyUpdates reads the ben-manes JSON outdated list", () => {

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -297,6 +297,22 @@ test("pomCaps / gradleCaps detect the Quarkus Micrometer metrics dependency", ()
   );
 });
 
+test("pomCaps / gradleCaps detect the Quarkus logging-manager extension", () => {
+  const withLm =
+    "<project><dependencies><dependency><groupId>io.quarkiverse.loggingmanager</groupId>" +
+    "<artifactId>quarkus-logging-manager</artifactId></dependency></dependencies></project>";
+  assert.equal(pomCaps(withLm, "app").loggingManager, true, "Maven: logging-manager detected");
+  assert.equal(pomCaps("<project/>", "app").loggingManager, false, "Maven: absent when no logging-manager dep");
+
+  const gradleWith = 'dependencies { runtimeOnly("io.quarkiverse.loggingmanager:quarkus-logging-manager") }';
+  assert.equal(gradleCaps(gradleWith, "app").loggingManager, true, "Gradle: logging-manager detected");
+  assert.equal(
+    gradleCaps("plugins { id 'java' }", "app").loggingManager,
+    false,
+    "Gradle: absent when no logging-manager dep",
+  );
+});
+
 test("normalizeQuarkusLoggers maps the listing to the shared shape (ROOT first)", () => {
   const out = normalizeQuarkusLoggers(
     [

--- a/test/parsers.test.mjs
+++ b/test/parsers.test.mjs
@@ -38,6 +38,8 @@ const {
   isPrerelease,
   pomCaps,
   gradleCaps,
+  looksLikeSmallryeHealth,
+  looksLikePrometheus,
 } = await import("../extension.mjs");
 
 // ---------------------------------------------------------------------------
@@ -279,6 +281,40 @@ test("quarkusMetrics surfaces the SmallRye health checks breakdown", () => {
 test("quarkusMetrics defaults the health checks to an empty list", () => {
   const out = quarkusMetrics(null, { status: "UP" });
   assert.deepEqual(out.health, { status: "UP", checks: [] });
+});
+
+// A secured Spring Boot app redirects /q/* to its login page; fetch follows the
+// redirect to a 200 HTML body. These guards keep that page out of the Quarkus tier.
+test("looksLikeSmallryeHealth accepts SmallRye Health but rejects login pages and Spring error JSON", () => {
+  assert.equal(looksLikeSmallryeHealth({ status: "UP", checks: [] }), true, "real SmallRye Health");
+  assert.equal(looksLikeSmallryeHealth({ status: "DOWN" }), true, "DOWN with no checks is still health");
+  assert.equal(looksLikeSmallryeHealth(null), false, "no body");
+  assert.equal(looksLikeSmallryeHealth("<html>login</html>"), false, "an HTML string isn't health JSON");
+  // Spring Boot's default error JSON carries a numeric status, not "UP"/"DOWN".
+  assert.equal(
+    looksLikeSmallryeHealth({ timestamp: "now", status: 401, error: "Unauthorized", path: "/q/health" }),
+    false,
+    "Spring's numeric-status error JSON is rejected",
+  );
+});
+
+test("looksLikePrometheus accepts a Micrometer scrape but rejects a login page", () => {
+  assert.equal(looksLikePrometheus(PROM), true, "a real Prometheus scrape with samples");
+  assert.equal(
+    looksLikePrometheus(
+      "# HELP jvm_threads_live_threads The current number of live threads\n# TYPE jvm_threads_live_threads gauge",
+    ),
+    true,
+    "HELP/TYPE comments alone are enough",
+  );
+  assert.equal(looksLikePrometheus(null), false, "no body");
+  assert.equal(
+    looksLikePrometheus(
+      '<!DOCTYPE html><html lang="en"><head><title>Please sign in</title></head><body>...</body></html>',
+    ),
+    false,
+    "a Spring Security login page is not Prometheus exposition",
+  );
 });
 
 test("pomCaps / gradleCaps detect the Quarkus Micrometer metrics dependency", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -183,6 +183,68 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
   assert.equal(status.hidden, true, "no Actuator status for a non-Spring module");
 });
 
+test("the Live JVM tab explains why it's inactive and offers the dependency fix", () => {
+  const metrics = () => win.document.getElementById("metrics").innerHTML;
+
+  // Spring Boot app without Actuator, not running: reason + Add Actuator with Copilot.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false }],
+    capabilities: { springBoot: true, maven: true },
+  });
+  win.renderMetrics({ appUp: false });
+  let fix = win.document.getElementById("metrics-fix");
+  assert.ok(fix, "a Spring app without Actuator offers a metrics fix");
+  assert.match(fix.textContent, /Add Actuator with Copilot/);
+  assert.ok(fix.classList.contains("fix-copilot"), "the metrics fix uses the orange Copilot CTA color");
+
+  // Quarkus app without Micrometer, running but no endpoint (process tier).
+  win.applyEnv({
+    modules: [{ name: "svc", artifactId: "svc", runnable: true, quarkus: true, quarkusMetrics: false }],
+    capabilities: { quarkus: true, maven: true },
+  });
+  win.renderMetrics({ appUp: true, metricsTier: "process" });
+  fix = win.document.getElementById("metrics-fix");
+  assert.ok(fix, "a Quarkus app without Micrometer offers a metrics fix");
+  assert.match(fix.textContent, /Add Quarkus metrics with Copilot/);
+
+  // Plain Java app, down: a reason, but no dependency fix to offer.
+  win.applyEnv({
+    modules: [{ name: "lib", artifactId: "lib", runnable: true }],
+    capabilities: { maven: true },
+  });
+  win.renderMetrics(null);
+  assert.equal(win.document.getElementById("metrics-fix"), null, "no dependency fix for a plain Java app");
+  assert.match(metrics(), /isn.t running/i, "explains that the app isn't running");
+});
+
+test("the Spring and Quarkus tabs explain why they're inactive", () => {
+  const actuatorSection = win.document.getElementById("spring-actuator-section");
+  const devtoolsSection = win.document.getElementById("spring-devtools-section");
+  const quarkusEmpty = win.document.getElementById("quarkus-empty");
+
+  // Neither a Spring nor a Quarkus project: Spring sub-sections hidden with a
+  // reason, Quarkus tab shows its "not a Quarkus app" reason.
+  win.applyEnv({
+    modules: [{ name: "lib", artifactId: "lib", runnable: true }],
+    capabilities: { maven: true },
+    spring: { detected: false },
+  });
+  assert.equal(actuatorSection.hidden, true, "Actuator section hidden without a Spring module");
+  assert.equal(devtoolsSection.hidden, true, "DevTools section hidden without a Spring module");
+  assert.match(win.document.getElementById("spring-version").innerHTML, /isn.t a Spring Boot/i);
+  assert.equal(quarkusEmpty.hidden, false, "Quarkus reason shown when it isn't a Quarkus app");
+  assert.match(quarkusEmpty.textContent, /isn.t a Quarkus app/i);
+
+  // A Spring Boot project: the sub-sections come back.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true }],
+    capabilities: { springBoot: true, maven: true },
+    spring: { detected: true, version: "3.3.0", status: "current" },
+  });
+  assert.equal(actuatorSection.hidden, false, "Actuator section visible for a Spring project");
+  assert.equal(devtoolsSection.hidden, false, "DevTools section visible for a Spring project");
+});
+
 test("the Settings tab is pinned to the top of the aside bar", () => {
   win.updateAsideAvailability({ metrics: true, loggers: false, scans: false });
   const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -120,31 +120,41 @@ test("renderMcp tolerates an unavailable MCP server", () => {
   assert.doesNotThrow(() => win.renderMcp({ available: false }));
 });
 
-test("renderLoggers tailors the no-endpoint message per framework", () => {
+test("the Loggers tab shares the inactive dependency story with Live JVM", () => {
   const list = () => win.document.getElementById("loggers-list").innerHTML;
 
-  // App down: a Live-JVM-style "not running" message, no fix button.
-  assert.doesNotThrow(() => win.renderLoggers({ available: false, appDown: true }));
-  assert.ok(/isn.t running/i.test(list()), "expected an app-not-running message like Live JVM");
-  assert.equal(win.document.getElementById("loggers-fix"), null, "no fix button when the app is down");
+  // App down on a plain Java project: a "not running" lead, no dependency fix.
+  win.applyEnv({ modules: [{ name: "lib", artifactId: "lib", runnable: true }], capabilities: { maven: true } });
+  win.renderLoggers({ available: false, appDown: true });
+  assert.match(list(), /isn.t running/i, "expected an app-not-running lead like Live JVM");
+  assert.equal(win.document.getElementById("diag-fix-lm"), null, "no fix button for a plain Java app");
 
-  // Spring Boot, app up, no /loggers: points at the Spring tab, no inline fix button
-  // (Actuator setup now lives in the Spring tab).
-  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "spring" }));
-  assert.ok(list().includes("Actuator"), "expected the Spring Boot Actuator hint");
-  assert.ok(/Spring<\/strong> tab/.test(list()), "points the user at the Spring tab");
-  assert.equal(win.document.getElementById("loggers-fix"), null, "no inline fix button for a Spring app");
+  // Spring Boot without Actuator, app up but no /loggers: Add Actuator then Add BootUI.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false }],
+    capabilities: { springBoot: true, maven: true },
+  });
+  win.renderLoggers({ available: false });
+  assert.ok(win.document.getElementById("diag-fix-actuator"), "Spring w/o Actuator offers Add Actuator");
+  assert.ok(win.document.getElementById("diag-fix-bootui"), "and Add BootUI alongside it");
 
-  // Quarkus: logging-manager hint + a Fix button, no Actuator copy.
-  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "quarkus" }));
-  assert.ok(list().includes("quarkus-logging-manager"), "expected the Quarkus logging-manager hint");
+  // Quarkus without logging-manager: a single Add logging-manager fix, no Spring copy.
+  win.applyEnv({
+    modules: [{ name: "svc", artifactId: "svc", runnable: true, quarkus: true, loggingManager: false }],
+    capabilities: { quarkus: true, maven: true },
+  });
+  win.renderLoggers({ available: false });
+  assert.ok(win.document.getElementById("diag-fix-lm"), "Quarkus w/o logging-manager offers its fix");
   assert.ok(!/Actuator/.test(list()), "no Spring Boot copy for a Quarkus app");
-  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button for Quarkus");
 
-  // Plain Java (or unknown): generic message, no fix button.
-  assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "java" }));
-  assert.ok(list().includes("only"), "expected the generic 'only Spring Boot or Quarkus' message");
-  assert.equal(win.document.getElementById("loggers-fix"), null, "no fix button for a non-framework app");
+  // Quarkus with logging-manager present: confirm it's set up, no fix button.
+  win.applyEnv({
+    modules: [{ name: "svc", artifactId: "svc", runnable: true, quarkus: true, loggingManager: true }],
+    capabilities: { quarkus: true, loggingManager: true, maven: true },
+  });
+  win.renderLoggers({ available: false, appDown: true });
+  assert.match(list(), /logging-manager is set up/i, "confirms logging-manager is set up");
+  assert.equal(win.document.getElementById("diag-fix-lm"), null, "no fix once logging-manager is present");
 });
 
 test("the Spring tab offers to add Actuator only when the module lacks it", () => {
@@ -186,16 +196,17 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
 test("the Live JVM tab explains why it's inactive and offers the dependency fix", () => {
   const metrics = () => win.document.getElementById("metrics").innerHTML;
 
-  // Spring Boot app without Actuator, not running: reason + Add Actuator with Copilot.
+  // Spring Boot app without Actuator, not running: Add Actuator then Add BootUI.
   win.applyEnv({
     modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false }],
     capabilities: { springBoot: true, maven: true },
   });
   win.renderMetrics({ appUp: false });
-  let fix = win.document.getElementById("metrics-fix");
-  assert.ok(fix, "a Spring app without Actuator offers a metrics fix");
-  assert.match(fix.textContent, /Add Actuator with Copilot/);
-  assert.ok(fix.classList.contains("fix-copilot"), "the metrics fix uses the orange Copilot CTA color");
+  let actuator = win.document.getElementById("diag-fix-actuator");
+  assert.ok(actuator, "a Spring app without Actuator offers Add Actuator");
+  assert.match(actuator.textContent, /Add Actuator with Copilot/);
+  assert.ok(actuator.classList.contains("fix-copilot"), "the metrics fix uses the orange Copilot CTA color");
+  assert.ok(win.document.getElementById("diag-fix-bootui"), "and offers Add BootUI alongside it");
 
   // Quarkus app without Micrometer, running but no endpoint (process tier).
   win.applyEnv({
@@ -203,9 +214,9 @@ test("the Live JVM tab explains why it's inactive and offers the dependency fix"
     capabilities: { quarkus: true, maven: true },
   });
   win.renderMetrics({ appUp: true, metricsTier: "process" });
-  fix = win.document.getElementById("metrics-fix");
-  assert.ok(fix, "a Quarkus app without Micrometer offers a metrics fix");
-  assert.match(fix.textContent, /Add Quarkus metrics with Copilot/);
+  const qm = win.document.getElementById("diag-fix-qm");
+  assert.ok(qm, "a Quarkus app without Micrometer offers a metrics fix");
+  assert.match(qm.textContent, /Add Quarkus metrics with Copilot/);
 
   // Plain Java app, down: a reason, but no dependency fix to offer.
   win.applyEnv({
@@ -213,8 +224,33 @@ test("the Live JVM tab explains why it's inactive and offers the dependency fix"
     capabilities: { maven: true },
   });
   win.renderMetrics(null);
-  assert.equal(win.document.getElementById("metrics-fix"), null, "no dependency fix for a plain Java app");
+  assert.equal(win.document.getElementById("diag-fix-actuator"), null, "no dependency fix for a plain Java app");
   assert.match(metrics(), /isn.t running/i, "explains that the app isn't running");
+});
+
+test("the Live JVM tab layers the Spring Actuator and BootUI offers", () => {
+  // Actuator already on the classpath but no BootUI: confirm Actuator is set up,
+  // drop the Actuator offer, and keep the BootUI offer.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: false }],
+    capabilities: { springBoot: true, actuator: true, maven: true },
+  });
+  win.renderMetrics({ appUp: false });
+  let html = win.document.getElementById("metrics").innerHTML;
+  assert.match(html, /Actuator is set up/i, "tells the user Actuator is set up");
+  assert.equal(win.document.getElementById("diag-fix-actuator"), null, "no Actuator offer once it's present");
+  assert.ok(win.document.getElementById("diag-fix-bootui"), "still offers BootUI for richer metrics");
+
+  // BootUI present: it covers everything, so no Actuator offer at all.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: true }],
+    capabilities: { springBoot: true, actuator: true, bootui: true, maven: true },
+  });
+  win.renderMetrics({ appUp: false });
+  html = win.document.getElementById("metrics").innerHTML;
+  assert.match(html, /BootUI is set up/i, "tells the user BootUI is set up");
+  assert.equal(win.document.getElementById("diag-fix-actuator"), null, "no Actuator offer when BootUI is present");
+  assert.equal(win.document.getElementById("diag-fix-bootui"), null, "no BootUI offer when BootUI is present");
 });
 
 test("the Spring and Quarkus tabs explain why they're inactive", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -293,6 +293,28 @@ test("the Live JVM tab layers the Spring Actuator and BootUI offers", () => {
   assert.equal(win.document.getElementById("diag-fix-bootui"), null, "no BootUI offer when BootUI is present");
 });
 
+test("the Advisor scans tab shares the inactive BootUI story with Live JVM", () => {
+  const scansHint = () => win.document.getElementById("scans-hint").innerHTML;
+
+  // BootUI set up but the app is down: same two-part message as Live JVM/Loggers.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: true }],
+    capabilities: { springBoot: true, actuator: true, bootui: true, maven: true },
+  });
+  win.renderMetrics({ appUp: false });
+  assert.match(scansHint(), /isn.t running/i, "scans tab explains the app isn't running");
+  assert.match(scansHint(), /BootUI is set up/i, "scans tab confirms BootUI is set up");
+  assert.match(scansHint(), /run the app to use this tab/i, "scans tab tells the user to run the app");
+
+  // Spring app without BootUI: point at the Add BootUI CTA above instead.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: false }],
+    capabilities: { springBoot: true, actuator: true, maven: true },
+  });
+  win.renderMetrics({ appUp: false });
+  assert.match(scansHint(), /need BootUI/i, "scans tab says advisor scans need BootUI when it's absent");
+});
+
 test("the Spring and Quarkus tabs explain why they're inactive", () => {
   const actuatorSection = win.document.getElementById("spring-actuator-section");
   const devtoolsSection = win.document.getElementById("spring-devtools-section");

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -151,6 +151,78 @@ test("the Settings tab is pinned to the top of the aside bar", () => {
   assert.ok(order("scans") > 100, "an unavailable panel sinks below the separator");
 });
 
+test("renderDeps renders an outdated-library list", () => {
+  assert.equal(typeof win.renderDeps, "function", "renderDeps should be a global");
+  // A bad payload shows an error, not a throw.
+  assert.doesNotThrow(() => win.renderDeps(null));
+  assert.doesNotThrow(() => win.renderDeps({ error: "boom" }));
+
+  // Idle snapshot: scan not yet run.
+  assert.doesNotThrow(() =>
+    win.renderDeps({
+      ran: false,
+      buildTool: "maven",
+      available: true,
+      updatesSupported: true,
+      updates: [],
+      counts: { total: 0, direct: 0, transitive: 0 },
+    }),
+  );
+  let html = win.document.getElementById("deps-result").innerHTML;
+  assert.ok(html.includes("Outdated libraries"), "expected the outdated-libraries section");
+  assert.ok(html.includes("Check dependencies"), "expected the prompt to run a scan");
+
+  // A completed scan with a direct + a transitive outdated dependency.
+  assert.doesNotThrow(() =>
+    win.renderDeps({
+      ran: true,
+      buildTool: "maven",
+      available: true,
+      updatesSupported: true,
+      updates: [
+        {
+          group: "com.google.guava",
+          artifact: "guava",
+          current: "19.0",
+          latest: "33.6.0-jre",
+          scope: "compile",
+          direct: true,
+          via: null,
+          prerelease: false,
+          jump: "major",
+        },
+        {
+          group: "org.slf4j",
+          artifact: "slf4j-api",
+          current: "1.7.20",
+          latest: "2.1.0-alpha1",
+          scope: "compile",
+          direct: false,
+          via: "org.example:lib",
+          prerelease: true,
+          jump: "major",
+        },
+      ],
+      counts: { total: 2, direct: 1, transitive: 1 },
+    }),
+  );
+  html = win.document.getElementById("deps-result").innerHTML;
+  assert.ok(html.includes("guava"), "expected the outdated dependency in the rendered list");
+  assert.ok(html.includes("data-dep-fix"), "expected a Fix-with-Copilot button per dependency");
+
+  // Gradle: outdated scanning unsupported.
+  assert.doesNotThrow(() =>
+    win.renderDeps({
+      ran: false,
+      buildTool: "gradle",
+      available: true,
+      updatesSupported: false,
+      updates: [],
+      counts: { total: 0, direct: 0, transitive: 0 },
+    }),
+  );
+});
+
 test("renderTests renders a graphical report with a failure", () => {
   const report = {
     summary: { tests: 2, passed: 1, failures: 1, errors: 0, skipped: 0, timeSec: 0.2, files: 1 },

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -193,6 +193,46 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
   assert.equal(status.hidden, true, "no Actuator status for a non-Spring module");
 });
 
+test("BootUI configured suppresses the Actuator offer and confirms BootUI", () => {
+  const addActuator = win.document.getElementById("btn-add-actuator");
+  const actuatorStatus = win.document.getElementById("actuator-status");
+  const actuatorBootui = win.document.getElementById("actuator-bootui-status");
+  const actuatorHint = win.document.getElementById("actuator-hint");
+  const bootuiConfigured = win.document.getElementById("bootui-configured");
+  const bootuiDesc = win.document.getElementById("bootui-desc");
+  const addBootui = win.document.getElementById("btn-add-bootui");
+
+  // BootUI configured (it bundles Actuator) even with actuator:false on the module:
+  // the Spring tab drops the Actuator hint + add button and confirms BootUI, and the
+  // scans tab confirms BootUI instead of pitching the starter.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false, bootui: true }],
+    capabilities: { springBoot: true, bootui: true, maven: true },
+  });
+  assert.equal(addActuator.hidden, true, "no Add Actuator when BootUI is configured");
+  assert.equal(actuatorHint.hidden, true, "Actuator hint hidden when BootUI is configured");
+  assert.equal(actuatorStatus.hidden, true, "no 'Actuator on classpath' line when BootUI is configured");
+  assert.equal(actuatorBootui.hidden, false, "Spring tab confirms BootUI includes Actuator");
+  assert.match(actuatorBootui.textContent, /BootUI is configured/i);
+  assert.equal(addBootui.hidden, true, "no Add BootUI once the module already has BootUI");
+  assert.equal(bootuiConfigured.hidden, false, "scans tab confirms BootUI is configured");
+  assert.match(bootuiConfigured.textContent, /BootUI is configured/i);
+  assert.equal(bootuiDesc.hidden, true, "the add-the-starter description is hidden once BootUI is configured");
+
+  // Actuator present but no BootUI: Actuator status shown, BootUI confirmation hidden,
+  // Add BootUI offered (richer metrics), no Add Actuator.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: false }],
+    capabilities: { springBoot: true, actuator: true, maven: true },
+  });
+  assert.equal(actuatorStatus.hidden, false, "Actuator status shown when Actuator present without BootUI");
+  assert.equal(actuatorBootui.hidden, true, "no BootUI confirmation when BootUI absent");
+  assert.equal(addActuator.hidden, true, "no Add Actuator when Actuator is already present");
+  assert.equal(addBootui.hidden, false, "still offers Add BootUI for richer metrics");
+  assert.equal(bootuiConfigured.hidden, true, "scans tab does not claim BootUI configured when it isn't");
+  assert.equal(bootuiDesc.hidden, false, "the add-the-starter description shows when BootUI is absent");
+});
+
 test("the Live JVM tab explains why it's inactive and offers the dependency fix", () => {
   const metrics = () => win.document.getElementById("metrics").innerHTML;
 

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -120,25 +120,60 @@ test("renderMcp tolerates an unavailable MCP server", () => {
   assert.doesNotThrow(() => win.renderMcp({ available: false }));
 });
 
-test("renderLoggers tailors the no-endpoint hint and fix button per framework", () => {
+test("renderLoggers tailors the no-endpoint message per framework", () => {
   const list = () => win.document.getElementById("loggers-list").innerHTML;
 
-  // Spring Boot: Actuator hint + a Fix button wired to install-actuator-loggers.
+  // App down: a Live-JVM-style "not running" message, no fix button.
+  assert.doesNotThrow(() => win.renderLoggers({ available: false, appDown: true }));
+  assert.ok(/isn.t running/i.test(list()), "expected an app-not-running message like Live JVM");
+  assert.equal(win.document.getElementById("loggers-fix"), null, "no fix button when the app is down");
+
+  // Spring Boot, app up, no /loggers: points at the Spring tab, no inline fix button
+  // (Actuator setup now lives in the Spring tab).
   assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "spring" }));
   assert.ok(list().includes("Actuator"), "expected the Spring Boot Actuator hint");
-  assert.ok(!list().includes("quarkus-logging-manager"), "no Quarkus copy for a Spring app");
-  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button");
+  assert.ok(/Spring<\/strong> tab/.test(list()), "points the user at the Spring tab");
+  assert.equal(win.document.getElementById("loggers-fix"), null, "no inline fix button for a Spring app");
 
   // Quarkus: logging-manager hint + a Fix button, no Actuator copy.
   assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "quarkus" }));
   assert.ok(list().includes("quarkus-logging-manager"), "expected the Quarkus logging-manager hint");
   assert.ok(!/Actuator/.test(list()), "no Spring Boot copy for a Quarkus app");
-  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button");
+  assert.ok(win.document.getElementById("loggers-fix"), "expected a Fix with Copilot button for Quarkus");
 
   // Plain Java (or unknown): generic message, no fix button.
   assert.doesNotThrow(() => win.renderLoggers({ available: false, runMode: "java" }));
   assert.ok(list().includes("only"), "expected the generic 'only Spring Boot or Quarkus' message");
   assert.equal(win.document.getElementById("loggers-fix"), null, "no fix button for a non-framework app");
+});
+
+test("the Spring tab offers to add Actuator only when the module lacks it", () => {
+  const btn = win.document.getElementById("btn-add-actuator");
+  const status = win.document.getElementById("actuator-status");
+
+  // Spring Boot module without Actuator: the add button shows, status hidden.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false, devtools: true }],
+    capabilities: { springBoot: true, maven: true },
+  });
+  assert.equal(btn.hidden, false, "Add Actuator shown when the module lacks Actuator");
+  assert.equal(status.hidden, true, "no 'on the classpath' status without Actuator");
+
+  // Spring Boot module with Actuator: button hidden, status shown.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, devtools: true }],
+    capabilities: { springBoot: true, maven: true },
+  });
+  assert.equal(btn.hidden, true, "Add Actuator hidden once Actuator is present");
+  assert.equal(status.hidden, false, "status confirms Actuator is on the classpath");
+
+  // Non-Spring module: neither the button nor the status shows.
+  win.applyEnv({
+    modules: [{ name: "lib", artifactId: "lib", runnable: true, springBoot: false, actuator: false }],
+    capabilities: {},
+  });
+  assert.equal(btn.hidden, true, "Add Actuator hidden for a non-Spring module");
+  assert.equal(status.hidden, true, "no Actuator status for a non-Spring module");
 });
 
 test("the Settings tab is pinned to the top of the aside bar", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -220,8 +220,8 @@ test("BootUI configured suppresses the Actuator part and confirms BootUI", () =>
   assert.equal(bootuiSpringHint.hidden, true, "the BootUI pitch hides once it's configured");
   assert.equal(addBootuiSpring.hidden, true, "no Add BootUI (Spring tab) once configured");
   assert.equal(addBootui.hidden, true, "no Add BootUI (scans tab) once configured");
-  assert.equal(bootuiConfigured.hidden, false, "scans tab confirms BootUI is configured");
-  assert.match(bootuiConfigured.textContent, /BootUI is configured/i);
+  assert.equal(bootuiConfigured.hidden, false, "scans tab confirms BootUI is set up");
+  assert.match(bootuiConfigured.textContent, /BootUI is set up/i);
   assert.equal(bootuiDesc.hidden, true, "the add-the-starter description is hidden once BootUI is configured");
 
   // Neither Actuator nor BootUI: both parts show, each with its Add … with Copilot CTA.
@@ -308,17 +308,22 @@ test("the Live JVM tab layers the Spring Actuator and BootUI offers", () => {
   assert.equal(win.document.getElementById("diag-fix-bootui"), null, "no BootUI offer when BootUI is present");
 });
 
-test("the Advisor scans tab shares the inactive BootUI story with Live JVM", () => {
+test("the Advisor scans inactive body gives the next step without repeating the title (§7.6)", () => {
   const scansHint = () => win.document.getElementById("scans-hint").innerHTML;
 
-  // BootUI set up but the app is down: same two-part message as Live JVM/Loggers.
+  // BootUI set up but the app is down: the pane title already says "BootUI is set
+  // up", so the inactive body just gives the next step (no redundant confirmation).
   win.applyEnv({
     modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: true }],
     capabilities: { springBoot: true, actuator: true, bootui: true, maven: true },
   });
   win.renderMetrics({ appUp: false });
   assert.match(scansHint(), /isn.t running/i, "scans tab explains the app isn't running");
-  assert.match(scansHint(), /BootUI is set up/i, "scans tab confirms BootUI is set up");
+  assert.doesNotMatch(
+    scansHint(),
+    /BootUI is set up/i,
+    "inactive body no longer repeats the title's set-up confirmation",
+  );
   assert.match(scansHint(), /run the app to use this tab/i, "scans tab tells the user to run the app");
 
   // Spring app without BootUI: point at the Add BootUI CTA above instead.
@@ -356,6 +361,28 @@ test("the Spring and Quarkus tabs explain why they're inactive", () => {
   });
   assert.equal(actuatorSection.hidden, false, "Actuator section visible for a Spring project");
   assert.equal(devtoolsSection.hidden, false, "DevTools section visible for a Spring project");
+});
+
+test("the Quarkus Register CTA sits above the MCP server panel (§7.5)", () => {
+  const desc = win.document.getElementById("quarkus-desc");
+  const btn = win.document.getElementById("quarkus-mcp-register");
+  const panel = win.document.getElementById("quarkus-mcp");
+  assert.ok(desc && btn && panel, "the Quarkus description, register button and MCP panel all exist");
+  // The CTA is a standalone sibling between the description and the MCP server
+  // panel — not nested inside the panel's "Quarkus Agent MCP server" switch-row.
+  assert.equal(
+    btn.parentElement,
+    panel.parentElement,
+    "the register button is a sibling of the MCP panel, not nested in it",
+  );
+  assert.ok(
+    desc.compareDocumentPosition(btn) & win.Node.DOCUMENT_POSITION_FOLLOWING,
+    "the register button comes after the description",
+  );
+  assert.ok(
+    btn.compareDocumentPosition(panel) & win.Node.DOCUMENT_POSITION_FOLLOWING,
+    "the register button comes above the Quarkus Agent MCP server panel",
+  );
 });
 
 test("the Settings tab is pinned to the top of the aside bar", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -210,17 +210,31 @@ test("renderDeps renders an outdated-library list", () => {
   assert.ok(html.includes("guava"), "expected the outdated dependency in the rendered list");
   assert.ok(html.includes("data-dep-fix"), "expected a Fix-with-Copilot button per dependency");
 
-  // Gradle: outdated scanning unsupported.
+  // Gradle: outdated scanning is now supported (same payload shape as Maven).
   assert.doesNotThrow(() =>
     win.renderDeps({
-      ran: false,
+      ran: true,
       buildTool: "gradle",
       available: true,
-      updatesSupported: false,
-      updates: [],
-      counts: { total: 0, direct: 0, transitive: 0 },
+      updatesSupported: true,
+      updates: [
+        {
+          group: "com.google.guava",
+          artifact: "guava",
+          current: "19.0",
+          latest: "33.6.0-jre",
+          scope: "runtime",
+          direct: true,
+          via: null,
+          prerelease: false,
+          jump: "major",
+        },
+      ],
+      counts: { total: 1, direct: 1, transitive: 0 },
     }),
   );
+  html = win.document.getElementById("deps-result").innerHTML;
+  assert.ok(html.includes("guava"), "expected the Gradle outdated dependency in the rendered list");
 });
 
 test("renderTests renders a graphical report with a failure", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -588,6 +588,42 @@ test("the Dependencies direct-only filter hides transitive updates (\u00a77.7)",
   assert.doesNotMatch(result(), /slf4j-api/, "transitive update hidden when direct-only is on");
 });
 
+test("the Dependencies direct-only toggle stays interactive even with no transitive updates (\u00a77.7)", () => {
+  const direct = win.document.getElementById("deps-direct");
+  // An all-direct scan (counts.transitive === 0) must NOT disable the toggle: it's a
+  // view preference, usable whenever the build tool supports update scanning.
+  win.renderDeps({
+    ran: true,
+    buildTool: "maven",
+    updatesSupported: true,
+    updates: [
+      {
+        group: "com.google.guava",
+        artifact: "guava",
+        current: "19.0",
+        latest: "33.6.0-jre",
+        scope: "compile",
+        direct: true,
+        via: null,
+        prerelease: false,
+        jump: "major",
+      },
+    ],
+    counts: { total: 1, direct: 1, transitive: 0 },
+  });
+  assert.equal(direct.disabled, false, "direct-only toggle stays enabled when there are no transitive updates");
+
+  // Only a project whose build tool can't scan for updates disables it.
+  win.renderDeps({
+    ran: true,
+    buildTool: "ant",
+    updatesSupported: false,
+    updates: [],
+    counts: { total: 0, direct: 0, transitive: 0 },
+  });
+  assert.equal(direct.disabled, true, "direct-only toggle is disabled when update scanning is unsupported");
+});
+
 test("applySettingsState restores the view/preference toggles", () => {
   assert.equal(typeof win.applySettingsState, "function", "applySettingsState should be a global");
   const depsDirect = win.document.getElementById("deps-direct");

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -151,6 +151,36 @@ test("the Settings tab is pinned to the top of the aside bar", () => {
   assert.ok(order("scans") > 100, "an unavailable panel sinks below the separator");
 });
 
+test("the aside bar keeps its canonical order in both the available and unavailable groups", () => {
+  // Make every gated tab available so the whole bar sits in the available group,
+  // then assert the canonical sequence the user expects:
+  // Settings, Live JVM, Loggers, Spring, Quarkus, BootUI, Upgrades.
+  win.updateAsideAvailability({ metrics: true, loggers: true, scans: true, spring: true, quarkus: true });
+  const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);
+  const canonical = ["settings", "metrics", "loggers", "spring", "quarkus", "scans", "deps"];
+  for (let i = 1; i < canonical.length; i++) {
+    assert.ok(
+      order(canonical[i]) > order(canonical[i - 1]),
+      `${canonical[i]} sorts after ${canonical[i - 1]} when available`,
+    );
+  }
+
+  // Grey out the runtime tabs: they drop into the unavailable group (below the
+  // separator) but keep the same relative order among themselves, while the
+  // always-on Settings + Upgrades stay on top.
+  win.updateAsideAvailability({ metrics: false, loggers: false, scans: false, spring: false, quarkus: false });
+  assert.equal(order("settings"), 0, "Settings still leads the available group");
+  assert.ok(order("deps") < 100 && order("deps") > 0, "Upgrades stays available, just after Settings");
+  const unavailable = ["metrics", "loggers", "spring", "quarkus", "scans"];
+  for (const name of unavailable) assert.ok(order(name) > 100, `${name} sinks below the separator`);
+  for (let i = 1; i < unavailable.length; i++) {
+    assert.ok(
+      order(unavailable[i]) > order(unavailable[i - 1]),
+      `${unavailable[i]} keeps its canonical order after ${unavailable[i - 1]} when unavailable`,
+    );
+  }
+});
+
 test("renderDeps renders an outdated-library list", () => {
   assert.equal(typeof win.renderDeps, "function", "renderDeps should be a global");
   // A bad payload shows an error, not a throw.

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -359,22 +359,22 @@ test("the Spring and Quarkus tabs explain why they're inactive", () => {
 });
 
 test("the Settings tab is pinned to the top of the aside bar", () => {
-  win.updateAsideAvailability({ metrics: true, loggers: false, scans: false });
+  win.updateAsideAvailability({ jvm: true, loggers: false, bootui: false });
   const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);
   // Available group sorts below the separator (order 50); within it Settings is
   // first (rank 0). Unavailable panels are offset by 100 so they sink to the bottom.
   assert.equal(order("settings"), 0, "Settings is pinned to the top of the bar");
-  assert.ok(order("metrics") > order("settings"), "an available panel sits below Settings");
-  assert.ok(order("scans") > 100, "an unavailable panel sinks below the separator");
+  assert.ok(order("jvm") > order("settings"), "an available panel sits below Settings");
+  assert.ok(order("bootui") > 100, "an unavailable panel sinks below the separator");
 });
 
 test("the aside bar keeps its canonical order in both the available and unavailable groups", () => {
   // Make every gated tab available so the whole bar sits in the available group,
   // then assert the canonical sequence the user expects:
   // Settings, Live JVM, Loggers, Spring, Quarkus, BootUI, Upgrades.
-  win.updateAsideAvailability({ metrics: true, loggers: true, scans: true, spring: true, quarkus: true });
+  win.updateAsideAvailability({ jvm: true, loggers: true, bootui: true, spring: true, quarkus: true });
   const order = (name) => Number(win.document.querySelector(`.atab[data-atab="${name}"]`).style.order);
-  const canonical = ["settings", "metrics", "loggers", "spring", "quarkus", "scans", "deps"];
+  const canonical = ["settings", "jvm", "loggers", "spring", "quarkus", "bootui", "deps"];
   for (let i = 1; i < canonical.length; i++) {
     assert.ok(
       order(canonical[i]) > order(canonical[i - 1]),
@@ -385,10 +385,10 @@ test("the aside bar keeps its canonical order in both the available and unavaila
   // Grey out the runtime tabs: they drop into the unavailable group (below the
   // separator) but keep the same relative order among themselves, while the
   // always-on Settings + Upgrades stay on top.
-  win.updateAsideAvailability({ metrics: false, loggers: false, scans: false, spring: false, quarkus: false });
+  win.updateAsideAvailability({ jvm: false, loggers: false, bootui: false, spring: false, quarkus: false });
   assert.equal(order("settings"), 0, "Settings still leads the available group");
   assert.ok(order("deps") < 100 && order("deps") > 0, "Upgrades stays available, just after Settings");
-  const unavailable = ["metrics", "loggers", "spring", "quarkus", "scans"];
+  const unavailable = ["jvm", "loggers", "spring", "quarkus", "bootui"];
   for (const name of unavailable) assert.ok(order(name) > 100, `${name} sinks below the separator`);
   for (let i = 1; i < unavailable.length; i++) {
     assert.ok(
@@ -638,10 +638,10 @@ test("a failed build shows the Fix button and replays the repaint pop", () => {
 test("the Spring Boot tab and its pane are present in the rail", () => {
   assert.ok(win.document.querySelector('.atab[data-atab="spring"]'), "Spring Boot rail button exists");
   assert.ok(win.document.getElementById("atab-spring"), "Spring Boot pane exists");
-  // It sits between Loggers and BootUI (scans).
+  // It sits between Loggers and BootUI (bootui).
   const order = [...win.document.querySelectorAll(".atab[data-atab]")].map((b) => b.dataset.atab);
   assert.ok(order.indexOf("spring") > order.indexOf("loggers"), "spring after loggers");
-  assert.ok(order.indexOf("spring") < order.indexOf("scans"), "spring before BootUI");
+  assert.ok(order.indexOf("spring") < order.indexOf("bootui"), "spring before BootUI");
 });
 
 test("renderSpringAdvisor reflects version status and gates the upgrade button", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -158,6 +158,13 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
   });
   assert.equal(btn.hidden, false, "Add Actuator shown when the module lacks Actuator");
   assert.equal(status.hidden, true, "no 'on the classpath' status without Actuator");
+  assert.match(btn.textContent, /with Copilot$/, "Add Actuator label ends with 'with Copilot'");
+  assert.ok(btn.classList.contains("fix-copilot"), "Add Actuator uses the orange fix-copilot CTA color");
+  for (const id of ["btn-add-actuator", "btn-add-devtools", "btn-add-bootui"]) {
+    const el = win.document.getElementById(id);
+    assert.match(el.textContent.trim(), /with Copilot$/, `${id} label ends with 'with Copilot'`);
+    assert.ok(el.classList.contains("fix-copilot"), `${id} uses the orange fix-copilot CTA color`);
+  }
 
   // Spring Boot module with Actuator: button hidden, status shown.
   win.applyEnv({

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -170,7 +170,7 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
   assert.equal(status.hidden, true, "no 'on the classpath' status without Actuator");
   assert.match(btn.textContent, /with Copilot$/, "Add Actuator label ends with 'with Copilot'");
   assert.ok(btn.classList.contains("fix-copilot"), "Add Actuator uses the orange fix-copilot CTA color");
-  for (const id of ["btn-add-actuator", "btn-add-devtools", "btn-add-bootui"]) {
+  for (const id of ["btn-add-actuator", "btn-add-devtools", "btn-add-bootui", "btn-add-bootui-spring"]) {
     const el = win.document.getElementById(id);
     assert.match(el.textContent.trim(), /with Copilot$/, `${id} label ends with 'with Copilot'`);
     assert.ok(el.classList.contains("fix-copilot"), `${id} uses the orange fix-copilot CTA color`);
@@ -193,42 +193,57 @@ test("the Spring tab offers to add Actuator only when the module lacks it", () =
   assert.equal(status.hidden, true, "no Actuator status for a non-Spring module");
 });
 
-test("BootUI configured suppresses the Actuator offer and confirms BootUI", () => {
+test("BootUI configured suppresses the Actuator part and confirms BootUI", () => {
+  const actuatorSection = win.document.getElementById("spring-actuator-section");
+  const bootuiSection = win.document.getElementById("spring-bootui-section");
   const addActuator = win.document.getElementById("btn-add-actuator");
   const actuatorStatus = win.document.getElementById("actuator-status");
-  const actuatorBootui = win.document.getElementById("actuator-bootui-status");
-  const actuatorHint = win.document.getElementById("actuator-hint");
+  const bootuiSpringStatus = win.document.getElementById("bootui-spring-status");
+  const bootuiSpringHint = win.document.getElementById("bootui-spring-hint");
+  const addBootuiSpring = win.document.getElementById("btn-add-bootui-spring");
   const bootuiConfigured = win.document.getElementById("bootui-configured");
   const bootuiDesc = win.document.getElementById("bootui-desc");
   const addBootui = win.document.getElementById("btn-add-bootui");
 
   // BootUI configured (it bundles Actuator) even with actuator:false on the module:
-  // the Spring tab drops the Actuator hint + add button and confirms BootUI, and the
-  // scans tab confirms BootUI instead of pitching the starter.
+  // the Actuator part is hidden entirely, the BootUI part confirms it, and the scans
+  // tab confirms it instead of pitching the starter.
   win.applyEnv({
     modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false, bootui: true }],
     capabilities: { springBoot: true, bootui: true, maven: true },
   });
+  assert.equal(actuatorSection.hidden, true, "Actuator section hidden when BootUI is configured");
   assert.equal(addActuator.hidden, true, "no Add Actuator when BootUI is configured");
-  assert.equal(actuatorHint.hidden, true, "Actuator hint hidden when BootUI is configured");
-  assert.equal(actuatorStatus.hidden, true, "no 'Actuator on classpath' line when BootUI is configured");
-  assert.equal(actuatorBootui.hidden, false, "Spring tab confirms BootUI includes Actuator");
-  assert.match(actuatorBootui.textContent, /BootUI is configured/i);
-  assert.equal(addBootui.hidden, true, "no Add BootUI once the module already has BootUI");
+  assert.equal(bootuiSection.hidden, false, "BootUI section shown for a Spring project");
+  assert.equal(bootuiSpringStatus.hidden, false, "Spring tab confirms BootUI is configured");
+  assert.match(bootuiSpringStatus.textContent, /BootUI is configured/i);
+  assert.equal(bootuiSpringHint.hidden, true, "the BootUI pitch hides once it's configured");
+  assert.equal(addBootuiSpring.hidden, true, "no Add BootUI (Spring tab) once configured");
+  assert.equal(addBootui.hidden, true, "no Add BootUI (scans tab) once configured");
   assert.equal(bootuiConfigured.hidden, false, "scans tab confirms BootUI is configured");
   assert.match(bootuiConfigured.textContent, /BootUI is configured/i);
   assert.equal(bootuiDesc.hidden, true, "the add-the-starter description is hidden once BootUI is configured");
 
-  // Actuator present but no BootUI: Actuator status shown, BootUI confirmation hidden,
-  // Add BootUI offered (richer metrics), no Add Actuator.
+  // Neither Actuator nor BootUI: both parts show, each with its Add … with Copilot CTA.
+  win.applyEnv({
+    modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: false, bootui: false }],
+    capabilities: { springBoot: true, maven: true },
+  });
+  assert.equal(actuatorSection.hidden, false, "Actuator section shown when Actuator is absent");
+  assert.equal(addActuator.hidden, false, "offers Add Actuator");
+  assert.equal(bootuiSection.hidden, false, "BootUI section shown below the Actuator part");
+  assert.equal(addBootuiSpring.hidden, false, "offers Add BootUI below the Actuator part");
+  assert.equal(bootuiSpringStatus.hidden, true, "no BootUI confirmation when BootUI is absent");
+
+  // Actuator present but no BootUI: Actuator status shown, BootUI still offered.
   win.applyEnv({
     modules: [{ name: "app", artifactId: "app", runnable: true, springBoot: true, actuator: true, bootui: false }],
     capabilities: { springBoot: true, actuator: true, maven: true },
   });
+  assert.equal(actuatorSection.hidden, false, "Actuator section shown when present without BootUI");
   assert.equal(actuatorStatus.hidden, false, "Actuator status shown when Actuator present without BootUI");
-  assert.equal(actuatorBootui.hidden, true, "no BootUI confirmation when BootUI absent");
   assert.equal(addActuator.hidden, true, "no Add Actuator when Actuator is already present");
-  assert.equal(addBootui.hidden, false, "still offers Add BootUI for richer metrics");
+  assert.equal(addBootuiSpring.hidden, false, "still offers Add BootUI for richer metrics");
   assert.equal(bootuiConfigured.hidden, true, "scans tab does not claim BootUI configured when it isn't");
   assert.equal(bootuiDesc.hidden, false, "the add-the-starter description shows when BootUI is absent");
 });
@@ -630,6 +645,7 @@ test("renderSpringAdvisor reflects version status and gates the upgrade button",
   });
   assert.equal(btn.hidden, false, "upgrade shown for an EOL line");
   assert.ok(box.querySelector(".spring-status.bad"), "EOL renders a 'bad' status chip");
+  assert.ok(btn.classList.contains("fix-copilot"), "the upgrade button uses the orange Copilot CTA color");
 
   // Latest line: no upgrade offered, an "ok" chip.
   win.renderSpringAdvisor({

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -398,6 +398,35 @@ test("the aside bar keeps its canonical order in both the available and unavaila
   }
 });
 
+test("renderMetrics maps the metrics tier to right-panel tab availability (\u00a74/\u00a75)", () => {
+  const avail = (name) => !win.document.querySelector(`.atab[data-atab="${name}"]`).classList.contains("unavailable");
+
+  // Tier bootui: Live JVM, Logs and the BootUI tab are all reachable.
+  win.renderMetrics({ appUp: true, metricsTier: "bootui" });
+  assert.ok(avail("jvm"), "bootui tier activates Live JVM");
+  assert.ok(avail("loggers"), "bootui tier activates Logs");
+  assert.ok(avail("bootui"), "bootui tier activates the BootUI tab");
+
+  // Tier actuator: Live JVM + Logs, but not BootUI (advisor scans need bootui).
+  win.renderMetrics({ appUp: true, metricsTier: "actuator" });
+  assert.ok(avail("jvm") && avail("loggers"), "actuator tier activates Live JVM + Logs");
+  assert.ok(!avail("bootui"), "actuator tier leaves the BootUI tab inactive");
+
+  // Tier quarkus: same three-way split as actuator.
+  win.renderMetrics({ appUp: true, metricsTier: "quarkus" });
+  assert.ok(avail("jvm") && avail("loggers"), "quarkus tier activates Live JVM + Logs");
+  assert.ok(!avail("bootui"), "quarkus tier leaves the BootUI tab inactive");
+
+  // Tier process (running but no endpoint): none of the three are reachable.
+  win.renderMetrics({ appUp: true, metricsTier: "process" });
+  assert.ok(!avail("jvm") && !avail("loggers") && !avail("bootui"), "process tier deactivates all three runtime tabs");
+
+  // App down: same, and the always-on tabs stay available.
+  win.renderMetrics({ appUp: false });
+  assert.ok(!avail("jvm") && !avail("loggers") && !avail("bootui"), "a down app deactivates all runtime tabs");
+  assert.ok(avail("settings") && avail("deps"), "Settings and Dependencies stay always-available");
+});
+
 test("renderDeps renders an outdated-library list", () => {
   assert.equal(typeof win.renderDeps, "function", "renderDeps should be a global");
   // A bad payload shows an error, not a throw.
@@ -482,6 +511,54 @@ test("renderDeps renders an outdated-library list", () => {
   );
   html = win.document.getElementById("deps-result").innerHTML;
   assert.ok(html.includes("guava"), "expected the Gradle outdated dependency in the rendered list");
+});
+
+test("the Dependencies direct-only filter hides transitive updates (\u00a77.7)", () => {
+  const report = {
+    ran: true,
+    buildTool: "maven",
+    available: true,
+    updatesSupported: true,
+    updates: [
+      {
+        group: "com.google.guava",
+        artifact: "guava",
+        current: "19.0",
+        latest: "33.6.0-jre",
+        scope: "compile",
+        direct: true,
+        via: null,
+        prerelease: false,
+        jump: "major",
+      },
+      {
+        group: "org.slf4j",
+        artifact: "slf4j-api",
+        current: "1.7.20",
+        latest: "2.1.0-alpha1",
+        scope: "compile",
+        direct: false,
+        via: "org.example:lib",
+        prerelease: true,
+        jump: "major",
+      },
+    ],
+    counts: { total: 2, direct: 1, transitive: 1 },
+  };
+  const direct = win.document.getElementById("deps-direct");
+  const result = () => win.document.getElementById("deps-result").innerHTML;
+
+  // Filter off: both the direct and the transitive update are listed.
+  direct.checked = false;
+  win.renderDeps(report);
+  assert.match(result(), /guava/, "direct update shown");
+  assert.match(result(), /slf4j-api/, "transitive update shown when the filter is off");
+
+  // Direct only: the transitive update is hidden, the direct one remains.
+  direct.checked = true;
+  win.renderDeps(report);
+  assert.match(result(), /guava/, "direct update still shown when direct-only is on");
+  assert.doesNotMatch(result(), /slf4j-api/, "transitive update hidden when direct-only is on");
 });
 
 test("applySettingsState restores the view/preference toggles", () => {

--- a/test/ui-smoke.test.mjs
+++ b/test/ui-smoke.test.mjs
@@ -484,6 +484,25 @@ test("renderDeps renders an outdated-library list", () => {
   assert.ok(html.includes("guava"), "expected the Gradle outdated dependency in the rendered list");
 });
 
+test("applySettingsState restores the view/preference toggles", () => {
+  assert.equal(typeof win.applySettingsState, "function", "applySettingsState should be a global");
+  const depsDirect = win.document.getElementById("deps-direct");
+  const failuresOnly = win.document.getElementById("in-failures-only");
+  const dbgSuspend = win.document.getElementById("in-dbg-suspend");
+
+  // Saved-on state restores each checkbox.
+  win.applySettingsState({ depsDirectOnly: true, testFailuresOnly: true, debugSuspend: true });
+  assert.equal(depsDirect.checked, true, "deps direct-only filter should restore checked");
+  assert.equal(failuresOnly.checked, true, "tests failures-only filter should restore checked");
+  assert.equal(dbgSuspend.checked, true, "debug suspend option should restore checked");
+
+  // Saved-off state clears them again.
+  win.applySettingsState({ depsDirectOnly: false, testFailuresOnly: false, debugSuspend: false });
+  assert.equal(depsDirect.checked, false, "deps direct-only filter should restore unchecked");
+  assert.equal(failuresOnly.checked, false, "tests failures-only filter should restore unchecked");
+  assert.equal(dbgSuspend.checked, false, "debug suspend option should restore unchecked");
+});
+
 test("renderTests renders a graphical report with a failure", () => {
   const report = {
     summary: { tests: 2, passed: 1, failures: 1, errors: 0, skipped: 0, timeSec: 0.2, files: 1 },


### PR DESCRIPTION
## Summary

This adds a new **Updates** tab to Coffilot's right panel and, along the way, turns the
whole right panel into a spec-governed, consistent surface.

**Updates panel (the headline feature).** A new always-available tab scans the project for
outdated libraries on demand and lists them with a major/minor/patch jump badge, current to
latest versions, and a direct/transitive scope badge. Expanding a row shows coordinates,
scope, and what pulled a transitive dependency in, with a per-finding **Fix with Copilot**
button. A **Direct only** toggle hides transitive findings. Scanning works for both Maven
(`versions:display-dependency-updates`) and Gradle (ben-manes versions plugin), auto-detected
per project.

**Right-panel specification + consistency pass.** Because the per-pane "is this active, and
why" rules had drifted, this introduces `specifications/RIGHT-PANEL-SPEC.md` as the source of
truth and brings the code in line with it:

- Capability-tiered metrics/logs: plain Java -> Spring Boot / Quarkus -> Actuator / Quarkus
  metrics -> BootUI, with BootUI implying Actuator. BootUI is now the preferred **Logs**
  source (reads/writes log levels via `/bootui/api/loggers`).
- Consistent inactive ("greyed") states that explain *why* a tab is off and offer the right
  orange "... with Copilot" CTA (Add Actuator / Add BootUI / Add logging-manager / Add Quarkus
  metrics / Update Spring Boot).
- Fixed a false **Quarkus** classification: a secured Spring Boot app without Actuator was
  misread as Quarkus because Spring Security's redirect to `/login` returned a 200 HTML body;
  the tier-3 probe now validates SmallRye health / Prometheus output before classifying.
- Canonical tab ordering with animated active/inactive moves, and persisted view toggles
  (deps `Direct only`, test failures-only, debug suspend) across reloads.

**Polish in this round:** renamed the tab `Upgrades` -> `Updates` (heading, button, tooltip,
and spec aligned; button is now `Update with Copilot`), a clearer up-arrow tab icon, and a
fix for a disclosure caret that used a JS-style `\u203A` escape in CSS (it rendered the literal
text "u203A" and spun vertically when expanded).

## Related issue

N/A

## Verification

- [x] `npm run check` passes (syntax check of `extension.mjs`).
- [x] `npm run format:check` passes (Prettier).
- [x] Manually verified in a live Coffilot canvas on Maven and Gradle projects (Spring Boot,
  Quarkus, BootUI, and a secured Spring Boot app).
- [x] Updated `README.md` / `PLAN.md` and added `specifications/RIGHT-PANEL-SPEC.md`.
- [x] No secrets committed.

Test suite: 145 tests, 0 failing (unit parsers, UI smoke via jsdom, and Maven/Gradle
end-to-end scans).

## Notes for reviewers

- The `Direct only` toggle was reworked from a scan-gated control into a plain view
  preference: it stays interactive whenever update scanning is supported, can be set before a
  scan, and filters live afterwards. Worth a sanity check on a project whose outdated deps are
  all direct (where it previously appeared dead).
- Most behavioural rules now live in `specifications/RIGHT-PANEL-SPEC.md`; reviewing that doc
  first makes the pane-by-pane logic easier to follow. UI smoke tests enforce the key rules.
- The Quarkus-detection fix is the one change with real runtime-classification impact; the
  `looksLikeSmallryeHealth` / `looksLikePrometheus` validators have dedicated unit tests.